### PR TITLE
파일 오픈 시 Scene패널 업데이트

### DIFF
--- a/release/scripts/startup/abler/lib/post_open.py
+++ b/release/scripts/startup/abler/lib/post_open.py
@@ -28,3 +28,8 @@ def change_and_reset_value() -> None:
         # string을 뺀 이유 : EnumProperty에 없는 값을 넣어주면 error가 뜸.
         # float = 0, bool = False 처럼 공통으로 들어갈 값이 없음.
         # type 없이 일괄적으로 처리하려고 했으나, EnumProperty에서 error가 나고 에이블러가 멈춰버림
+
+
+def update_scene() -> None:
+    # 파일 맨 처음 열었을때 scene패널명을 현재 씬과 맞춰주기 위한 함수
+    bpy.data.window_managers["WinMan"].ACON_prop.scene = bpy.context.scene.name

--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -1,9 +1,8 @@
 import bpy
 import sys
 from bpy.app.handlers import persistent
-from .lib import cameras, shadow, render, scenes
+from .lib import cameras, shadow, render, scenes, post_open
 from .lib.materials import materials_setup, materials_handler
-from .lib.post_open import change_and_reset_value
 from .lib.tracker import tracker
 from types import SimpleNamespace
 
@@ -55,8 +54,8 @@ def load_handler(dummy):
             scene.view_settings.view_transform = "Standard"
 
         scenes.refresh_look_at_me()
-        change_and_reset_value()
-        bpy.data.window_managers["WinMan"].ACON_prop.scene = bpy.context.scene.name
+        post_open.change_and_reset_value()
+        post_open.update_scene()
     finally:
         tracker.turn_on()
 

--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -56,6 +56,7 @@ def load_handler(dummy):
 
         scenes.refresh_look_at_me()
         change_and_reset_value()
+        bpy.data.window_managers["WinMan"].ACON_prop.scene = bpy.context.scene.name
     finally:
         tracker.turn_on()
 


### PR DESCRIPTION
파일을 열었을 때 Scene 패널의 현재 씬 명이 해당 씬이 아닌 패널 탭 맨처음 이름을 가져오고 있어서 현재 씬 명을 받도록 추가했습니다.
2.93에서 PR 하려고 했으나 2.93에선 씬 property가 제대로 업데이트 안돼서 3.0에서 PR 올렸습니다(3.0에선 업데이트 잘 됩니다).