### PR TITLE
파일 오픈 시 레이어 패널 업데이트

### DIFF
--- a/release/scripts/startup/abler/lib/post_open.py
+++ b/release/scripts/startup/abler/lib/post_open.py
@@ -33,3 +33,13 @@ def change_and_reset_value() -> None:
 def update_scene() -> None:
     # 파일 맨 처음 열었을때 scene패널명을 현재 씬과 맞춰주기 위한 함수
     bpy.data.window_managers["WinMan"].ACON_prop.scene = bpy.context.scene.name
+
+
+def upadte_layers():
+
+    context = bpy.context
+    if not context.scene.l_exclude and bpy.data.collections["Layers"]:
+        for child in bpy.data.collections["Layers"].children:
+            added_l_exclude = context.scene.l_exclude.add()
+            added_l_exclude.name = child.name
+            added_l_exclude.value = True

--- a/release/scripts/startup/abler/lib/post_open.py
+++ b/release/scripts/startup/abler/lib/post_open.py
@@ -35,8 +35,8 @@ def update_scene() -> None:
     bpy.data.window_managers["WinMan"].ACON_prop.scene = bpy.context.scene.name
 
 
-def upadte_layers():
-
+def update_layers():
+    # 파일 오픈시 Layer패널 업데이트
     context = bpy.context
     if not context.scene.l_exclude and bpy.data.collections["Layers"]:
         for child in bpy.data.collections["Layers"].children:

--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -56,6 +56,7 @@ def load_handler(dummy):
         scenes.refresh_look_at_me()
         post_open.change_and_reset_value()
         post_open.update_scene()
+        post_open.upadte_layers()
     finally:
         tracker.turn_on()
 

--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -56,7 +56,7 @@ def load_handler(dummy):
         scenes.refresh_look_at_me()
         post_open.change_and_reset_value()
         post_open.update_scene()
-        post_open.upadte_layers()
+        post_open.update_layers()
     finally:
         tracker.turn_on()
 


### PR DESCRIPTION
에이블러 첫 화면에서 코니방에 레이어 표시가 안됩니다. release/datafiles/startup.blend 파일을 직접 열면 레이어 패널이 잘 나오는데 첫 시작에서만 (모종의 이유로) scene.l_exclude가 업데이트가 안됩니다. 정확한 원인은 모르겠습니다.

에이블러 첫 시작에서 scene.l_exclude를 업데이트 해주는 `update_layers()` 함수를 넣어줬습니다.

요 함수를 넣음으로써 아래처럼 [Layers] 하위의 콜렉션들이 있는 파일을 열면 자동으로 레이어 패널에 보여집니다.
![image](https://user-images.githubusercontent.com/87409148/159412783-a839d348-5e56-4f36-9441-79bbb76fcd8f.png)
