### PR TITLE
Sun-Shadow properties 파라미터 step 넣기

### DIFF
--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -265,6 +265,7 @@ class AconSceneProperty(bpy.types.PropertyGroup):
         description="Adjust sun altitude",
         subtype="ANGLE",
         unit="ROTATION",
+        step=100,
         default=radians(20),
         update=shadow.changeSunRotation,
     )
@@ -275,6 +276,7 @@ class AconSceneProperty(bpy.types.PropertyGroup):
         description="Adjust sun azimuth",
         subtype="ANGLE",
         unit="ROTATION",
+        step=100,
         default=radians(130),
         update=shadow.changeSunRotation,
     )


### PR DESCRIPTION
<img width="224" alt="스크린샷 2022-03-25 오후 4 08 13" src="https://user-images.githubusercontent.com/87409148/160071682-68fb0812-cc3f-46b1-a929-a9ce046a56c2.png">
Shadow 토글의 파라미터에 좌우 버튼이 안먹히고 있어서 step을 추가해주었습니다(step=100을 해줘야 1°씩 올라갑니다).
다른 슬라이더에 step을 넣는것과는 별개인 버그성 이슈입니다.
