### PR TITLE
윈도에서 make update 할 때 trunk 에서 lib 가져오는 문제 수정

### DIFF
--- a/build_files/windows/check_libraries.cmd
+++ b/build_files/windows/check_libraries.cmd
@@ -4,6 +4,9 @@ if "%BUILD_VS_YEAR%"=="2022" set BUILD_VS_LIBDIRPOST=vc15
 
 set BUILD_VS_SVNDIR=win64_%BUILD_VS_LIBDIRPOST%
 set BUILD_VS_LIBDIR="%BLENDER_DIR%..\lib\%BUILD_VS_SVNDIR%"
+set /p LIB_VERSION=<"%BLENDER_DIR%\.lib-version"
+
+echo Detected Blender library version %LIB_VERSION%
 
 if NOT "%verbose%" == "" (
 	echo Library Directory = "%BUILD_VS_LIBDIR%"
@@ -20,7 +23,7 @@ if NOT EXIST %BUILD_VS_LIBDIR% (
 			echo Downloading %BUILD_VS_SVNDIR% libraries, please wait.
 			echo.
 :RETRY			
-			"%SVN%" checkout https://svn.blender.org/svnroot/bf-blender/trunk/lib/%BUILD_VS_SVNDIR% %BUILD_VS_LIBDIR%
+			"%SVN%" checkout https://svn.blender.org/svnroot/bf-blender/tags/blender-%LIB_VERSION%-release/lib/%BUILD_VS_SVNDIR% %BUILD_VS_LIBDIR%
 			if errorlevel 1 (
 				set /p LibRetry= "Error during download, retry? y/n"
 				if /I "!LibRetry!"=="Y" (


### PR DESCRIPTION
윈도랑 맥이랑 make update 작동방식이 조금 다른데, 제가 이전에 lib 받아오는 부분 수정할 때 맥에서 작업해서 미처 이 부분을 발견하지 못했습니다.

이 변경사항이 있기 전에는 윈도에서 아래와 같이 동작했습니다.

- 윈도에서 `make.bat update` 를 실행하면
   1. `check_libraries.cmd` 에서 `trunk` 기준으로 `svn checkout` 을 실행
   2. `make_update.py` 에서 `tags/blender-3.0-release` 기준으로 `svn checkout` 을 한 번 더 실행

(참고로, 맥에서는 2만 실행됩니다)

이 때문에, 필요없는 최신 lib 파일들을 한 번 받은 다음 예전 버전인 3.0 기준의 lib 파일들을 한 번 더 받게 되는 불필요한 과정이 실행됩니다. 그 과정에서 @habijung  이 겪으신 것처럼 svn 상태가 꼬이는 문제가 생겼던 것으로 보입니다.

애초에 윈도에서도 1번 과정이 없으면 베스트겠지만, 1번과 2번 사이에 동작하는 스크립트들 중에 lib 폴더가 있어야만 동작하는 부분들이 있어서, 1번 과정에서도 (이번에 새로 추가한) `.lib-version` 파일을 기준으로 svn 브랜치를 선택하도록 수정했습니다.

같은 픽스를 2.93 에이블러에도 바로 넣겠습니다~~