### PR TITLE
배경 이미지가 없을 경우 해당 이미지 로딩 건너뛰기

### DIFF
--- a/release/scripts/startup/abler/lib/render.py
+++ b/release/scripts/startup/abler/lib/render.py
@@ -73,15 +73,18 @@ def setupBackgroundImagesCompositor(node_left=None, node_right=None, scene=None)
 
         image = background_image.image
 
-        if (image is None) or (0 in image.size):
-            # 배경 이미지가 여러 장일 경우 문제가 있는 이미지만 알림 띄우기
-            """
+        # 배경 이미지를 추가하지 않았을 때는 알림을 표시하지 않습니다.
+        if image is None:
+            continue
+
+        # 배경 이미지에 사용된 파일을 찾을 수 없으면 알림을 표시합니다.
+        if 0 in image.size:
             bpy.ops.acon3d.alert(
                 "INVOKE_DEFAULT",
-                title="Check Background Image",
-                message_1=f"Failed to load background image : {image.name}",
+                title="Check Background Image File",
+                message_1="Failed to load background image file:",
+                message_2=f"{image.name}",
             )
-            """
             continue
 
         node_image = nodes.new("CompositorNodeImage")

--- a/release/scripts/startup/abler/lib/render.py
+++ b/release/scripts/startup/abler/lib/render.py
@@ -72,6 +72,18 @@ def setupBackgroundImagesCompositor(node_left=None, node_right=None, scene=None)
     for background_image in reversed(background_images):
 
         image = background_image.image
+
+        if 0 in image.size:
+            # 배경 이미지가 여러 장일 경우 문제가 있는 이미지만 알림 띄우기
+            """
+            bpy.ops.acon3d.alert(
+                "INVOKE_DEFAULT",
+                title="Check Background Image",
+                message_1=f"Failed to load background image : {image.name}",
+            )
+            """
+            continue
+
         node_image = nodes.new("CompositorNodeImage")
         node_image.image = image
 

--- a/release/scripts/startup/abler/lib/render.py
+++ b/release/scripts/startup/abler/lib/render.py
@@ -73,7 +73,7 @@ def setupBackgroundImagesCompositor(node_left=None, node_right=None, scene=None)
 
         image = background_image.image
 
-        if 0 in image.size:
+        if (image is None) or (0 in image.size):
             # 배경 이미지가 여러 장일 경우 문제가 있는 이미지만 알림 띄우기
             """
             bpy.ops.acon3d.alert(


### PR DESCRIPTION
## 기획 세션 논의 사항
- [x] 배경이미지 로딩 불가가 발생하면 해당 파일에 대한 알림을 띄울건지 확인
- [x] 배경이미지 추가 없이 렌더 할 때 알림을 띄울건지 확인
- [ ] 해당 문제가 해결되면 merge

## 문제
- 배경이미지를 추가하고 `Unpack Item` 기능 **(1회성)** 을 사용하여 배경이미지를 추출한 뒤, 파일의 이동/삭제 등으로 이미지 파일 로딩이 불가능 하면 발생
- 오류 내용 : `ZeroDivisionError: division by zero`

## 수정 사항
- 배경이미지 로딩이 불가능하면 파일 정보가 없기 때문에 `image.size` 값이 없습니다. 해당 문제가 발생할 경우 다음 이미지 로딩으로 건너뜁니다.