### PR TITLE
스플래시 화면에 에이블러 버전 표시

### DIFF
--- a/release/scripts/startup/bl_operators/wm.py
+++ b/release/scripts/startup/bl_operators/wm.py
@@ -2988,7 +2988,8 @@ class WM_MT_splash(Menu):
         def abler_version():
             from abler.lib.tracker._versioning import get_version
             if abler_version := get_version():
-                return abler_version+" version"
+                major, minor, patch = abler_version
+                return f"v{major}.{minor}.{patch}"
             else:
                 return "Production version"
 

--- a/release/scripts/startup/bl_operators/wm.py
+++ b/release/scripts/startup/bl_operators/wm.py
@@ -2985,6 +2985,13 @@ class WM_MT_splash(Menu):
     bl_label = "Splash"
 
     def draw(self, context):
+        def abler_version():
+            from abler.lib.tracker._versioning import get_version
+            if abler_version := get_version():
+                return abler_version+" version"
+            else:
+                return "Production version"
+
         layout = self.layout
         layout.operator_context = 'EXEC_DEFAULT'
 
@@ -3076,12 +3083,7 @@ class WM_MT_splash(Menu):
         col2.operator("wm.url_open_preset", text="Blender Development Fund", icon='FUND', text_ctxt="*").type = 'FUND'
 
         layout.separator()
-        from abler.lib.tracker._versioning import get_version
-        if abler_version := get_version():
-            layout.label(text=abler_version+" version")
-        else:
-            layout.label(text="Production version")
-
+        layout.label(text=abler_version())
         layout.separator()
 
 

--- a/release/scripts/startup/bl_operators/wm.py
+++ b/release/scripts/startup/bl_operators/wm.py
@@ -3076,6 +3076,12 @@ class WM_MT_splash(Menu):
         col2.operator("wm.url_open_preset", text="Blender Development Fund", icon='FUND', text_ctxt="*").type = 'FUND'
 
         layout.separator()
+        from abler.lib.tracker._versioning import get_version
+        if abler_version := get_version():
+            layout.label(text=abler_version+" version")
+        else:
+            layout.label(text="Production version")
+
         layout.separator()
 
 

--- a/release/scripts/startup/bl_operators/wm.py
+++ b/release/scripts/startup/bl_operators/wm.py
@@ -2991,7 +2991,7 @@ class WM_MT_splash(Menu):
                 major, minor, patch = abler_version
                 return f"v{major}.{minor}.{patch}"
             else:
-                return "Production version"
+                return f"dev({bpy.app.build_hash})"
 
         layout = self.layout
         layout.operator_context = 'EXEC_DEFAULT'

--- a/source/blender/windowmanager/intern/wm_splash_screen.c
+++ b/source/blender/windowmanager/intern/wm_splash_screen.c
@@ -212,6 +212,12 @@ static uiBlock *wm_block_create_splash(bContext *C, ARegion *region, void *UNUSE
 
   UI_but_func_set(but, wm_block_close, block, NULL);
 
+  // 블렌더 버전(2.96)을 삭제하고 에이블러 버전을 보여주기로 변경
+  // wm_block_splash_add_label(block,
+  //                           BKE_blender_version_string(),
+  //                           splash_width - 8.0 * U.dpi_fac,
+  //                           splash_height - 13.0 * U.dpi_fac);
+
   const int layout_margin_x = U.dpi_fac * 26;
   uiLayout *layout = UI_block_layout(block,
                                      UI_LAYOUT_VERTICAL,

--- a/source/blender/windowmanager/intern/wm_splash_screen.c
+++ b/source/blender/windowmanager/intern/wm_splash_screen.c
@@ -212,11 +212,6 @@ static uiBlock *wm_block_create_splash(bContext *C, ARegion *region, void *UNUSE
 
   UI_but_func_set(but, wm_block_close, block, NULL);
 
-  wm_block_splash_add_label(block,
-                            BKE_blender_version_string(),
-                            splash_width - 8.0 * U.dpi_fac,
-                            splash_height - 13.0 * U.dpi_fac);
-
   const int layout_margin_x = U.dpi_fac * 26;
   uiLayout *layout = UI_block_layout(block,
                                      UI_LAYOUT_VERTICAL,


### PR DESCRIPTION
에이블러 버전 표시 및 블렌더 버전 삭제했습니다.
<img width="492" alt="스크린샷 2022-04-05 오후 1 31 01" src="https://user-images.githubusercontent.com/87409148/161681891-3b848239-ccba-4cdd-b6f8-45711368cbfb.png">
`abler_version` 함수에서 이전에 쓰이던 get_version을 쓰되 None일 경우 `Production version`을 반환하도록 했습니다.

노션 카드 : https://www.notion.so/acon3d/e77b7857a9634fd5b88d653bdf560538