### PR TITLE
배경이미지 삭제 시 IndexError 발생 오류

### DIFF
--- a/release/scripts/startup/abler/camera_control.py
+++ b/release/scripts/startup/abler/camera_control.py
@@ -207,9 +207,12 @@ class RemoveBackgroundOperator(bpy.types.Operator):
     index: bpy.props.IntProperty(name="Index", default=0)
 
     def execute(self, context):
-        image = context.scene.camera.data.background_images[self.index]
-        image.image = None
-        bpy.context.scene.camera.data.background_images.remove(image)
+        try:
+            image = context.scene.camera.data.background_images[self.index]
+            image.image = None
+            bpy.context.scene.camera.data.background_images.remove(image)
+        except:
+            pass
         return {"FINISHED"}
 
 


### PR DESCRIPTION
배경이미지 삭제 시 좌측 하단 패널에서 유저가 값을 직접 입력해서 IndexError 발생하는 오류입니다.
Try/Except 문으로 감싸서 에러메세지 발생 안되도록 처리했습니다.

노션 카드 : https://www.notion.so/acon3d/IndexError-42a06384286e42a9a3e4ec5bedb1b0c1