### PR TITLE
파일 중복 저장 시 숫자 추가

### DIFF
--- a/release/scripts/presets/keyconfig/keymap_data/abler_default.py
+++ b/release/scripts/presets/keyconfig/keymap_data/abler_default.py
@@ -398,9 +398,9 @@ def km_window(params):
             ("acon3d.file_open", {"type": 'F1', "value": 'PRESS'}, None),
             ("wm.link", {"type": 'O', "value": 'PRESS', "ctrl": True, "alt": True}, None),
             ("wm.append", {"type": 'F1', "value": 'PRESS', "shift": True}, None),
-            ("wm.save_mainfile", {"type": 'W', "value": 'PRESS', "ctrl": True}, None),
-            ("wm.save_as_mainfile", {"type": 'F2', "value": 'PRESS'}, None),
-            ("wm.save_as_mainfile", {"type": 'S', "value": 'PRESS', "ctrl": True, "alt": True},
+            ("acon3d.save", {"type": 'W', "value": 'PRESS', "ctrl": True}, None),
+            ("acon3d.save_as", {"type": 'F2', "value": 'PRESS'}, None),
+            ("acon3d.save_as", {"type": 'S', "value": 'PRESS', "ctrl": True, "alt": True},
              {"properties": [("copy", True)]}),
             ("wm.window_new", {"type": 'W', "value": 'PRESS', "ctrl": True, "alt": True}, None),
             ("wm.window_fullscreen_toggle", {"type": 'F11', "value": 'PRESS', "alt": True}, None),
@@ -415,8 +415,8 @@ def km_window(params):
         op_menu("TOPBAR_MT_file_new", {"type": 'N', "value": 'PRESS', "ctrl": True}),
         op_menu("TOPBAR_MT_file_open_recent", {"type": 'O', "value": 'PRESS', "shift": True, "ctrl": True}),
         ("acon3d.file_open", {"type": 'O', "value": 'PRESS', "ctrl": True}, None),
-        ("wm.save_mainfile", {"type": 'S', "value": 'PRESS', "ctrl": True}, None),
-        ("wm.save_as_mainfile", {"type": 'S', "value": 'PRESS', "shift": True, "ctrl": True}, None),
+        ("acon3d.save", {"type": 'S', "value": 'PRESS', "ctrl": True}, None),
+        ("acon3d.save_as", {"type": 'S', "value": 'PRESS', "shift": True, "ctrl": True}, None),
         ("wm.quit_blender", {"type": 'Q', "value": 'PRESS', "ctrl": True}, None),
 
         # Quick menu and toolbar

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -39,6 +39,32 @@ from .lib.materials import materials_setup
 from .lib.tracker import tracker
 
 
+def splitFilepath(filepath):
+    # Get basename without file extension
+    dirname, basename = os.path.split(os.path.normpath(filepath))
+
+    if "." in basename:
+        basename = ".".join(basename.split(".")[:-1])
+
+    return dirname, basename
+
+
+def numberingFilepath(filepath, ext):
+    dirname, basename = splitFilepath(filepath)
+    basepath = os.path.join(dirname, basename)
+
+    num_path = basepath
+    num_name = basename
+    number = 2
+
+    while os.path.isfile(f"{num_path}{ext}"):
+        num_path = f"{basepath} ({number})"
+        num_name = f"{basename} ({number})"
+        number += 1
+
+    return num_path, num_name
+
+
 class ImportOperator(bpy.types.Operator, ImportHelper):
     """Import file according to the current settings"""
 
@@ -177,25 +203,16 @@ class SaveOperator(bpy.types.Operator, ExportHelper):
     def execute(self, context):
         tracker.save()
 
-        # Get basename without file extension
-        dirname, basename = os.path.split(os.path.normpath(self.filepath))
-
-        if "." in basename:
-            basename = ".".join(basename.split(".")[:-1])
-
         if bpy.data.is_saved:
+            dirname, basename = splitFilepath(self.filepath)
+
             bpy.ops.wm.save_mainfile({"dict": "override"}, filepath=self.filepath)
             self.report({"INFO"}, f'Saved "{basename}{self.filename_ext}"')
 
         else:
-            base_filepath = os.path.join(dirname, basename)
-            numbered_filepath = base_filepath
-            number = 2
-
-            while os.path.isfile(f"{numbered_filepath}{self.filename_ext}"):
-                numbered_filepath = f"{base_filepath} ({number})"
-                numbered_filename = f"{basename} ({number})"
-                number += 1
+            numbered_filepath, numbered_filename = numberingFilepath(
+                self.filepath, self.filename_ext
+            )
 
             self.filepath = f"{numbered_filepath}{self.filename_ext}"
 
@@ -217,20 +234,9 @@ class SaveAsOperator(bpy.types.Operator, ExportHelper):
     def execute(self, context):
         tracker.save_as()
 
-        # Get basename without file extension
-        dirname, basename = os.path.split(os.path.normpath(self.filepath))
-
-        if "." in basename:
-            basename = ".".join(basename.split(".")[:-1])
-
-        base_filepath = os.path.join(dirname, basename)
-        numbered_filepath = base_filepath
-        number = 2
-
-        while os.path.isfile(f"{numbered_filepath}{self.filename_ext}"):
-            numbered_filepath = f"{base_filepath} ({number})"
-            numbered_filename = f"{basename} ({number})"
-            number += 1
+        numbered_filepath, numbered_filename = numberingFilepath(
+            self.filepath, self.filename_ext
+        )
 
         self.filepath = f"{numbered_filepath}{self.filename_ext}"
 

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -199,15 +199,13 @@ class SaveOperator(bpy.types.Operator, ExportHelper):
 
         else:
             return ExportHelper.invoke(self, context, event)
-            # return super().invoke(context, event)
 
     def execute(self, context):
         tracker.save()
 
         if bpy.data.is_saved:
+            self.filepath = context.blend_data.filepath
             dirname, basename = splitFilepath(self.filepath)
-            print(f"dirname  : {dirname}")
-            print(f"basename : {basename}")
 
             bpy.ops.wm.save_mainfile({"dict": "override"}, filepath=self.filepath)
             self.report({"INFO"}, f'Saved "{basename}{self.filename_ext}"')
@@ -229,16 +227,17 @@ class SaveOperator(bpy.types.Operator, ExportHelper):
     # 파일이 최초 저장될 때는 invoke()를 활용해서 파일 브라우저에서 파일명을 관리를 해야하지만
     # 파일이 이미 저장된 상태일 때는 invoke()를 넘어가고 바로 execute()를 실행해야 합니다.
     # 그래서 invoke()와 execute()에서 모두 bpy.data.is_saved 로 나누었습니다.
+    """
+    def execute(self, context):
 
-    # def execute(self, context):
+        if bpy.data.is_saved:
+            SaveCurrentOperator.execute(self, context)
 
-    #     if bpy.data.is_saved:
-    #         SaveCurrentOperator.execute(self, context)
-
-    #     else:
-    #         tracker.turn_off()
-    #         SaveAsOperator.execute(self, context)
-    #         tracker.turn_on()
+        else:
+            tracker.turn_off()
+            SaveAsOperator.execute(self, context)
+            tracker.turn_on()
+    """
 
 
 class SaveAsOperator(bpy.types.Operator, ExportHelper):

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -184,40 +184,38 @@ class FlyOperator(bpy.types.Operator):
         return {"FINISHED"}
 
 
-class SaveOperator(bpy.types.Operator, ExportHelper):
+class SaveOperator(bpy.types.Operator):
     """Save the current Blender file"""
 
     bl_idname = "acon3d.save"
     bl_label = "Save"
     bl_translation_context = "*"
 
+    def execute(self, context):
+
+        if bpy.data.is_saved:
+            bpy.ops.acon3d.save_again()
+        else:
+            tracker.turn_off()
+            bpy.ops.acon3d.save_as()
+            tracker.turn_on()
+
+        return {"FINISHED"}
+
+
+class SaveAgainOperator(bpy.types.Operator, ExportHelper):
+
+    bl_idname = "acon3d.save_again"
+    bl_label = "Save"
+    bl_translation_context = "*"
+
     filename_ext = ".blend"
 
-    def invoke(self, context, event):
-        if bpy.data.is_saved:
-            return self.execute(context)
-
-        else:
-            return super().invoke(context, event)
-
     def execute(self, context):
-        tracker.save()
+        dirname, basename = splitFilepath(self.filepath)
 
-        if bpy.data.is_saved:
-            dirname, basename = splitFilepath(self.filepath)
-
-            bpy.ops.wm.save_mainfile({"dict": "override"}, filepath=self.filepath)
-            self.report({"INFO"}, f'Saved "{basename}{self.filename_ext}"')
-
-        else:
-            numbered_filepath, numbered_filename = numberingFilepath(
-                self.filepath, self.filename_ext
-            )
-
-            self.filepath = f"{numbered_filepath}{self.filename_ext}"
-
-            bpy.ops.wm.save_mainfile({"dict": "override"}, filepath=self.filepath)
-            self.report({"INFO"}, f'Saved "{numbered_filename}{self.filename_ext}"')
+        bpy.ops.wm.save_mainfile({"dict": "override"}, filepath=self.filepath)
+        self.report({"INFO"}, f'Saved "{basename}{self.filename_ext}"')
 
         return {"FINISHED"}
 
@@ -302,8 +300,9 @@ classes = (
     ApplyToonStyleOperator,
     FileOpenOperator,
     FlyOperator,
-    SaveOperator,
+    SaveAgainOperator,
     SaveAsOperator,
+    SaveOperator,
 )
 
 

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -193,6 +193,10 @@ class SaveOperator(bpy.types.Operator, ExportHelper):
 
     filename_ext = ".blend"
 
+    # invoke() 사용을 하지 않고 execute() 분리 시도 방법은 현재 어렵습니다.
+    # Helper 함수에서는 invoke()가 호출되어서 파일 브라우저 관리를 하는데,
+    # 파일이 최초 저장될 때는 invoke()를 활용해서 파일 브라우저에서 파일명을 관리를 해야하지만,
+    # 파일이 이미 저장된 상태일 때는 invoke()를 넘어가고 바로 execute()를 실행해야 합니다.
     def invoke(self, context, event):
         if bpy.data.is_saved:
             return self.execute(context)
@@ -221,23 +225,6 @@ class SaveOperator(bpy.types.Operator, ExportHelper):
             self.report({"INFO"}, f'Saved "{numbered_filename}{self.filename_ext}"')
 
         return {"FINISHED"}
-
-    # invoke() 사용을 하지 않기 위해 execute() 분리 시도 방법은 현재 어렵습니다.
-    # Helper 함수에서는 invoke()가 호출되어서 파일 브라우저 관리를 하는데,
-    # 파일이 최초 저장될 때는 invoke()를 활용해서 파일 브라우저에서 파일명을 관리를 해야하지만
-    # 파일이 이미 저장된 상태일 때는 invoke()를 넘어가고 바로 execute()를 실행해야 합니다.
-    # 그래서 invoke()와 execute()에서 모두 bpy.data.is_saved 로 나누었습니다.
-    """
-    def execute(self, context):
-
-        if bpy.data.is_saved:
-            SaveCurrentOperator.execute(self, context)
-
-        else:
-            tracker.turn_off()
-            SaveAsOperator.execute(self, context)
-            tracker.turn_on()
-    """
 
 
 class SaveAsOperator(bpy.types.Operator, ExportHelper):

--- a/release/scripts/startup/bl_ui/space_topbar.py
+++ b/release/scripts/startup/bl_ui/space_topbar.py
@@ -294,10 +294,10 @@ class TOPBAR_MT_file(Menu):
         layout.separator()
 
         layout.operator_context = 'EXEC_AREA' if context.blend_data.is_saved else 'INVOKE_AREA'
-        layout.operator("wm.save_mainfile", text="Save", icon='FILE_TICK')
+        layout.operator("acon3d.save", text="Save", icon='FILE_TICK')
 
         layout.operator_context = 'INVOKE_AREA'
-        layout.operator("wm.save_as_mainfile", text="Save As...")
+        layout.operator("acon3d.save_as", text="Save As...")
         layout.operator_context = 'INVOKE_AREA'
         layout.operator("wm.save_as_mainfile", text="Save Copy...").copy = True
 


### PR DESCRIPTION
## 문제
- 파일 저장 시, 파일 브라우저에서 파일명이 중복이어도 경고 표시만 있고 안내 없이 덮어쓰기로 저장됨

## 진행 상황
- [x] 현재 파일명이 저장하려는 폴더명에 존재할 때 (저장하려는 파일명이 중복일 때), 저장되는 파일명에 숫자 추가
  **예시) `a.blend`**
  - 최초 저장 ▶ `a.blend`
  - `a.blend`가 존재하고 `a.blend` 로 저장 ▶ `a (2).blend`
  - `a (2).blend`가 존재하고 `a (2).blend` 로 저장 ▶ `a (2) (2).blend`
  - `a.blend`, `a (2).blend`가 존재하고 `a.blend` 로 저장 ▶ `a (3).blend`
- [x] 단축키 저장도 중복 처리 적용
- [x] ABLER 메뉴를 통한 저장도 중복 처리 적용 

## 구현
### Save
- `ExportHelper` 추가
- `New` 파일이면 파일 경로가 없기 때문에 `untitled.blend` 추가를 위한 `invoke()` 구분
- 한번 저장된 이력이 있으면 파일 경로 그대로 받아서 `Save`
- 한번도 저장된 이력이 없으면 파일 브라우저 실행 후 파일명 처리 실행 및 `Save`

### Save As
- `ExportHelper` 추가
- `New` 파일과 구분할 필요가 없기 때문에 바로 파일 브라우저 실행 후 파일명 처리 및 `Save As` 실행
