### PR TITLE
두 세션 열리는 현상 해결

### DIFF
--- a/launcher_abler/AblerLauncher.py
+++ b/launcher_abler/AblerLauncher.py
@@ -325,6 +325,12 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
         if req["message"] == "Not Found":
             self.frm_start.show()
             self.btn_execute.show()
+            if sys.platform == "win32":
+                self.btn_execute.clicked.connect(self.exec_windows)
+            elif sys.platform == "darwin":
+                self.btn_execute.clicked.connect(self.exec_osx)
+            elif sys.platform == "linux":
+                self.btn_execute.clicked.connect(self.exec_linux)
             self.btn_update_launcher.hide()
             self.btn_update.hide()
         version_tag = req["name"][1:]

--- a/launcher_abler/AblerLauncher.py
+++ b/launcher_abler/AblerLauncher.py
@@ -325,12 +325,6 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
         if req["message"] == "Not Found":
             self.frm_start.show()
             self.btn_execute.show()
-            if sys.platform == "win32":
-                self.btn_execute.clicked.connect(self.exec_windows)
-            elif sys.platform == "darwin":
-                self.btn_execute.clicked.connect(self.exec_osx)
-            elif sys.platform == "linux":
-                self.btn_execute.clicked.connect(self.exec_linux)
             self.btn_update_launcher.hide()
             self.btn_update.hide()
         version_tag = req["name"][1:]
@@ -443,12 +437,6 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
         if req["message"] == "Not Found":
             self.frm_start.show()
             self.btn_execute.show()
-            if sys.platform == "win32":
-                self.btn_execute.clicked.connect(self.exec_windows)
-            elif sys.platform == "darwin":
-                self.btn_execute.clicked.connect(self.exec_osx)
-            elif sys.platform == "linux":
-                self.btn_execute.clicked.connect(self.exec_linux)
             self.btn_update_launcher.hide()
             self.btn_update.hide()
             return False


### PR DESCRIPTION
런쳐에서 run abler시에 두 세션이 열리는 현상을 방지했습니다

subprocess가 두번 등록되어서 두 개의 세션이 열리는 현상이었습니다.