### PR TITLE
reflection 적용 오류 개선

### DIFF
--- a/release/scripts/startup/abler/lib/materials/materials_setup.py
+++ b/release/scripts/startup/abler/lib/materials/materials_setup.py
@@ -530,6 +530,10 @@ def applyAconToonStyle():
                 mat.node_tree.links.new(
                     node_texImage.outputs[1], node_combinedToon.inputs[8]
                 )
+                # 블렌더 3.0에서 자동으로 이미지와 MixFactor1이 연결, 끊어줘야함
+                if l := node_combinedToon.inputs[2].links:
+                    mat.node_tree.links.remove(l[0])
+
             mat.node_tree.links.new(node_combinedToon.outputs[0], out_node.inputs[0])
 
             materials_handler.setMaterialParametersByType(mat)


### PR DESCRIPTION
블렌더 3.0으로 이관하면서 쉐이더 노드의 이미지가 자동으로 MixFactor1에 연결되어 재질의 Reflection이 잘 반영되지 않았습니다.
요 연결부를 처음 시작할때 끊어주었습니다.

노션 카드 : https://www.notion.so/acon3d/reflection-198f5300512248b39e9d6149090b1048