### PR TITLE
로그아웃 기능 구현

### DIFF
--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -260,45 +260,6 @@ class SaveAsOperator(bpy.types.Operator, ExportHelper):
         return {"FINISHED"}
 
 
-class LogoutOperator(bpy.types.Operator):
-    """Logout user account"""
-
-    bl_idname = "acon3d.logout"
-    bl_label = "Logout"
-    bl_translation_context = "*"
-
-    def execute(self, context):
-        tracker.logout()
-
-        self.prop = bpy.data.meshes.get("ACON_userInfo").ACON_prop
-        path = bpy.utils.resource_path("USER")
-        path_cookiesFolder = os.path.join(path, "cookies")
-        path_cookiesFile = os.path.join(path_cookiesFolder, "acon3d_session")
-
-        # TODO: New, Quit 대화창을 사용하지 말고, is_dirty == True 면 save_as() 실행해주기
-        #       save_as()에서 modal을 실행할 때, sleep()을 하면 return {"FINISHED"}가 늦어져서 sleep() 사용 불가능
-        #       Render에 있는 event timer를 참고하면 좋을 것 같음
-        if os.path.exists(path_cookiesFile):
-            os.remove(path_cookiesFile)
-            self.prop.login_status = "IDLE"
-
-            # 아래 동작이 문제가 있으면 modal_operator() 실행하고, pyautogui.click()을 사용해서 클릭 이벤트 발생하기
-            # 혹시라도 클릭 이벤트와 사용자의 특정 행동 충돌 문제에 대한 의문이 있어, null 이벤트 생성이 가능하다면
-            # pyautogui 사용하지 않기
-            bpy.ops.acon3d.modal_operator("INVOKE_DEFAULT")
-            self.prop.username = read_remembered_username()
-            bpy.ops.wm.splash("INVOKE_DEFAULT")
-
-            # TODO: bpy.ops.wm.read_homefile()을 사용해 현재 파일 처리 과정 구현
-            #       현재 splash 화면에서 프로그램을 종료하면 Quit 대화창으로 저장 기능을 사용할 수는 있지만
-            #       splash 화면과 저장 modal이 충돌할 가능성 있음
-
-        else:
-            print("No login session file")
-
-        return {"FINISHED"}
-
-
 class Acon3dImportPanel(bpy.types.Panel):
     bl_idname = "ACON3D_PT_import"
     bl_label = "General"
@@ -360,7 +321,6 @@ classes = (
     FlyOperator,
     SaveOperator,
     SaveAsOperator,
-    LogoutOperator,
 )
 
 

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -36,6 +36,7 @@ from bpy_extras.io_utils import ImportHelper, ExportHelper
 from .lib import scenes
 from .lib.materials import materials_setup
 from .lib.tracker import tracker
+from .lib.remember_username import read_remembered_username
 
 
 def splitFilepath(filepath):
@@ -260,31 +261,37 @@ class SaveAsOperator(bpy.types.Operator, ExportHelper):
 
 
 class LogoutOperator(bpy.types.Operator):
-    """Logout"""
+    """Logout user account"""
 
     bl_idname = "acon3d.logout"
-    bl_label = "logout"
+    bl_label = "Logout"
     bl_translation_context = "*"
 
-    is_quit: bpy.props.BoolProperty(name="Quit Blender", default=True)
-
     def execute(self, context):
-        # tracker.logout()
-
-        print("\nExecute Logout")
+        tracker.logout()
 
         self.prop = bpy.data.meshes.get("ACON_userInfo").ACON_prop
         path = bpy.utils.resource_path("USER")
         path_cookiesFolder = os.path.join(path, "cookies")
         path_cookiesFile = os.path.join(path_cookiesFolder, "acon3d_session")
 
+        # TODO: New, Quit 대화창을 사용하지 말고, is_dirty == True 면 save_as() 실행해주기
+        #       save_as()에서 modal을 실행할 때, sleep()을 하면 return {"FINISHED"}가 늦어져서 sleep() 사용 불가능
+        #       Render에 있는 event timer를 참고하면 좋을 것 같음
         if os.path.exists(path_cookiesFile):
             os.remove(path_cookiesFile)
             self.prop.login_status = "IDLE"
-            bpy.ops.acon3d.modal_operator("INVOKE_DEFAULT")
 
-            # bpy.ops.wm.read_homefile("INVOKE_DEFAULT")
-            # bpy.ops.wm.read_homefile(use_splash=True)
+            # 아래 동작이 문제가 있으면 modal_operator() 실행하고, pyautogui.click()을 사용해서 클릭 이벤트 발생하기
+            # 혹시라도 클릭 이벤트와 사용자의 특정 행동 충돌 문제에 대한 의문이 있어, null 이벤트 생성이 가능하다면
+            # pyautogui 사용하지 않기
+            bpy.ops.acon3d.modal_operator("INVOKE_DEFAULT")
+            self.prop.username = read_remembered_username()
+            bpy.ops.wm.splash("INVOKE_DEFAULT")
+
+            # TODO: bpy.ops.wm.read_homefile()을 사용해 현재 파일 처리 과정 구현
+            #       현재 splash 화면에서 프로그램을 종료하면 Quit 대화창으로 저장 기능을 사용할 수는 있지만
+            #       splash 화면과 저장 modal이 충돌할 가능성 있음
 
         else:
             print("No login session file")

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -259,6 +259,39 @@ class SaveAsOperator(bpy.types.Operator, ExportHelper):
         return {"FINISHED"}
 
 
+class LogoutOperator(bpy.types.Operator):
+    """Logout"""
+
+    bl_idname = "acon3d.logout"
+    bl_label = "logout"
+    bl_translation_context = "*"
+
+    is_quit: bpy.props.BoolProperty(name="Quit Blender", default=True)
+
+    def execute(self, context):
+        # tracker.logout()
+
+        print("\nExecute Logout")
+
+        self.prop = bpy.data.meshes.get("ACON_userInfo").ACON_prop
+        path = bpy.utils.resource_path("USER")
+        path_cookiesFolder = os.path.join(path, "cookies")
+        path_cookiesFile = os.path.join(path_cookiesFolder, "acon3d_session")
+
+        if os.path.exists(path_cookiesFile):
+            os.remove(path_cookiesFile)
+            self.prop.login_status = "IDLE"
+            bpy.ops.acon3d.modal_operator("INVOKE_DEFAULT")
+
+            # bpy.ops.wm.read_homefile("INVOKE_DEFAULT")
+            # bpy.ops.wm.read_homefile(use_splash=True)
+
+        else:
+            print("No login session file")
+
+        return {"FINISHED"}
+
+
 class Acon3dImportPanel(bpy.types.Panel):
     bl_idname = "ACON3D_PT_import"
     bl_label = "General"
@@ -272,6 +305,9 @@ class Acon3dImportPanel(bpy.types.Panel):
 
     def draw(self, context):
         layout = self.layout
+
+        row = layout.row()
+        row.operator("acon3d.logout")
 
         row = layout.row()
         row.scale_y = 1.0
@@ -317,6 +353,7 @@ classes = (
     FlyOperator,
     SaveOperator,
     SaveAsOperator,
+    LogoutOperator,
 )
 
 

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -275,9 +275,6 @@ class Acon3dImportPanel(bpy.types.Panel):
         layout = self.layout
 
         row = layout.row()
-        row.operator("acon3d.logout")
-
-        row = layout.row()
         row.scale_y = 1.0
         row.operator("acon3d.file_open")
         row.operator("acon3d.import_blend", text="Import")

--- a/release/scripts/startup/abler/lib/tracker/_tracker.py
+++ b/release/scripts/startup/abler/lib/tracker/_tracker.py
@@ -11,6 +11,7 @@ class EventKind(enum.Enum):
     login = "Login"
     login_fail = "Login Fail"
     login_auto = "Login Auto"
+    logout = "Logout"
     file_open = "File Open"
     render_quick = "Render Quick"
     render_full = "Render Full"
@@ -136,6 +137,9 @@ class Tracker(metaclass=ABCMeta):
 
     def login_auto(self):
         self._track(EventKind.login_auto.value)
+
+    def logout(self):
+        self._track(EventKind.logout.value)
 
     def file_open(self):
         self._track(EventKind.file_open.value)

--- a/release/scripts/startup/abler/operators.py
+++ b/release/scripts/startup/abler/operators.py
@@ -3,6 +3,7 @@ import bpy
 from .lib.materials import materials_setup
 from .lib.remember_username import read_remembered_checkbox, read_remembered_username
 
+
 class Acon3dToonStyleOperator(bpy.types.Operator):
     """Iterate all materials and change them into toon style"""
 
@@ -15,15 +16,15 @@ class Acon3dToonStyleOperator(bpy.types.Operator):
         return {"FINISHED"}
 
 
-class Logout(bpy.types.Operator):
-    """Logout user account for menu"""
+class Acon3dLogoutOperator(bpy.types.Operator):
+    """Logout user account"""
 
-    bl_idname = "acon3d.logout_menu"
-    bl_label = "Logout_menu"
+    bl_idname = "acon3d.logout"
+    bl_label = "Log Out"
     bl_translation_context = "*"
 
     def execute(self, context):
-        # prop를 업데이트 하면 ACON_userInfo에도 반영됨
+        # prop를 업데이트 하면 ACON_userInfo도 업데이트
         prop = bpy.data.meshes.get("ACON_userInfo").ACON_prop
         path = bpy.utils.resource_path("USER")
         path_cookiesFolder = os.path.join(path, "cookies")
@@ -35,13 +36,14 @@ class Logout(bpy.types.Operator):
         if os.path.exists(path_cookiesFile):
             os.remove(path_cookiesFile)
 
-            # login_status가 SUCCESS가 아닌 상태에서 modal_operator를 실행하고 쿠키 파일 확인하기
+            # login_status가 SUCCESS가 아닌 상태에서 modal_operator를 실행
             prop.login_status = "IDLE"
             bpy.ops.acon3d.modal_operator("INVOKE_DEFAULT")
 
-            # 아이디 기억하기 체크박스 상태와 아이디 업데이트
+            # 아이디 기억하기 체크박스 상태와 아이디 불러오기
             prop.remember_username = read_remembered_checkbox()
             prop.username = read_remembered_username()
+
             bpy.ops.wm.splash("INVOKE_DEFAULT")
 
             # TODO: bpy.ops.wm.read_homefile()을 사용해 현재 파일 처리 과정 구현
@@ -54,10 +56,9 @@ class Logout(bpy.types.Operator):
         return {"FINISHED"}
 
 
-
 classes = (
     Acon3dToonStyleOperator,
-    Logout,
+    Acon3dLogoutOperator,
 )
 
 

--- a/release/scripts/startup/abler/operators.py
+++ b/release/scripts/startup/abler/operators.py
@@ -30,9 +30,9 @@ class Acon3dLogoutOperator(bpy.types.Operator):
         path_cookiesFolder = os.path.join(path, "cookies")
         path_cookiesFile = os.path.join(path_cookiesFolder, "acon3d_session")
 
-        # TODO: New, Quit 대화창을 사용하지 말고, is_dirty == True 면 save_as() 실행해주기
-        #       save_as()에서 modal을 실행할 때, sleep()을 하면 return {"FINISHED"}가 늦어져서 sleep() 사용 불가능
-        #       Render에 있는 event timer를 참고하면 좋을 것 같음
+        # TODO: 종료창 대신, is_dirty == True면 save 먼저 실행해주기
+        #       save modal과 splash modal이 동시에 겹쳐지는 문제가 있음
+        #       render.py에 있는 event timer를 참고하면 좋을듯
         if os.path.exists(path_cookiesFile):
             os.remove(path_cookiesFile)
 
@@ -45,11 +45,6 @@ class Acon3dLogoutOperator(bpy.types.Operator):
             prop.username = read_remembered_username()
 
             bpy.ops.wm.splash("INVOKE_DEFAULT")
-
-            # TODO: bpy.ops.wm.read_homefile()을 사용해 현재 파일 처리 과정 구현
-            #       현재 splash 화면에서 프로그램을 종료하면 Quit 대화창으로 저장 기능을 사용할 수는 있지만
-            #       splash 화면과 저장 modal이 충돌할 가능성 있음
-
         else:
             print("No login session file")
 

--- a/release/scripts/startup/abler/operators.py
+++ b/release/scripts/startup/abler/operators.py
@@ -1,5 +1,7 @@
+import os
 import bpy
 from .lib.materials import materials_setup
+from .lib.remember_username import read_remembered_checkbox, read_remembered_username
 
 class Acon3dToonStyleOperator(bpy.types.Operator):
     """Iterate all materials and change them into toon style"""
@@ -12,8 +14,50 @@ class Acon3dToonStyleOperator(bpy.types.Operator):
         materials_setup.applyAconToonStyle()
         return {"FINISHED"}
 
+
+class Logout(bpy.types.Operator):
+    """Logout user account for menu"""
+
+    bl_idname = "acon3d.logout_menu"
+    bl_label = "Logout_menu"
+    bl_translation_context = "*"
+
+    def execute(self, context):
+        # prop를 업데이트 하면 ACON_userInfo에도 반영됨
+        prop = bpy.data.meshes.get("ACON_userInfo").ACON_prop
+        path = bpy.utils.resource_path("USER")
+        path_cookiesFolder = os.path.join(path, "cookies")
+        path_cookiesFile = os.path.join(path_cookiesFolder, "acon3d_session")
+
+        # TODO: New, Quit 대화창을 사용하지 말고, is_dirty == True 면 save_as() 실행해주기
+        #       save_as()에서 modal을 실행할 때, sleep()을 하면 return {"FINISHED"}가 늦어져서 sleep() 사용 불가능
+        #       Render에 있는 event timer를 참고하면 좋을 것 같음
+        if os.path.exists(path_cookiesFile):
+            os.remove(path_cookiesFile)
+
+            # login_status가 SUCCESS가 아닌 상태에서 modal_operator를 실행하고 쿠키 파일 확인하기
+            prop.login_status = "IDLE"
+            bpy.ops.acon3d.modal_operator("INVOKE_DEFAULT")
+
+            # 아이디 기억하기 체크박스 상태와 아이디 업데이트
+            prop.remember_username = read_remembered_checkbox()
+            prop.username = read_remembered_username()
+            bpy.ops.wm.splash("INVOKE_DEFAULT")
+
+            # TODO: bpy.ops.wm.read_homefile()을 사용해 현재 파일 처리 과정 구현
+            #       현재 splash 화면에서 프로그램을 종료하면 Quit 대화창으로 저장 기능을 사용할 수는 있지만
+            #       splash 화면과 저장 modal이 충돌할 가능성 있음
+
+        else:
+            print("No login session file")
+
+        return {"FINISHED"}
+
+
+
 classes = (
     Acon3dToonStyleOperator,
+    Logout,
 )
 
 

--- a/release/scripts/startup/bl_ui/space_topbar.py
+++ b/release/scripts/startup/bl_ui/space_topbar.py
@@ -220,6 +220,10 @@ class TOPBAR_MT_editor_menus(Menu):
 
         layout.menu("TOPBAR_MT_window")
         layout.menu("TOPBAR_MT_help")
+        
+        layout.separator()
+        
+        layout.operator("acon3d.logout")
 
 
 class TOPBAR_MT_blender(Menu):

--- a/release/scripts/startup/bl_ui/space_topbar.py
+++ b/release/scripts/startup/bl_ui/space_topbar.py
@@ -222,8 +222,9 @@ class TOPBAR_MT_editor_menus(Menu):
         layout.menu("TOPBAR_MT_help")
         
         layout.separator()
-        
-        layout.operator("acon3d.logout")
+
+        # layout.operator("acon3d.logout")
+        layout.operator("acon3d.logout_menu")
 
 
 class TOPBAR_MT_blender(Menu):

--- a/release/scripts/startup/bl_ui/space_topbar.py
+++ b/release/scripts/startup/bl_ui/space_topbar.py
@@ -220,11 +220,6 @@ class TOPBAR_MT_editor_menus(Menu):
 
         layout.menu("TOPBAR_MT_window")
         layout.menu("TOPBAR_MT_help")
-        
-        layout.separator()
-
-        # layout.operator("acon3d.logout")
-        layout.operator("acon3d.logout_menu")
 
 
 class TOPBAR_MT_blender(Menu):
@@ -235,6 +230,7 @@ class TOPBAR_MT_blender(Menu):
 
         layout.operator("wm.splash")
         layout.operator("wm.splash_about")
+        layout.operator("acon3d.logout")
 
         layout.separator()
 


### PR DESCRIPTION
## 요약

- 로그인은 있지만 로그아웃이 없어 로그아웃 기능 구현
- 로그아웃 기능 UI 위치 논의 완료
- 자세한 내용은 Notion 문서: [로그아웃 기능 구현](https://www.notion.so/acon3d/e04062c4d446419cbd8768447da7f076)

![image](https://user-images.githubusercontent.com/52474700/170638912-16fab17e-fade-41ec-8877-e86c3c8b9e8f.png)


## 진행 상황

- [x]  사용자의 로그인 쿠키 파일 삭제
- [x]  `login_status`의 `success` 상태를 해제하고 `credential_modal` 활성화
- [x]  코니방 (homefile) 돌아가기 없이, 현재 파일에서 로그아웃 된 스플래쉬 실행
- [x]  Username 받아오기
- [x]  UI 논의 후 메뉴바에 로그아웃 기능 구현 결정
- [x]  Remember Username 상태 받아오기


## 코드

- 로그아웃 Operator

https://github.com/ACON3D/blender/blob/62c8b090ca3bf7acb65d1e44bc119fbf6fab87b5/release/scripts/startup/abler/operators.py#L19-L51


## 추가 문제

> 아래의 문제들은 추후 필요 시에 다룰 예정

1. 파일 브라우저와 스플래쉬 창이 겹침
2. 스플래쉬 창이 뜬 상태에서 프로그램 종료창 발생