### PR TITLE
toon-shading-depth default 추가 

### DIFF
--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -198,6 +198,7 @@ class AconSceneProperty(bpy.types.PropertyGroup):
         name="Toon Color Depth",
         description="Change number of colors used for shading",
         items=[("2", "2 depth", ""), ("3", "3 depth", "")],
+        default="3",
         update=materials_handler.changeToonDepth,
     )
 


### PR DESCRIPTION
https://acontainer.slack.com/archives/C02K1NPTV42/p1649831589660969
슬랙에서 나온 얘기 반영해서 toon-shading-depth `default="3"`로 추가해주었습니다.
혹시나해서 startup.blend에서도 3 depth로 저장하고 변경했습니다.
