### PR TITLE
updated request not found exception

### DIFF
--- a/launcher_abler/AblerLauncher.py
+++ b/launcher_abler/AblerLauncher.py
@@ -262,12 +262,11 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
         self.btn_Quit.clicked.connect(QtCore.QCoreApplication.instance().quit)
         self.btn_about.clicked.connect(self.about)
         self.btn_acon.clicked.connect(self.open_acon3d)
-
         try:
             if not (self.check_launcher()):
                 self.check_once()
         except Exception as e:
-            logger.debug(e)
+            logger.error(e)
 
     def open_acon3d(self):
         url = QtCore.QUrl("https://www.acon3d.com/")
@@ -324,7 +323,12 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
         results = []
         if test_arg:
             req = req[0]
-        if req["message"] == "Not Found":
+        is_no_release = False
+        try:
+            is_no_release = req["message"] == "Not Found"
+        except Exception as e:
+            logger.debug("Release found")
+        if is_no_release:
             self.frm_start.show()
             self.btn_execute.show()
             if sys.platform == "win32":
@@ -442,7 +446,12 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
         results = []
         if test_arg:
             req = req[0]
-        if req["message"] == "Not Found":
+        is_no_release = False
+        try:
+            is_no_release = req["message"] == "Not Found"
+        except Exception as e:
+            logger.debug("Release found")
+        if is_no_release:
             self.frm_start.show()
             self.btn_execute.show()
             self.btn_update_launcher.hide()


### PR DESCRIPTION
런쳐에서 릴리즈가 없을 때의 request의 response에 "message" 라는 항목이 없어서 update launcher 버튼만 떠있고 아무것도 진행이 안되는 문제를 해결했습니다.

빠르게 리뷰 부탁드릴게요!! 이거 기반으로 다시 릴리즈 파일 만들어서 올려야 할 것 같아요
