### PR TITLE
[폐기 예정] 아웃라인 셰이더 개선을 위한 prepass 추가

### DIFF
--- a/source/blender/draw/CMakeLists.txt
+++ b/source/blender/draw/CMakeLists.txt
@@ -114,6 +114,8 @@ set(SRC
   engines/basic/basic_engine.c
   engines/image/image_engine.c
   engines/image/image_shader.c
+  engines/eevee/eevee_abler.h
+  engines/eevee/eevee_abler.c
   engines/eevee/eevee_bloom.c
   engines/eevee/eevee_cryptomatte.c
   engines/eevee/eevee_data.c
@@ -235,6 +237,8 @@ set(LIB
   bf_windowmanager
 )
 
+data_to_c_simple(engines/eevee/shaders/abler_prepass_vert.glsl SRC)
+data_to_c_simple(engines/eevee/shaders/abler_prepass_frag.glsl SRC)
 data_to_c_simple(engines/eevee/shaders/ambient_occlusion_lib.glsl SRC)
 data_to_c_simple(engines/eevee/shaders/background_vert.glsl SRC)
 data_to_c_simple(engines/eevee/shaders/common_uniforms_lib.glsl SRC)

--- a/source/blender/draw/engines/eevee/eevee_abler.c
+++ b/source/blender/draw/engines/eevee/eevee_abler.c
@@ -1,0 +1,82 @@
+#include "eevee_abler.h"
+#include "DRW_render.h"
+#include "GPU_platform.h"
+#include "GPU_texture.h"
+#include "eevee_private.h"
+
+void EEVEE_abler_prepass_init(EEVEE_ViewLayerData *sldata, EEVEE_Data *vedata)
+{
+  // Inspired by `workbench_opaque_engine_init`
+  EEVEE_TextureList *txl = vedata->txl;
+  EEVEE_FramebufferList *fbl = vedata->fbl;
+
+  DRW_texture_ensure_fullscreen_2d(&txl->abler_depth_buffer, GPU_DEPTH24_STENCIL8, 0);
+  DRW_texture_ensure_fullscreen_2d(&txl->abler_normal_buffer, GPU_RGBA16F, DRW_TEX_FILTER);
+  DRW_texture_ensure_fullscreen_2d(&txl->abler_object_buffer, GPU_R16UI, 0);
+
+  GPU_framebuffer_ensure_config(&fbl->abler_prepass_fb,
+                                {
+                                    GPU_ATTACHMENT_TEXTURE(txl->abler_depth_buffer),
+                                    GPU_ATTACHMENT_TEXTURE(txl->abler_normal_buffer),
+                                    GPU_ATTACHMENT_TEXTURE(txl->abler_object_buffer),
+                                });
+}
+
+void EEVEE_abler_prepass_cache_init(EEVEE_ViewLayerData *sldata, EEVEE_Data *vedata)
+{
+  EEVEE_PassList *psl = vedata->psl;
+  int state = DRW_STATE_WRITE_COLOR | DRW_STATE_WRITE_DEPTH | DRW_STATE_DEPTH_LESS_EQUAL;
+  DRW_PASS_CREATE(psl->abler_prepass, state);
+}
+
+void EEVEE_abler_prepass_cache_populate(EEVEE_Data *vedata, Object *ob)
+{
+  // Inspired by `workbench_cache_common_populate`
+  EEVEE_PassList *psl = vedata->psl;
+  EEVEE_ViewLayerData *sldata = EEVEE_view_layer_data_ensure();
+
+  struct GPUBatch *batch = DRW_cache_object_surface_get(ob);
+  if (batch) {
+    GPUShader *sh = EEVEE_shaders_abler_prepass_sh_get();
+    DRWShadingGroup *grp = DRW_shgroup_create(sh, psl->abler_prepass);
+    DRW_shgroup_uniform_block(grp, "common_block", sldata->common_ubo);
+    DRW_shgroup_call(grp, batch, ob);
+  }
+}
+
+void EEVEE_abler_prepass_cache_finish(EEVEE_Data *vedata)
+{
+  // Inspired by `workbench_cache_finish`
+  EEVEE_TextureList *txl = vedata->txl;
+  EEVEE_FramebufferList *fbl = vedata->fbl;
+
+  GPU_framebuffer_ensure_config(&fbl->abler_prepass_fb,
+                                {
+                                    GPU_ATTACHMENT_TEXTURE(txl->abler_depth_buffer),
+                                    GPU_ATTACHMENT_TEXTURE(txl->abler_normal_buffer),
+                                    GPU_ATTACHMENT_TEXTURE(txl->abler_object_buffer),
+                                });
+  // TODO: workbench 의 id_clear_fb 용도 확인
+}
+
+void EEVEE_abler_prepass_draw(EEVEE_Data *vedata)
+{
+  const float clear_col[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+
+  EEVEE_PassList *psl = vedata->psl;
+  EEVEE_FramebufferList *fbl = vedata->fbl;
+
+  DRW_stats_group_start("Abler prepass");
+  GPU_framebuffer_bind(fbl->abler_prepass_fb);
+  GPU_framebuffer_clear_color_depth_stencil(fbl->abler_prepass_fb, clear_col, 1.0f, 0x00);
+  DRW_draw_pass(psl->abler_prepass);
+  DRW_stats_group_end();
+
+  // Restore
+  GPU_framebuffer_bind(fbl->main_fb);
+}
+
+void EEVEE_abler_prepass_free()
+{
+  // Do nothing
+}

--- a/source/blender/draw/engines/eevee/eevee_abler.c
+++ b/source/blender/draw/engines/eevee/eevee_abler.c
@@ -29,21 +29,6 @@ void EEVEE_abler_prepass_cache_init(EEVEE_ViewLayerData *sldata, EEVEE_Data *ved
   DRW_PASS_CREATE(psl->abler_prepass, state);
 }
 
-void EEVEE_abler_prepass_cache_populate(EEVEE_Data *vedata, Object *ob)
-{
-  // Inspired by `workbench_cache_common_populate`
-  EEVEE_PassList *psl = vedata->psl;
-  EEVEE_ViewLayerData *sldata = EEVEE_view_layer_data_ensure();
-
-  struct GPUBatch *batch = DRW_cache_object_surface_get(ob);
-  if (batch) {
-    GPUShader *sh = EEVEE_shaders_abler_prepass_sh_get();
-    DRWShadingGroup *grp = DRW_shgroup_create(sh, psl->abler_prepass);
-    DRW_shgroup_uniform_block(grp, "common_block", sldata->common_ubo);
-    DRW_shgroup_call(grp, batch, ob);
-  }
-}
-
 void EEVEE_abler_prepass_cache_finish(EEVEE_Data *vedata)
 {
   // Inspired by `workbench_cache_finish`

--- a/source/blender/draw/engines/eevee/eevee_abler.c
+++ b/source/blender/draw/engines/eevee/eevee_abler.c
@@ -14,6 +14,14 @@ void EEVEE_abler_prepass_init(EEVEE_ViewLayerData *sldata, EEVEE_Data *vedata)
   DRW_texture_ensure_fullscreen_2d(&txl->abler_normal_buffer, GPU_RGBA16F, DRW_TEX_FILTER);
   DRW_texture_ensure_fullscreen_2d(&txl->abler_object_buffer, GPU_R16UI, 0);
 
+  // Follow maxzbuffer_fb
+  // TODO: Workaround for Intel GPUs
+  GPU_framebuffer_ensure_config(&fbl->abler_copy_depth_fb,
+                                {
+                                    GPU_ATTACHMENT_TEXTURE(txl->abler_depth_buffer),
+                                    GPU_ATTACHMENT_LEAVE,
+                                });
+
   GPU_framebuffer_ensure_config(&fbl->abler_prepass_fb,
                                 {
                                     GPU_ATTACHMENT_TEXTURE(txl->abler_depth_buffer),
@@ -25,8 +33,15 @@ void EEVEE_abler_prepass_init(EEVEE_ViewLayerData *sldata, EEVEE_Data *vedata)
 void EEVEE_abler_prepass_cache_init(EEVEE_ViewLayerData *sldata, EEVEE_Data *vedata)
 {
   EEVEE_PassList *psl = vedata->psl;
-  int state = DRW_STATE_WRITE_COLOR | DRW_STATE_WRITE_DEPTH | DRW_STATE_DEPTH_LESS_EQUAL;
-  DRW_PASS_CREATE(psl->abler_prepass, state);
+  // Follow maxz_copydepth_ps
+  DRW_PASS_CREATE(psl->abler_copy_depth_pass, DRW_STATE_WRITE_DEPTH | DRW_STATE_DEPTH_ALWAYS);
+  DRW_PASS_CREATE(psl->abler_prepass, DRW_STATE_WRITE_COLOR | DRW_STATE_WRITE_DEPTH | DRW_STATE_DEPTH_LESS_EQUAL);
+
+  struct GPUBatch *quad = DRW_cache_fullscreen_quad_get();
+  DRWShadingGroup *grp = DRW_shgroup_create(EEVEE_shaders_abler_copy_depth_pass_sh_get(), psl->abler_copy_depth_pass);
+  DefaultTextureList *dtxl = DRW_viewport_texture_list_get();
+  DRW_shgroup_uniform_texture_ref_ex(grp, "depthBuffer", &dtxl->depth, GPU_SAMPLER_DEFAULT);
+  DRW_shgroup_call(grp, quad, NULL);
 }
 
 void EEVEE_abler_prepass_cache_finish(EEVEE_Data *vedata)
@@ -35,6 +50,7 @@ void EEVEE_abler_prepass_cache_finish(EEVEE_Data *vedata)
   EEVEE_TextureList *txl = vedata->txl;
   EEVEE_FramebufferList *fbl = vedata->fbl;
 
+  // TODO: 중복 코드
   GPU_framebuffer_ensure_config(&fbl->abler_prepass_fb,
                                 {
                                     GPU_ATTACHMENT_TEXTURE(txl->abler_depth_buffer),
@@ -52,9 +68,13 @@ void EEVEE_abler_prepass_draw(EEVEE_Data *vedata)
   EEVEE_FramebufferList *fbl = vedata->fbl;
 
   DRW_stats_group_start("Abler prepass");
-  GPU_framebuffer_bind(fbl->abler_prepass_fb);
-  GPU_framebuffer_clear_color_depth_stencil(fbl->abler_prepass_fb, clear_col, 1.0f, 0x00);
-  DRW_draw_pass(psl->abler_prepass);
+
+  GPU_framebuffer_bind(fbl->abler_copy_depth_fb);
+  DRW_draw_pass(psl->abler_copy_depth_pass);
+
+//  GPU_framebuffer_bind(fbl->abler_prepass_fb);
+//  GPU_framebuffer_clear_color_depth_stencil(fbl->abler_prepass_fb, clear_col, 1.0f, 0x00);
+//  DRW_draw_pass(psl->abler_prepass);
   DRW_stats_group_end();
 
   // Restore

--- a/source/blender/draw/engines/eevee/eevee_abler.h
+++ b/source/blender/draw/engines/eevee/eevee_abler.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "eevee_private.h"
+
+void EEVEE_abler_prepass_init(EEVEE_ViewLayerData *sldata, EEVEE_Data *vedata);
+
+void EEVEE_abler_prepass_cache_init(EEVEE_ViewLayerData *sldata, EEVEE_Data *vedata);
+
+void EEVEE_abler_prepass_cache_populate(EEVEE_Data *vedata, Object *ob);
+
+void EEVEE_abler_prepass_cache_finish(EEVEE_Data *vedata);
+
+void EEVEE_abler_prepass_draw(EEVEE_Data *vedata);
+
+void EEVEE_abler_prepass_free(void);

--- a/source/blender/draw/engines/eevee/eevee_abler.h
+++ b/source/blender/draw/engines/eevee/eevee_abler.h
@@ -6,7 +6,8 @@ void EEVEE_abler_prepass_init(EEVEE_ViewLayerData *sldata, EEVEE_Data *vedata);
 
 void EEVEE_abler_prepass_cache_init(EEVEE_ViewLayerData *sldata, EEVEE_Data *vedata);
 
-void EEVEE_abler_prepass_cache_populate(EEVEE_Data *vedata, Object *ob);
+// 불투명 재질에 대해서만 캐시를 생성하도록 EEVEE_materials_cache_populate 에서 대신 처리
+// void EEVEE_abler_prepass_cache_populate(EEVEE_Data *vedata, Object *ob);
 
 void EEVEE_abler_prepass_cache_finish(EEVEE_Data *vedata);
 

--- a/source/blender/draw/engines/eevee/eevee_engine.c
+++ b/source/blender/draw/engines/eevee/eevee_engine.c
@@ -558,6 +558,7 @@ static void eevee_render_to_image(void *vedata,
       EEVEE_lights_cache_finish(sldata, vedata);
       EEVEE_lightprobes_cache_finish(sldata, vedata);
       EEVEE_renderpasses_cache_finish(sldata, vedata);
+      EEVEE_abler_prepass_cache_finish(vedata);
 
       EEVEE_subsurface_draw_init(sldata, vedata);
       EEVEE_effects_draw_init(sldata, vedata);

--- a/source/blender/draw/engines/eevee/eevee_engine.c
+++ b/source/blender/draw/engines/eevee/eevee_engine.c
@@ -154,8 +154,6 @@ void EEVEE_cache_populate(void *vedata, Object *ob)
   if (cast_shadow) {
     EEVEE_shadows_caster_register(sldata, ob);
   }
-
-  EEVEE_abler_prepass_cache_populate(vedata, ob);
 }
 
 static void eevee_cache_finish(void *vedata)

--- a/source/blender/draw/engines/eevee/eevee_engine.c
+++ b/source/blender/draw/engines/eevee/eevee_engine.c
@@ -281,13 +281,13 @@ static void eevee_draw_scene(void *vedata)
     SET_FLAG_FROM_TEST(clear_bits, (stl->effects->enabled_effects & EFFECT_SSS), GPU_STENCIL_BIT);
     GPU_framebuffer_clear(fbl->main_fb, clear_bits, clear_col, clear_depth, clear_stencil);
 
-    /* Abler prepass */
-    EEVEE_abler_prepass_draw(vedata);
-
     /* Depth prepass */
     DRW_stats_group_start("Prepass");
     DRW_draw_pass(psl->depth_ps);
     DRW_stats_group_end();
+
+    /* Abler prepass */
+    EEVEE_abler_prepass_draw(vedata);
 
     /* Create minmax texture */
     DRW_stats_group_start("Main MinMax buffer");

--- a/source/blender/draw/engines/eevee/eevee_materials.c
+++ b/source/blender/draw/engines/eevee/eevee_materials.c
@@ -106,6 +106,7 @@ void EEVEE_material_bind_resources(DRWShadingGroup *shgrp,
 
   DRW_shgroup_uniform_int_copy(shgrp, "outputSssId", 1);
   DRW_shgroup_uniform_texture(shgrp, "utilTex", e_data.util_tex);
+  DRW_shgroup_uniform_texture_ref(shgrp, "ablerObjectBuffer", &vedata->txl->abler_object_buffer);
   if (use_diffuse || use_glossy || use_refract) {
     DRW_shgroup_uniform_texture_ref(shgrp, "shadowCubeTexture", &sldata->shadow_cube_pool);
     DRW_shgroup_uniform_texture_ref(shgrp, "shadowCascadeTexture", &sldata->shadow_cascade_pool);

--- a/source/blender/draw/engines/eevee/eevee_materials.c
+++ b/source/blender/draw/engines/eevee/eevee_materials.c
@@ -107,6 +107,8 @@ void EEVEE_material_bind_resources(DRWShadingGroup *shgrp,
   DRW_shgroup_uniform_int_copy(shgrp, "outputSssId", 1);
   DRW_shgroup_uniform_texture(shgrp, "utilTex", e_data.util_tex);
   DRW_shgroup_uniform_texture_ref(shgrp, "ablerObjectBuffer", &vedata->txl->abler_object_buffer);
+  DRW_shgroup_uniform_texture_ref(shgrp, "ablerDepthBuffer", &vedata->txl->abler_depth_buffer);
+  DRW_shgroup_uniform_texture_ref(shgrp, "ablerNormalBuffer", &vedata->txl->abler_normal_buffer);
   if (use_diffuse || use_glossy || use_refract) {
     DRW_shgroup_uniform_texture_ref(shgrp, "shadowCubeTexture", &sldata->shadow_cube_pool);
     DRW_shgroup_uniform_texture_ref(shgrp, "shadowCascadeTexture", &sldata->shadow_cascade_pool);

--- a/source/blender/draw/engines/eevee/eevee_private.h
+++ b/source/blender/draw/engines/eevee/eevee_private.h
@@ -249,6 +249,7 @@ typedef struct EEVEE_BoundBox {
 
 typedef struct EEVEE_PassList {
   /* ABLER prepass */
+  struct DRWPass *abler_copy_depth_pass;
   struct DRWPass *abler_prepass;
 
   /* Shadows */
@@ -348,6 +349,7 @@ typedef struct EEVEE_PassList {
 
 typedef struct EEVEE_FramebufferList {
   /* ABLER prepass */
+  struct GPUFrameBuffer *abler_copy_depth_fb;
   struct GPUFrameBuffer *abler_prepass_fb;
 
   /* Effects */
@@ -1243,6 +1245,7 @@ struct GPUShader *EEVEE_shaders_probe_cube_display_sh_get(void);
 struct GPUShader *EEVEE_shaders_probe_grid_display_sh_get(void);
 struct GPUShader *EEVEE_shaders_probe_planar_display_sh_get(void);
 struct GPUShader *EEVEE_shaders_update_noise_sh_get(void);
+struct GPUShader *EEVEE_shaders_abler_copy_depth_pass_sh_get(void);
 struct GPUShader *EEVEE_shaders_abler_prepass_sh_get(void);
 struct GPUShader *EEVEE_shaders_velocity_resolve_sh_get(void);
 struct GPUShader *EEVEE_shaders_taa_resolve_sh_get(EEVEE_EffectsFlag enabled_effects);

--- a/source/blender/draw/engines/eevee/eevee_private.h
+++ b/source/blender/draw/engines/eevee/eevee_private.h
@@ -248,6 +248,9 @@ typedef struct EEVEE_BoundBox {
 } EEVEE_BoundBox;
 
 typedef struct EEVEE_PassList {
+  /* ABLER prepass */
+  struct DRWPass *abler_prepass;
+
   /* Shadows */
   struct DRWPass *shadow_pass;
   struct DRWPass *shadow_accum_pass;
@@ -344,6 +347,9 @@ typedef struct EEVEE_PassList {
 } EEVEE_PassList;
 
 typedef struct EEVEE_FramebufferList {
+  /* ABLER prepass */
+  struct GPUFrameBuffer *abler_prepass_fb;
+
   /* Effects */
   struct GPUFrameBuffer *gtao_fb;
   struct GPUFrameBuffer *gtao_debug_fb;
@@ -407,6 +413,11 @@ typedef struct EEVEE_FramebufferList {
 } EEVEE_FramebufferList;
 
 typedef struct EEVEE_TextureList {
+  /* ABLER prepass */
+  struct GPUTexture *abler_object_buffer;
+  struct GPUTexture *abler_normal_buffer;
+  struct GPUTexture *abler_depth_buffer;
+
   /* Effects */
   struct GPUTexture *color_post; /* R16_G16_B16 */
   struct GPUTexture *mist_accum;
@@ -1232,6 +1243,7 @@ struct GPUShader *EEVEE_shaders_probe_cube_display_sh_get(void);
 struct GPUShader *EEVEE_shaders_probe_grid_display_sh_get(void);
 struct GPUShader *EEVEE_shaders_probe_planar_display_sh_get(void);
 struct GPUShader *EEVEE_shaders_update_noise_sh_get(void);
+struct GPUShader *EEVEE_shaders_abler_prepass_sh_get(void);
 struct GPUShader *EEVEE_shaders_velocity_resolve_sh_get(void);
 struct GPUShader *EEVEE_shaders_taa_resolve_sh_get(EEVEE_EffectsFlag enabled_effects);
 struct bNodeTree *EEVEE_shader_default_surface_nodetree(Material *ma);

--- a/source/blender/draw/engines/eevee/eevee_render.c
+++ b/source/blender/draw/engines/eevee/eevee_render.c
@@ -270,8 +270,6 @@ void EEVEE_render_cache(void *vedata,
   if (cast_shadow) {
     EEVEE_shadows_caster_register(sldata, ob);
   }
-
-  EEVEE_abler_prepass_cache_populate(vedata, ob);
 }
 
 static void eevee_render_color_result(RenderLayer *rl,

--- a/source/blender/draw/engines/eevee/eevee_render.c
+++ b/source/blender/draw/engines/eevee/eevee_render.c
@@ -45,6 +45,7 @@
 #include "RE_pipeline.h"
 
 #include "eevee_private.h"
+#include "eevee_abler.h"
 
 /* Return true if init properly. */
 bool EEVEE_render_init(EEVEE_Data *ved, RenderEngine *engine, struct Depsgraph *depsgraph)
@@ -626,6 +627,10 @@ void EEVEE_render_draw(EEVEE_Data *vedata, RenderEngine *engine, RenderLayer *rl
 
     GPU_framebuffer_bind(fbl->main_fb);
     GPU_framebuffer_clear_color_depth_stencil(fbl->main_fb, clear_col, clear_depth, clear_stencil);
+
+    /* Abler prepass */
+    EEVEE_abler_prepass_draw(vedata);
+
     /* Depth prepass */
     DRW_draw_pass(psl->depth_ps);
     /* Create minmax texture */

--- a/source/blender/draw/engines/eevee/eevee_renderpasses.c
+++ b/source/blender/draw/engines/eevee/eevee_renderpasses.c
@@ -519,6 +519,16 @@ void EEVEE_renderpasses_draw_debug(EEVEE_Data *vedata)
     case 11:
       tx = effects->velocity_tx;
       break;
+    // Abler specific
+    case 97:
+      tx = txl->abler_depth_buffer;
+      break;
+    case 98:
+      tx = txl->abler_normal_buffer;
+      break;
+    case 99:
+      tx = txl->abler_object_buffer;
+      break;
     default:
       break;
   }

--- a/source/blender/draw/engines/eevee/eevee_shaders.c
+++ b/source/blender/draw/engines/eevee/eevee_shaders.c
@@ -49,6 +49,9 @@ static const char *filter_defines =
 #endif
 
 static struct {
+  /* ABLER prepass */
+  struct GPUShader *abler_prepass_sh;
+
   /* Lookdev */
   struct GPUShader *studiolight_probe_sh;
   struct GPUShader *studiolight_background_sh;
@@ -186,6 +189,8 @@ extern char datatoc_common_math_geom_lib_glsl[];
 extern char datatoc_common_view_lib_glsl[];
 extern char datatoc_gpu_shader_common_obinfos_lib_glsl[];
 
+extern char datatoc_abler_prepass_vert_glsl[];
+extern char datatoc_abler_prepass_frag_glsl[];
 extern char datatoc_ambient_occlusion_lib_glsl[];
 extern char datatoc_background_vert_glsl[];
 extern char datatoc_bsdf_common_lib_glsl[];
@@ -935,6 +940,18 @@ GPUShader *EEVEE_shaders_update_noise_sh_get(void)
   return e_data.update_noise_sh;
 }
 
+GPUShader *EEVEE_shaders_abler_prepass_sh_get(void)
+{
+  if (e_data.abler_prepass_sh == NULL) {
+    e_data.abler_prepass_sh = DRW_shader_create_with_shaderlib(datatoc_abler_prepass_vert_glsl,
+                                                               NULL,
+                                                               datatoc_abler_prepass_frag_glsl,
+                                                               e_data.lib,
+                                                               SHADER_DEFINES);
+  }
+  return e_data.abler_prepass_sh;
+}
+
 GPUShader *EEVEE_shaders_taa_resolve_sh_get(EEVEE_EffectsFlag enabled_effects)
 {
   GPUShader **sh;
@@ -1537,6 +1554,8 @@ struct GPUMaterial *EEVEE_material_get(
 
 void EEVEE_shaders_free(void)
 {
+  DRW_SHADER_FREE_SAFE(e_data.abler_prepass_sh);
+
   MEM_SAFE_FREE(e_data.surface_prepass_frag);
   MEM_SAFE_FREE(e_data.surface_lit_frag);
   MEM_SAFE_FREE(e_data.surface_geom_barycentric);

--- a/source/blender/draw/engines/eevee/eevee_shaders.c
+++ b/source/blender/draw/engines/eevee/eevee_shaders.c
@@ -51,6 +51,7 @@ static const char *filter_defines =
 static struct {
   /* ABLER prepass */
   struct GPUShader *abler_prepass_sh;
+  struct GPUShader *abler_copy_depth_pass_sh;
 
   /* Lookdev */
   struct GPUShader *studiolight_probe_sh;
@@ -189,6 +190,8 @@ extern char datatoc_common_math_geom_lib_glsl[];
 extern char datatoc_common_view_lib_glsl[];
 extern char datatoc_gpu_shader_common_obinfos_lib_glsl[];
 
+extern char datatoc_abler_copy_depth_pass_vert_glsl[];
+extern char datatoc_abler_copy_depth_pass_frag_glsl[];
 extern char datatoc_abler_prepass_vert_glsl[];
 extern char datatoc_abler_prepass_frag_glsl[];
 extern char datatoc_ambient_occlusion_lib_glsl[];
@@ -950,6 +953,16 @@ GPUShader *EEVEE_shaders_abler_prepass_sh_get(void)
                                                                SHADER_DEFINES);
   }
   return e_data.abler_prepass_sh;
+}
+
+GPUShader *EEVEE_shaders_abler_copy_depth_pass_sh_get(void)
+{
+  if (e_data.abler_copy_depth_pass_sh == NULL) {
+    e_data.abler_copy_depth_pass_sh = DRW_shader_create_fullscreen(datatoc_effect_minmaxz_frag_glsl,
+                                                            "#define MAX_PASS\n"
+                                                            "#define COPY_DEPTH\n");
+  }
+  return e_data.abler_copy_depth_pass_sh;
 }
 
 GPUShader *EEVEE_shaders_taa_resolve_sh_get(EEVEE_EffectsFlag enabled_effects)

--- a/source/blender/draw/engines/eevee/shaders/abler_copy_depth_pass_frag.glsl
+++ b/source/blender/draw/engines/eevee/shaders/abler_copy_depth_pass_frag.glsl
@@ -1,0 +1,71 @@
+/**
+ * Copied from effect_minmaxz_frag.glsl
+ */
+
+#ifdef LAYERED
+uniform sampler2DArray depthBuffer;
+uniform int depthLayer;
+#else
+uniform sampler2D depthBuffer;
+#endif
+
+#ifndef COPY_DEPTH
+uniform vec2 texelSize;
+#endif
+
+#ifdef LAYERED
+#  define sampleLowerMip(t) texture(depthBuffer, vec3(t, depthLayer)).r
+#  define gatherLowerMip(t) textureGather(depthBuffer, vec3(t, depthLayer))
+#else
+#  define sampleLowerMip(t) texture(depthBuffer, t).r
+#  define gatherLowerMip(t) textureGather(depthBuffer, t)
+#endif
+
+#ifdef MIN_PASS
+#  define minmax2(a, b) min(a, b)
+#  define minmax3(a, b, c) min(min(a, b), c)
+#  define minmax4(a, b, c, d) min(min(min(a, b), c), d)
+#else /* MAX_PASS */
+#  define minmax2(a, b) max(a, b)
+#  define minmax3(a, b, c) max(max(a, b), c)
+#  define minmax4(a, b, c, d) max(max(max(a, b), c), d)
+#endif
+
+/* On some AMD card / driver combination, it is needed otherwise,
+ * the shader does not write anything. */
+#if defined(GPU_INTEL) || defined(GPU_ATI)
+out vec4 fragColor;
+#endif
+
+void main()
+{
+  vec2 texel = gl_FragCoord.xy;
+
+#ifdef COPY_DEPTH
+  vec2 uv = texel / vec2(textureSize(depthBuffer, 0).xy);
+
+  float val = sampleLowerMip(uv);
+#else
+  /* NOTE(@fclem): textureSize() does not work the same on all implementations
+   * when changing the min and max texture levels. Use uniform instead (see T87801). */
+  vec2 uv = texel * 2.0 * texelSize;
+
+  vec4 samp;
+#  ifdef GPU_ARB_texture_gather
+  samp = gatherLowerMip(uv);
+#  else
+  samp.x = sampleLowerMip(uv + vec2(-0.5, -0.5) * texelSize);
+  samp.y = sampleLowerMip(uv + vec2(-0.5, 0.5) * texelSize);
+  samp.z = sampleLowerMip(uv + vec2(0.5, -0.5) * texelSize);
+  samp.w = sampleLowerMip(uv + vec2(0.5, 0.5) * texelSize);
+#  endif
+
+  float val = minmax4(samp.x, samp.y, samp.z, samp.w);
+#endif
+
+#if defined(GPU_INTEL) || defined(GPU_ATI)
+  /* Use color format instead of 24bit depth texture */
+  fragColor = vec4(val);
+#endif
+  gl_FragDepth = val;
+}

--- a/source/blender/draw/engines/eevee/shaders/abler_prepass_frag.glsl
+++ b/source/blender/draw/engines/eevee/shaders/abler_prepass_frag.glsl
@@ -1,0 +1,14 @@
+#pragma BLENDER_REQUIRE(common_view_lib.glsl)
+
+layout(location = 0) out vec3 normalData;
+layout(location = 1) out uint objectId;
+
+in vec3 normal_interp;
+flat in int object_id;
+
+// Inspired by workbench_prepass_frag.glsl
+void main()
+{
+  normalData = normal_interp;
+  objectId = uint(object_id);
+}

--- a/source/blender/draw/engines/eevee/shaders/abler_prepass_vert.glsl
+++ b/source/blender/draw/engines/eevee/shaders/abler_prepass_vert.glsl
@@ -1,0 +1,16 @@
+#pragma BLENDER_REQUIRE(common_view_lib.glsl)
+
+in vec3 pos;
+in vec3 nor;
+
+out vec3 normal_interp;
+flat out int object_id;
+
+// Inspired by workbench_prepass_vert.glsl
+void main()
+{
+  vec3 world_pos = point_object_to_world(pos);
+  gl_Position = point_world_to_ndc(world_pos);
+  normal_interp = normalize(normal_object_to_view(nor));
+  object_id = int(uint(resource_handle) & 0xFFFFu) + 1;
+}

--- a/source/blender/gpu/shaders/material/gpu_shader_material_outline.glsl
+++ b/source/blender/gpu/shaders/material/gpu_shader_material_outline.glsl
@@ -14,6 +14,8 @@ void node_outline(vec3 normal,
   ivec2 texel = ivec2(gl_FragCoord.xy);
   float texel_depth = texelFetch(maxzBuffer, texel, 0).r;
   float texel_z = get_view_z_from_depth(texel_depth);
+  vec2 texel_uv = vec2(texel) / textureSize(maxzBuffer, 0).xy;
+  vec3 texel_vs = get_view_space_from_depth(texel_uv, texel_depth);
 
   //ivec2 offsets[4] = ivec2[4](ivec2(-1, -1), ivec2(-1, 1), ivec2(1, -1), ivec2(1, 1));
   ivec2 offsets[4] = ivec2[4](ivec2(-1, 0), ivec2(1, 0), ivec2(0, -1), ivec2(0, 1));
@@ -55,9 +57,6 @@ void node_outline(vec3 normal,
     vec2 offset_uv = vec2(offset) / textureSize(maxzBuffer, 0).xy;
     vec3 offset_vs = get_view_space_from_depth(offset_uv, texel_depth);
     vec3 actual_offset_vs = get_view_space_from_depth(offset_uv, offset_depth);
-
-    vec2 texel_uv = vec2(texel) / textureSize(maxzBuffer, 0).xy;
-    vec3 texel_vs = get_view_space_from_depth(texel_uv, texel_depth);
 
     width_ws_size = length(offset_vs - texel_vs);
 

--- a/source/blender/gpu/shaders/material/gpu_shader_material_outline.glsl
+++ b/source/blender/gpu/shaders/material/gpu_shader_material_outline.glsl
@@ -1,4 +1,6 @@
 uniform usampler2D ablerObjectBuffer;
+uniform sampler2D ablerDepthBuffer;
+uniform sampler2D ablerNormalBuffer;
 
 void node_outline(vec3 normal,
                   float width,
@@ -15,9 +17,9 @@ void node_outline(vec3 normal,
   object = 0;
 
   ivec2 texel = ivec2(gl_FragCoord.xy);
-  float texel_depth = texelFetch(maxzBuffer, texel, 0).r;
+  float texel_depth = texelFetch(ablerDepthBuffer, texel, 0).r;
   float texel_z = get_view_z_from_depth(texel_depth);
-  vec2 texel_uv = vec2(texel) / textureSize(maxzBuffer, 0).xy;
+  vec2 texel_uv = vec2(texel) / textureSize(ablerDepthBuffer, 0).xy;
   vec3 texel_vs = get_view_space_from_depth(texel_uv, texel_depth);
   uint texel_object = texelFetch(ablerObjectBuffer, texel, 0).r;
 
@@ -55,14 +57,14 @@ void node_outline(vec3 normal,
     ivec2 sample_offset = offsets[i] * int(round(width));
 
     ivec2 offset = texel + sample_offset;
-    float offset_depth = texelFetch(maxzBuffer, offset, 0).r;
+    float offset_depth = texelFetch(ablerDepthBuffer, offset, 0).r;
     float offset_z = get_view_z_from_depth(offset_depth);
     uint offset_object = texelFetch(ablerObjectBuffer, offset, 0).r;
     if (texel_object != offset_object) {
       object = 1.0;
     }
 
-    vec2 offset_uv = vec2(offset) / textureSize(maxzBuffer, 0).xy;
+    vec2 offset_uv = vec2(offset) / textureSize(ablerDepthBuffer, 0).xy;
     vec3 offset_vs = get_view_space_from_depth(offset_uv, texel_depth);
     vec3 actual_offset_vs = get_view_space_from_depth(offset_uv, offset_depth);
 

--- a/source/blender/gpu/shaders/material/gpu_shader_material_outline.glsl
+++ b/source/blender/gpu/shaders/material/gpu_shader_material_outline.glsl
@@ -1,3 +1,5 @@
+uniform usampler2D ablerObjectBuffer;
+
 void node_outline(vec3 normal,
                   float width,
                   out float depth,
@@ -10,12 +12,14 @@ void node_outline(vec3 normal,
   vec3 viewNormal = normalize(normal_world_to_view(normal));
   depth_hit_position = vec3(0,0,0);
   negative_depth_hit_position = vec3(0, 0, 0);
+  object = 0;
 
   ivec2 texel = ivec2(gl_FragCoord.xy);
   float texel_depth = texelFetch(maxzBuffer, texel, 0).r;
   float texel_z = get_view_z_from_depth(texel_depth);
   vec2 texel_uv = vec2(texel) / textureSize(maxzBuffer, 0).xy;
   vec3 texel_vs = get_view_space_from_depth(texel_uv, texel_depth);
+  uint texel_object = texelFetch(ablerObjectBuffer, texel, 0).r;
 
   //ivec2 offsets[4] = ivec2[4](ivec2(-1, -1), ivec2(-1, 1), ivec2(1, -1), ivec2(1, 1));
   ivec2 offsets[4] = ivec2[4](ivec2(-1, 0), ivec2(1, 0), ivec2(0, -1), ivec2(0, 1));
@@ -53,6 +57,10 @@ void node_outline(vec3 normal,
     ivec2 offset = texel + sample_offset;
     float offset_depth = texelFetch(maxzBuffer, offset, 0).r;
     float offset_z = get_view_z_from_depth(offset_depth);
+    uint offset_object = texelFetch(ablerObjectBuffer, offset, 0).r;
+    if (texel_object != offset_object) {
+      object = 1.0;
+    }
 
     vec2 offset_uv = vec2(offset) / textureSize(maxzBuffer, 0).xy;
     vec3 offset_vs = get_view_space_from_depth(offset_uv, texel_depth);
@@ -89,5 +97,4 @@ void node_outline(vec3 normal,
 
   depth = max_depth;
   negative_depth = -min_depth;
-  object = 0;
 }


### PR DESCRIPTION
본격 렌더링을 하기 전에 필요한 버퍼를 미리 그리는 것을 가지고 prepass 라고 부르더라고요. 그래서 저도 그렇게 이름 붙여 봤습니다!

이 prepass 에서는 depth, normal, object id 버퍼를 그립니다. 그것을 위해 필요한 내용을 추가했습니다.

- 필요한 vertex, fragment shader 작성
- framebuffer, texture, shader program 등의 필요한 자원 생성하는 과정 추가
- object 별로 draw call 생성하는 과정 추가 (batch, shgroup)

자세한 내용은 별도의 세션을 통해 설명해보도록 하겠습니다.

작성한 코드는 주로 workbench 의 내용을 참고했고, 블렌더 내의 다른 코드와 구분이 가게, "abler prepass" 라는 단어를 많이 쓰고 코드도 꼭 필요한 경우가 아니면 새로 만든 별개의 파일에 넣었습니다.

테스트 방법:

평소대로 빌드하신 뒤, 파이썬 콘솔에서

```
bpy.app.debug_value = 98
```

을 입력하시면 normal 버퍼가 뷰포트에 출력됩니다.