### PR TITLE
명령어로 런처 버전 업데이트

### DIFF
--- a/launcher_abler/ConfigSelector.py
+++ b/launcher_abler/ConfigSelector.py
@@ -89,7 +89,6 @@ class ConfigSelector:
 
         if os.path.isfile(self.config_bak):
             shutil.copyfile(self.config_bak, self.config)
-            os.remove(self.config_bak)
 
         return
 

--- a/launcher_abler/ConfigSelector.py
+++ b/launcher_abler/ConfigSelector.py
@@ -31,7 +31,6 @@ class ConfigSelector:
         """
         Read config.ini & Extract ABLER and Launcher version.
         """
-
         with open(self.config, "r") as f:
             for line in f.readlines():
                 line = line.strip("\n")
@@ -43,30 +42,27 @@ class ConfigSelector:
 
                 self.config_data.append(line)
 
+        if args.print:
+            print(f"[config.ini]")
+            print(f"ABLER    ver : {self.abler_ver}")
+            print(f"Launcher ver : {self.launcher_ver}")
+
         return
 
     def set_config(self):
         """
         Set ABLER & Launcher version.
         """
-        get_abler = self.abler_ver if args.abler is None else args.abler
-        get_launcher = self.launcher_ver if args.launcher is None else args.launcher
-
-        if args.print:
-            print(f"[config.ini]")
-            print(f"ABLER    ver : {get_abler}")
-            print(f"Launcher ver : {get_launcher}")
-
         with open(self.config, "w") as f:
             for line in self.config_data:
                 if "installed" in line:
                     line = line.split(" ")[:-1]
-                    line.append(get_abler)
+                    line.append(self.abler_ver)
                     line = " ".join(line)
 
                 elif "launcher" in line:
                     line = line.split(" ")[:-1]
-                    line.append(get_launcher)
+                    line.append(self.launcher_ver)
                     line = " ".join(line)
 
                 f.writelines(line)
@@ -78,7 +74,10 @@ class ConfigSelector:
         """
         Save back-up of config.ini
         """
-        shutil.copyfile(self.config, self.config_bak)
+        print("Copy config.ini to config.bak")
+
+        if not os.path.isfile(self.config_bak):
+            shutil.copyfile(self.config, self.config_bak)
 
         return
 
@@ -86,6 +85,8 @@ class ConfigSelector:
         """
         Reset back-up to config.ini
         """
+        print("Reset config.bak to config.ini")
+
         if os.path.isfile(self.config_bak):
             shutil.copyfile(self.config_bak, self.config)
             os.remove(self.config_bak)
@@ -96,29 +97,53 @@ class ConfigSelector:
         """
         Remove config.bak
         """
+        print("Remove config.bak")
+
         if os.path.isfile(self.config_bak):
             os.remove(self.config_bak)
 
         return
 
+    def update_version(self):
+        """
+        Auto update with args
+        """
+        if "abler" in args.update:
+            self.abler_ver = "0.0.1"
+
+        if "launcher" in args.update:
+            self.launcher_ver = "0.0.1"
+
 
 def main():
     config = ConfigSelector()
 
-    if args.copy:
-        config.copy_config()
+    if not os.path.isfile(config.config_bak):
+        if args.copy:
+            config.copy_config()
 
-    if args.reset:
-        config.reset_config()
+        else:
+            print("Please back-up config.ini with '--copy'")
 
-    if args.remove:
-        config.remove_backup()
+    else:
+        if args.copy:
+            print("Already exists back-up file.")
 
-    if args.run:
-        config.copy_config()
-        config.read_config()
-        config.set_config()
-        subprocess.call(config.launcher)
+        if args.reset:
+            config.reset_config()
+
+        if args.remove:
+            config.remove_backup()
+
+        if args.update:
+            config.copy_config()
+            config.read_config()
+            config.update_version()
+            config.set_config()
+
+        if args.run:
+            print(f"Run {config.launcher}")
+            subprocess.call(config.launcher)
 
     return
 
@@ -126,21 +151,23 @@ def main():
 if __name__ == "__main__":
     # Define parser
     parser = argparse.ArgumentParser(
-        description="Test ABLER launcher update", usage="Parser [options]"
+        description="ABLER launcher update test.", usage="Parser [options]"
     )
 
-    parser.add_argument("--launcher", "-l", action="store", default=None, type=str)
-    parser.add_argument("--abler", "-a", action="store", default=None, type=str)
+    parser.add_argument("--print", "-p", action="store_true")
     parser.add_argument("--copy", "-c", action="store_true")
     parser.add_argument("--reset", "-r", action="store_true")
     parser.add_argument("--remove", action="store_true")
-    parser.add_argument("--print", "-p", action="store_true")
+    parser.add_argument(
+        "--update", "-u", action="store", default=None, type=str, nargs="*"
+    )
     parser.add_argument("--run", action="store_true")
 
     args = parser.parse_args()
 
     if len(sys.argv) == 1:
-        print("Please set ABLER or Launcher version.")
+        print("ABLER launcher update test.")
+        print("Please set arguments.")
 
     else:
         main()

--- a/launcher_abler/ConfigSelector.py
+++ b/launcher_abler/ConfigSelector.py
@@ -1,0 +1,148 @@
+"""
+Launcher Update Test
+"""
+import os
+import pathlib
+import subprocess
+import shutil
+import argparse
+import sys
+
+
+class ConfigSelector:
+    def __init__(self):
+        # Path settings
+        self.home = pathlib.Path.home()
+        self.updater = os.path.join(
+            self.home, "AppData\\Roaming\\Blender Foundation\\Blender\\2.96\\updater"
+        )
+        self.launcher = os.path.join(self.updater, "AblerLauncher.exe")
+        self.config = os.path.join(self.updater, "config.ini")
+        self.config_bak = os.path.join(self.updater, "config.bak")
+        self.config_data = []
+
+        # Version
+        self.abler_ver = None
+        self.launcher_ver = None
+
+        return
+
+    def read_config(self):
+        """
+        Read config.ini & Extract ABLER and Launcher version.
+        """
+
+        with open(self.config, "r") as f:
+            for line in f.readlines():
+                line = line.strip("\n")
+
+                if "installed" in line:
+                    self.abler_ver = line.split(" ")[-1]
+                elif "launcher" in line:
+                    self.launcher_ver = line.split(" ")[-1]
+
+                self.config_data.append(line)
+
+        return
+
+    def set_config(self):
+        """
+        Set ABLER & Launcher version.
+        """
+        get_abler = self.abler_ver if args.abler is None else args.abler
+        get_launcher = self.launcher_ver if args.launcher is None else args.launcher
+
+        if args.print:
+            print(f"[config.ini]")
+            print(f"ABLER    ver : {get_abler}")
+            print(f"Launcher ver : {get_launcher}")
+
+        with open(self.config, "w") as f:
+            for line in self.config_data:
+                if "installed" in line:
+                    line = line.split(" ")[:-1]
+                    line.append(get_abler)
+                    line = " ".join(line)
+
+                elif "launcher" in line:
+                    line = line.split(" ")[:-1]
+                    line.append(get_launcher)
+                    line = " ".join(line)
+
+                f.writelines(line)
+                f.writelines("\n")
+
+        return
+
+    def copy_config(self):
+        """
+        Save back-up of config.ini
+        """
+        shutil.copyfile(self.config, self.config_bak)
+
+        return
+
+    def reset_config(self):
+        """
+        Reset back-up to config.ini
+        """
+        if os.path.isfile(self.config_bak):
+            shutil.copyfile(self.config_bak, self.config)
+
+        return
+
+    def remove_config(self):
+        """
+        Remove config.bak
+        """
+        if os.path.isfile(self.config_bak):
+            os.remove(self.config_bak)
+
+        return
+
+
+def main():
+    config = ConfigSelector()
+
+    if args.copy:
+        config.copy_config()
+
+    if args.reset:
+        config.reset_config()
+
+    if args.remove:
+        config.remove_config()
+
+    config.read_config()
+    config.set_config()
+
+    if args.run:
+        subprocess.call(config.launcher)
+
+    return
+
+
+if __name__ == "__main__":
+    # Define parser
+    parser = argparse.ArgumentParser(
+        description="Test ABLER launcher update", usage="Parser [options]"
+    )
+
+    parser.add_argument("--launcher", "-l", action="store", default=None, type=str)
+    parser.add_argument("--abler", "-a", action="store", default=None, type=str)
+    parser.add_argument("--copy", "-c", action="store_true")
+    parser.add_argument("--reset", "-r", action="store_true")
+    parser.add_argument("--remove", action="store_true")
+    parser.add_argument("--print", "-p", action="store_true")
+    parser.add_argument("--run", action="store_true")
+
+    args = parser.parse_args()
+
+    if len(sys.argv) == 1:
+        print("Please set ABLER or Launcher version.")
+
+    else:
+        main()
+
+    if args.print:
+        print(args)

--- a/launcher_abler/ConfigSelector.py
+++ b/launcher_abler/ConfigSelector.py
@@ -88,10 +88,11 @@ class ConfigSelector:
         """
         if os.path.isfile(self.config_bak):
             shutil.copyfile(self.config_bak, self.config)
+            os.remove(self.config_bak)
 
         return
 
-    def remove_config(self):
+    def remove_backup(self):
         """
         Remove config.bak
         """
@@ -111,12 +112,12 @@ def main():
         config.reset_config()
 
     if args.remove:
-        config.remove_config()
-
-    config.read_config()
-    config.set_config()
+        config.remove_backup()
 
     if args.run:
+        config.copy_config()
+        config.read_config()
+        config.set_config()
         subprocess.call(config.launcher)
 
     return

--- a/launcher_abler/ConfigSelector.py
+++ b/launcher_abler/ConfigSelector.py
@@ -18,7 +18,7 @@ class ConfigSelector:
         )
         self.launcher = os.path.join(self.updater, "AblerLauncher.exe")
         self.config = os.path.join(self.updater, "config.ini")
-        self.config_bak = os.path.join(self.updater, "config.bak")
+        self.config_bak = os.path.join(self.updater, "config.ini.bak")
         self.config_data = []
 
         # Version
@@ -74,7 +74,7 @@ class ConfigSelector:
         """
         Save back-up of config.ini
         """
-        print("Copy config.ini to config.bak")
+        print("Copy config.ini to config.ini.bak")
 
         if not os.path.isfile(self.config_bak):
             shutil.copyfile(self.config, self.config_bak)
@@ -85,7 +85,7 @@ class ConfigSelector:
         """
         Reset back-up to config.ini
         """
-        print("Reset config.bak to config.ini")
+        print("Reset config.ini.bak to config.ini")
 
         if os.path.isfile(self.config_bak):
             shutil.copyfile(self.config_bak, self.config)
@@ -94,9 +94,9 @@ class ConfigSelector:
 
     def remove_backup(self):
         """
-        Remove config.bak
+        Remove config.ini.bak
         """
-        print("Remove config.bak")
+        print("Remove config.ini.bak")
 
         if os.path.isfile(self.config_bak):
             os.remove(self.config_bak)
@@ -126,7 +126,7 @@ def main():
 
     else:
         if args.copy:
-            print("Already exists back-up file.")
+            print("Back-up file already exists.")
 
         if args.reset:
             config.reset_config()


### PR DESCRIPTION
## 관련 문서

- Notion : [명령어로 런처 버전 업데이트](https://www.notion.so/acon3d/cda3e9c96072483594d314e25b386df9)

## 진행 사항

- [x]  런처 업데이트 및 설치 테스트 필요성 인지
- [x]  명령어로 `config.ini` 수정 및 리셋
- [ ]  Case별로 `config.ini` 수정하고 런처 실행 자동화
- [ ]  Python 또는 명령어 없이 QA 자동화

## Usage

```bash
# ABLER Launcher 디렉터리로 이동
$ cd ~/blender/launcher_abler

# config.ini 파일 백업
$ python ConfigSelector.py --copy

# 명령어 실행으로 업데이트 테스트
# Update : Launcher O / ABLER O
$ python ConfigSelector.py --run --update launcher abler
```

## `ConfigSelector.py` 명령어

```bash
$ python ConfigSelector.py --help
usage: Parser [options]

ABLER launcher update test.

optional arguments:
  -h, --help            show this help message and exit
  --print, -p
  --copy, -c
  --reset, -r
  --remove
  --update [UPDATE ...], -u [UPDATE ...]
  --run
```

- `--print` : 자세한 사항 표시
- `--copy` : 현재 `config.ini` 를 백업. 백업 파일이 없으면 실행 필요
- `--reset` : 백업 파일로 `config.ini` 리셋 및 백업 파일 삭제
- `--remove` : 백업 파일 삭제
- `--update` : 업데이트할 조건 추가 (`abler` or `launcher`)
- `--run` : `AblerLauncher.exe` 실행