### PR TITLE
싱크홀 현상 개선

### DIFF
--- a/source/blender/draw/CMakeLists.txt
+++ b/source/blender/draw/CMakeLists.txt
@@ -114,6 +114,8 @@ set(SRC
   engines/basic/basic_engine.c
   engines/image/image_engine.c
   engines/image/image_shader.c
+  engines/eevee/eevee_abler.h
+  engines/eevee/eevee_abler.c
   engines/eevee/eevee_bloom.c
   engines/eevee/eevee_cryptomatte.c
   engines/eevee/eevee_data.c
@@ -235,6 +237,7 @@ set(LIB
   bf_windowmanager
 )
 
+data_to_c_simple(engines/eevee/shaders/abler_copy_depth_pass_frag.glsl SRC)
 data_to_c_simple(engines/eevee/shaders/ambient_occlusion_lib.glsl SRC)
 data_to_c_simple(engines/eevee/shaders/background_vert.glsl SRC)
 data_to_c_simple(engines/eevee/shaders/common_uniforms_lib.glsl SRC)

--- a/source/blender/draw/engines/eevee/eevee_abler.c
+++ b/source/blender/draw/engines/eevee/eevee_abler.c
@@ -1,0 +1,63 @@
+#include "eevee_abler.h"
+#include "DRW_render.h"
+#include "GPU_platform.h"
+#include "GPU_texture.h"
+#include "eevee_private.h"
+
+void EEVEE_abler_prepass_init(EEVEE_ViewLayerData *sldata, EEVEE_Data *vedata)
+{
+  // Inspired by `workbench_opaque_engine_init`
+  EEVEE_TextureList *txl = vedata->txl;
+  EEVEE_FramebufferList *fbl = vedata->fbl;
+
+  DRW_texture_ensure_fullscreen_2d(&txl->abler_depth_buffer, GPU_DEPTH24_STENCIL8, 0);
+
+  // Adapted from maxzbuffer_fb
+  GPU_framebuffer_ensure_config(&fbl->abler_copy_depth_fb,
+                                {
+                                    GPU_ATTACHMENT_TEXTURE(txl->abler_depth_buffer),
+                                    GPU_ATTACHMENT_LEAVE,
+                                });
+}
+
+void EEVEE_abler_prepass_cache_init(EEVEE_ViewLayerData *sldata, EEVEE_Data *vedata)
+{
+  EEVEE_PassList *psl = vedata->psl;
+
+  {
+    // Adapted from maxz_copydepth_ps
+    DRW_PASS_CREATE(psl->abler_copy_depth_pass, DRW_STATE_WRITE_DEPTH | DRW_STATE_DEPTH_ALWAYS);
+    struct GPUBatch *quad = DRW_cache_fullscreen_quad_get();
+    DRWShadingGroup *grp = DRW_shgroup_create(EEVEE_shaders_abler_copy_depth_pass_sh_get(),
+                                              psl->abler_copy_depth_pass);
+    DefaultTextureList *dtxl = DRW_viewport_texture_list_get();
+    DRW_shgroup_uniform_texture_ref_ex(grp, "depthBuffer", &dtxl->depth, GPU_SAMPLER_DEFAULT);
+    DRW_shgroup_call(grp, quad, NULL);
+  }
+}
+
+void EEVEE_abler_prepass_cache_finish(EEVEE_Data *vedata)
+{
+  // Do nothing now, leaved for future use
+}
+
+void EEVEE_abler_prepass_draw(EEVEE_Data *vedata)
+{
+  EEVEE_PassList *psl = vedata->psl;
+  EEVEE_FramebufferList *fbl = vedata->fbl;
+
+  DRW_stats_group_start("Abler copy depth pass");
+
+  GPU_framebuffer_bind(fbl->abler_copy_depth_fb);
+  DRW_draw_pass(psl->abler_copy_depth_pass);
+
+  DRW_stats_group_end();
+
+  // Restore
+  GPU_framebuffer_bind(fbl->main_fb);
+}
+
+void EEVEE_abler_prepass_free()
+{
+  // Do nothing now, leaved for future use
+}

--- a/source/blender/draw/engines/eevee/eevee_abler.h
+++ b/source/blender/draw/engines/eevee/eevee_abler.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "eevee_private.h"
+
+void EEVEE_abler_prepass_init(EEVEE_ViewLayerData *sldata, EEVEE_Data *vedata);
+
+void EEVEE_abler_prepass_cache_init(EEVEE_ViewLayerData *sldata, EEVEE_Data *vedata);
+
+void EEVEE_abler_prepass_cache_finish(EEVEE_Data *vedata);
+
+void EEVEE_abler_prepass_draw(EEVEE_Data *vedata);
+
+void EEVEE_abler_prepass_free(void);

--- a/source/blender/draw/engines/eevee/eevee_engine.c
+++ b/source/blender/draw/engines/eevee/eevee_engine.c
@@ -38,6 +38,8 @@
 
 #include "eevee_engine.h" /* own include */
 
+#include "eevee_abler.h"
+
 #define EEVEE_ENGINE "BLENDER_EEVEE"
 
 /* *********** FUNCTIONS *********** */
@@ -89,6 +91,7 @@ static void eevee_engine_init(void *ved)
   EEVEE_materials_init(sldata, vedata, stl, fbl);
   EEVEE_shadows_init(sldata);
   EEVEE_lightprobes_init(sldata, vedata);
+  EEVEE_abler_prepass_init(sldata, vedata);
 }
 
 static void eevee_cache_init(void *vedata)
@@ -107,6 +110,7 @@ static void eevee_cache_init(void *vedata)
   EEVEE_subsurface_cache_init(sldata, vedata);
   EEVEE_temporal_sampling_cache_init(sldata, vedata);
   EEVEE_volumes_cache_init(sldata, vedata);
+  EEVEE_abler_prepass_cache_init(sldata, vedata);
 }
 
 void EEVEE_cache_populate(void *vedata, Object *ob)
@@ -165,6 +169,7 @@ static void eevee_cache_finish(void *vedata)
   EEVEE_lights_cache_finish(sldata, vedata);
   EEVEE_lightprobes_cache_finish(sldata, vedata);
   EEVEE_renderpasses_cache_finish(sldata, vedata);
+  EEVEE_abler_prepass_cache_finish(vedata);
 
   EEVEE_subsurface_draw_init(sldata, vedata);
   EEVEE_effects_draw_init(sldata, vedata);
@@ -280,6 +285,9 @@ static void eevee_draw_scene(void *vedata)
     DRW_stats_group_start("Prepass");
     DRW_draw_pass(psl->depth_ps);
     DRW_stats_group_end();
+
+    /* ABLER specific */
+    EEVEE_abler_prepass_draw(vedata);
 
     /* Create minmax texture */
     DRW_stats_group_start("Main MinMax buffer");
@@ -548,6 +556,7 @@ static void eevee_render_to_image(void *vedata,
       EEVEE_lights_cache_finish(sldata, vedata);
       EEVEE_lightprobes_cache_finish(sldata, vedata);
       EEVEE_renderpasses_cache_finish(sldata, vedata);
+      EEVEE_abler_prepass_cache_finish(vedata);
 
       EEVEE_subsurface_draw_init(sldata, vedata);
       EEVEE_effects_draw_init(sldata, vedata);
@@ -613,6 +622,7 @@ static void eevee_store_metadata(void *vedata, struct RenderResult *render_resul
 
 static void eevee_engine_free(void)
 {
+  EEVEE_abler_prepass_free();
   EEVEE_shaders_free();
   EEVEE_lightprobes_free();
   EEVEE_materials_free();

--- a/source/blender/draw/engines/eevee/eevee_materials.c
+++ b/source/blender/draw/engines/eevee/eevee_materials.c
@@ -106,6 +106,7 @@ void EEVEE_material_bind_resources(DRWShadingGroup *shgrp,
 
   DRW_shgroup_uniform_int_copy(shgrp, "outputSssId", 1);
   DRW_shgroup_uniform_texture(shgrp, "utilTex", e_data.util_tex);
+  DRW_shgroup_uniform_texture_ref(shgrp, "ablerDepthBuffer", &vedata->txl->abler_depth_buffer);
   if (use_diffuse || use_glossy || use_refract) {
     DRW_shgroup_uniform_texture_ref(shgrp, "shadowCubeTexture", &sldata->shadow_cube_pool);
     DRW_shgroup_uniform_texture_ref(shgrp, "shadowCascadeTexture", &sldata->shadow_cascade_pool);

--- a/source/blender/draw/engines/eevee/eevee_private.h
+++ b/source/blender/draw/engines/eevee/eevee_private.h
@@ -248,6 +248,9 @@ typedef struct EEVEE_BoundBox {
 } EEVEE_BoundBox;
 
 typedef struct EEVEE_PassList {
+  /* ABLER specific */
+  struct DRWPass *abler_copy_depth_pass;
+
   /* Shadows */
   struct DRWPass *shadow_pass;
   struct DRWPass *shadow_accum_pass;
@@ -344,6 +347,9 @@ typedef struct EEVEE_PassList {
 } EEVEE_PassList;
 
 typedef struct EEVEE_FramebufferList {
+  /* ABLER specific */
+  struct GPUFrameBuffer *abler_copy_depth_fb;
+
   /* Effects */
   struct GPUFrameBuffer *gtao_fb;
   struct GPUFrameBuffer *gtao_debug_fb;
@@ -407,6 +413,9 @@ typedef struct EEVEE_FramebufferList {
 } EEVEE_FramebufferList;
 
 typedef struct EEVEE_TextureList {
+  /* ABLER specific */
+  struct GPUTexture *abler_depth_buffer;
+
   /* Effects */
   struct GPUTexture *color_post; /* R16_G16_B16 */
   struct GPUTexture *mist_accum;
@@ -1232,6 +1241,7 @@ struct GPUShader *EEVEE_shaders_probe_cube_display_sh_get(void);
 struct GPUShader *EEVEE_shaders_probe_grid_display_sh_get(void);
 struct GPUShader *EEVEE_shaders_probe_planar_display_sh_get(void);
 struct GPUShader *EEVEE_shaders_update_noise_sh_get(void);
+struct GPUShader *EEVEE_shaders_abler_copy_depth_pass_sh_get(void);
 struct GPUShader *EEVEE_shaders_velocity_resolve_sh_get(void);
 struct GPUShader *EEVEE_shaders_taa_resolve_sh_get(EEVEE_EffectsFlag enabled_effects);
 struct bNodeTree *EEVEE_shader_default_surface_nodetree(Material *ma);

--- a/source/blender/draw/engines/eevee/eevee_render.c
+++ b/source/blender/draw/engines/eevee/eevee_render.c
@@ -44,6 +44,7 @@
 
 #include "RE_pipeline.h"
 
+#include "eevee_abler.h"
 #include "eevee_private.h"
 
 /* Return true if init properly. */
@@ -151,6 +152,7 @@ void EEVEE_render_modules_init(EEVEE_Data *vedata,
   EEVEE_materials_init(sldata, vedata, stl, fbl);
   EEVEE_shadows_init(sldata);
   EEVEE_lightprobes_init(sldata, vedata);
+  EEVEE_abler_prepass_init(sldata, vedata);
 }
 
 void EEVEE_render_view_sync(EEVEE_Data *vedata, RenderEngine *engine, struct Depsgraph *depsgraph)
@@ -192,6 +194,7 @@ void EEVEE_render_cache_init(EEVEE_ViewLayerData *sldata, EEVEE_Data *vedata)
   EEVEE_temporal_sampling_cache_init(sldata, vedata);
   EEVEE_volumes_cache_init(sldata, vedata);
   EEVEE_cryptomatte_cache_init(sldata, vedata);
+  EEVEE_abler_prepass_cache_init(sldata, vedata);
 }
 
 /* Used by light cache. in this case engine is NULL. */
@@ -628,6 +631,10 @@ void EEVEE_render_draw(EEVEE_Data *vedata, RenderEngine *engine, RenderLayer *rl
     GPU_framebuffer_clear_color_depth_stencil(fbl->main_fb, clear_col, clear_depth, clear_stencil);
     /* Depth prepass */
     DRW_draw_pass(psl->depth_ps);
+
+    /* ABLER specific */
+    EEVEE_abler_prepass_draw(vedata);
+
     /* Create minmax texture */
     EEVEE_create_minmax_buffer(vedata, dtxl->depth, -1);
     EEVEE_occlusion_compute(sldata, vedata);

--- a/source/blender/draw/engines/eevee/eevee_renderpasses.c
+++ b/source/blender/draw/engines/eevee/eevee_renderpasses.c
@@ -519,6 +519,10 @@ void EEVEE_renderpasses_draw_debug(EEVEE_Data *vedata)
     case 11:
       tx = effects->velocity_tx;
       break;
+    // Abler specific
+    case 99:
+      tx = txl->abler_depth_buffer;
+      break;
     default:
       break;
   }

--- a/source/blender/draw/engines/eevee/eevee_shaders.c
+++ b/source/blender/draw/engines/eevee/eevee_shaders.c
@@ -49,6 +49,9 @@ static const char *filter_defines =
 #endif
 
 static struct {
+  /* ABLER specific */
+  struct GPUShader *abler_copy_depth_pass_sh;
+
   /* Lookdev */
   struct GPUShader *studiolight_probe_sh;
   struct GPUShader *studiolight_background_sh;
@@ -186,6 +189,7 @@ extern char datatoc_common_math_geom_lib_glsl[];
 extern char datatoc_common_view_lib_glsl[];
 extern char datatoc_gpu_shader_common_obinfos_lib_glsl[];
 
+extern char datatoc_abler_copy_depth_pass_frag_glsl[];
 extern char datatoc_ambient_occlusion_lib_glsl[];
 extern char datatoc_background_vert_glsl[];
 extern char datatoc_bsdf_common_lib_glsl[];
@@ -935,6 +939,18 @@ GPUShader *EEVEE_shaders_update_noise_sh_get(void)
   return e_data.update_noise_sh;
 }
 
+GPUShader *EEVEE_shaders_abler_copy_depth_pass_sh_get(void)
+{
+  // Adapted from EEVEE_shaders_effect_maxz_copydepth_sh_get
+  if (e_data.abler_copy_depth_pass_sh == NULL) {
+    e_data.abler_copy_depth_pass_sh = DRW_shader_create_fullscreen(
+        datatoc_abler_copy_depth_pass_frag_glsl,
+        "#define MAX_PASS\n"
+        "#define COPY_DEPTH\n");
+  }
+  return e_data.abler_copy_depth_pass_sh;
+}
+
 GPUShader *EEVEE_shaders_taa_resolve_sh_get(EEVEE_EffectsFlag enabled_effects)
 {
   GPUShader **sh;
@@ -1651,4 +1667,7 @@ void EEVEE_shaders_free(void)
     MEM_freeN(e_data.world.ntree);
     e_data.world.ntree = NULL;
   }
+
+  /* Abler specific */
+  DRW_SHADER_FREE_SAFE(e_data.abler_copy_depth_pass_sh);
 }

--- a/source/blender/draw/engines/eevee/shaders/abler_copy_depth_pass_frag.glsl
+++ b/source/blender/draw/engines/eevee/shaders/abler_copy_depth_pass_frag.glsl
@@ -1,0 +1,71 @@
+/**
+ * Copied from effect_minmaxz_frag.glsl
+ */
+
+#ifdef LAYERED
+uniform sampler2DArray depthBuffer;
+uniform int depthLayer;
+#else
+uniform sampler2D depthBuffer;
+#endif
+
+#ifndef COPY_DEPTH
+uniform vec2 texelSize;
+#endif
+
+#ifdef LAYERED
+#  define sampleLowerMip(t) texture(depthBuffer, vec3(t, depthLayer)).r
+#  define gatherLowerMip(t) textureGather(depthBuffer, vec3(t, depthLayer))
+#else
+#  define sampleLowerMip(t) texture(depthBuffer, t).r
+#  define gatherLowerMip(t) textureGather(depthBuffer, t)
+#endif
+
+#ifdef MIN_PASS
+#  define minmax2(a, b) min(a, b)
+#  define minmax3(a, b, c) min(min(a, b), c)
+#  define minmax4(a, b, c, d) min(min(min(a, b), c), d)
+#else /* MAX_PASS */
+#  define minmax2(a, b) max(a, b)
+#  define minmax3(a, b, c) max(max(a, b), c)
+#  define minmax4(a, b, c, d) max(max(max(a, b), c), d)
+#endif
+
+/* On some AMD card / driver combination, it is needed otherwise,
+ * the shader does not write anything. */
+#if defined(GPU_INTEL) || defined(GPU_ATI)
+out vec4 fragColor;
+#endif
+
+void main()
+{
+  vec2 texel = gl_FragCoord.xy;
+
+#ifdef COPY_DEPTH
+  vec2 uv = texel / vec2(textureSize(depthBuffer, 0).xy);
+
+  float val = sampleLowerMip(uv);
+#else
+  /* NOTE(@fclem): textureSize() does not work the same on all implementations
+   * when changing the min and max texture levels. Use uniform instead (see T87801). */
+  vec2 uv = texel * 2.0 * texelSize;
+
+  vec4 samp;
+#  ifdef GPU_ARB_texture_gather
+  samp = gatherLowerMip(uv);
+#  else
+  samp.x = sampleLowerMip(uv + vec2(-0.5, -0.5) * texelSize);
+  samp.y = sampleLowerMip(uv + vec2(-0.5, 0.5) * texelSize);
+  samp.z = sampleLowerMip(uv + vec2(0.5, -0.5) * texelSize);
+  samp.w = sampleLowerMip(uv + vec2(0.5, 0.5) * texelSize);
+#  endif
+
+  float val = minmax4(samp.x, samp.y, samp.z, samp.w);
+#endif
+
+#if defined(GPU_INTEL) || defined(GPU_ATI)
+  /* Use color format instead of 24bit depth texture */
+  fragColor = vec4(val);
+#endif
+  gl_FragDepth = val;
+}

--- a/source/blender/gpu/shaders/material/gpu_shader_material_outline.glsl
+++ b/source/blender/gpu/shaders/material/gpu_shader_material_outline.glsl
@@ -1,3 +1,5 @@
+uniform sampler2D ablerDepthBuffer;
+
 void node_outline(vec3 normal,
                   float width,
                   out float depth,
@@ -12,8 +14,10 @@ void node_outline(vec3 normal,
   negative_depth_hit_position = vec3(0, 0, 0);
 
   ivec2 texel = ivec2(gl_FragCoord.xy);
-  float texel_depth = texelFetch(maxzBuffer, texel, 0).r;
+  float texel_depth = texelFetch(ablerDepthBuffer, texel, 0).r;
   float texel_z = get_view_z_from_depth(texel_depth);
+  vec2 texel_uv = vec2(texel) / textureSize(ablerDepthBuffer, 0).xy;
+  vec3 texel_vs = get_view_space_from_depth(texel_uv, texel_depth);
 
   //ivec2 offsets[4] = ivec2[4](ivec2(-1, -1), ivec2(-1, 1), ivec2(1, -1), ivec2(1, 1));
   ivec2 offsets[4] = ivec2[4](ivec2(-1, 0), ivec2(1, 0), ivec2(0, -1), ivec2(0, 1));
@@ -49,15 +53,11 @@ void node_outline(vec3 normal,
     ivec2 sample_offset = offsets[i] * int(round(width));
 
     ivec2 offset = texel + sample_offset;
-    float offset_depth = texelFetch(maxzBuffer, offset, 0).r;
+    float offset_depth = texelFetch(ablerDepthBuffer, offset, 0).r;
     float offset_z = get_view_z_from_depth(offset_depth);
-
-    vec2 offset_uv = vec2(offset) / textureSize(maxzBuffer, 0).xy;
+    vec2 offset_uv = vec2(offset) / textureSize(ablerDepthBuffer, 0).xy;
     vec3 offset_vs = get_view_space_from_depth(offset_uv, texel_depth);
     vec3 actual_offset_vs = get_view_space_from_depth(offset_uv, offset_depth);
-
-    vec2 texel_uv = vec2(texel) / textureSize(maxzBuffer, 0).xy;
-    vec3 texel_vs = get_view_space_from_depth(texel_uv, texel_depth);
 
     width_ws_size = length(offset_vs - texel_vs);
 


### PR DESCRIPTION
# 작업 목적

- 싱크홀 현상은 기존의 아웃라인 셰이더에서 사용되던 depth buffer(maxzbuffer)의 해상도가 낮아서 생긴 문제로 추정되어, 이를 수정했습니다.

# 작업 내용

- 해상도 그대로 depth buffer 를 복사하는 abler prepass 추가
- outline GLSL 코드에서 해당 depth buffer 를 사용

# [이전에 올렸던 PR](https://github.com/ACON3D/blender/pull/32) #32 과의 차이점

- 이전에 올렸던 PR 에서 작업했던 방식은 "블렌더 머티리얼의 셰이더 노드를 통과하지 않고" 자체적으로 작성한 셰이더를 통해 depth, normal, object 정보를 그렸습니다.
- 하지만 위 방식에는, "블렌더 머티리얼의 셰이더 노드에서 투명 처리된" 부분을 인식할 수 없다는 한계가 있었고, 이에 따라 투명 재질과 투명 텍스처에서 아웃라인이 잘못 그려지는 문제가 있었습니다.
- 위 문제에 대한 해결책으로, "이미 블렌더 머티리얼을 고려해서 그려진" 내장 depth buffer 를 그대로 복사해서 (즉, 해상도를 유지해서) 아웃라인 셰이더에서 사용하도록 바꾸어서 문제를 해결했습니다.
- 그렇다고 해서 #32 의 내용이 모두 쓸모없어진 것은 아니고,  normal, object ID 관련된 내용은 투명재질을 고려하는 방식으로 추후 살려볼 수 있을 것 같습니다.

# 한계

- 싱크홀 현상이 "완전히" 사라진 것은 아닙니다. 창 크기를 극단적으로 줄였을 때에는 여전히 약간의 검은색 artifact 가 보입니다. 
- (하지만 실사용 시 이렇게까지 작게 렌더링하는 경우는 거의 없으므로 대부분의 경우에 싱크홀 현상을 잡을 수 있을 것으로 보입니다.)