### PR TITLE
업데이트 완료 후 config.ini 버전 정보 업데이트

### DIFF
--- a/launcher_abler/AblerLauncher.py
+++ b/launcher_abler/AblerLauncher.py
@@ -155,14 +155,16 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
             state_ui, finallist = UpdateLauncher.check_launcher(
                 dir_, self.launcher_installed
             )
-            self.entry = finallist[0]
+            if finallist:
+                self.entry = finallist[0]
             self.parse_launcher_state(state_ui)
 
             if not state_ui:
                 state_ui, finallist = UpdateAbler.check_abler(
                     dir_, self.installedversion
                 )
-                self.entry = finallist[0]
+                if finallist:
+                    self.entry = finallist[0]
                 self.parse_abler_state(state_ui)
 
         except Exception as e:

--- a/launcher_abler/AblerLauncher.py
+++ b/launcher_abler/AblerLauncher.py
@@ -141,6 +141,7 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
         self.installedversion = ""
         self.launcher_installed = ""
         self.lastcheck = ""
+        self.entry = {}
         global dir_
         global launcherdir_
 
@@ -154,21 +155,20 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
             state_ui, finallist = UpdateLauncher.check_launcher(
                 dir_, self.launcher_installed
             )
-            self.parse_launcher_state(state_ui, finallist)
+            self.entry = finallist[0]
+            self.parse_launcher_state(state_ui)
 
             if not state_ui:
                 state_ui, finallist = UpdateAbler.check_abler(
                     dir_, self.installedversion
                 )
-                self.parse_abler_state(state_ui, finallist)
-
-            # config.ini 업데이트 위해서 새로 할당
-            self.entry = finallist[0]
+                self.entry = finallist[0]
+                self.parse_abler_state(state_ui)
 
         except Exception as e:
             logger.error(e)
 
-    def parse_launcher_state(self, state_ui, finallist):
+    def parse_launcher_state(self, state_ui):
         if state_ui == StateUI.error:
             self.statusBar().showMessage(
                 "Error reaching server - check your internet connection"
@@ -185,11 +185,11 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
             # self.setup_execute_ui()
 
         elif state_ui == StateUI.update_launcher:
-            self.setup_update_launcher_ui(finallist)
+            self.setup_update_launcher_ui()
         else:
             return
 
-    def parse_abler_state(self, state_ui, finallist):
+    def parse_abler_state(self, state_ui):
         if state_ui == StateUI.error:
             self.statusBar().showMessage(
                 "Error reaching server - check your internet connection"
@@ -201,7 +201,7 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
             self.setup_execute_ui()
 
         elif state_ui == StateUI.update_abler:
-            self.setup_update_abler_ui(finallist)
+            self.setup_update_abler_ui()
 
         elif state_ui == StateUI.execute:
             self.setup_execute_ui()
@@ -267,23 +267,23 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
         self.btn_about.clicked.connect(self.about)
         self.btn_acon.clicked.connect(self.open_acon3d)
 
-    def setup_update_launcher_ui(self, finallist):
+    def setup_update_launcher_ui(self):
         self.btn_update_launcher.show()
         self.btn_update.hide()
         self.btn_execute.hide()
         self.btn_update_launcher.clicked.connect(
-            lambda throwaway=0, entry=finallist[0]: self.download(
+            lambda throwaway=0, entry=self.entry: self.download(
                 entry, dir_name=launcherdir_
             )
         )
 
-    def setup_update_abler_ui(self, finallist):
+    def setup_update_abler_ui(self):
         # ABLER를 업데이트
         self.btn_update_launcher.hide()
         self.btn_update.show()
         self.btn_execute.hide()
         self.btn_update.clicked.connect(
-            lambda throwaway=0, entry=finallist[0]: self.download(entry, dir_name=dir_)
+            lambda throwaway=0, entry=self.entry: self.download(entry, dir_name=dir_)
         )
 
     def setup_execute_ui(self):


### PR DESCRIPTION
## 문제

- 에이블러 런처로 실행시에 업데이트 도중 Quit 혹은 프로그램을 종료하게 되면 업데이트가 취소되고 원래 버전 정보가 있어야함
- 그런데, 업데이트 버튼을 누르면 곧바로 `config.ini`가 새 버전으로 업데이트 되어 런처를 재실행하면 업데이트를 정상적으로 할 수 없는 문제가 있음
- 관련 문서 : [노션](https://www.notion.so/acon3d/a6447b8789de488aadeee1177cffc4ac)


## 해결 방안

- `config.set` 코드를 `Tread`가 끝나는 시점에 실행해야함
- `done_abler`, `done_launcher` 함수 내로 옮기면 해결


## 수정 사항

- `configparser.ConfigParser()` 가 런처와 에이블러에서 중복 정의되기 때문에 하나의 함수 `def update_config`로 간소화
- `AblerLauncher.py` 내부에서 `finallist[0]` 만 `entry`로 사용되기 때문에 `self.entry`로 정의하고 변수 대체