### PR TITLE
런처에 릴리즈 관련 argument 추가

### DIFF
--- a/launcher_abler/AblerLauncher.py
+++ b/launcher_abler/AblerLauncher.py
@@ -138,7 +138,7 @@ class WorkerThread(QtCore.QThread):
 
 class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
     def __init__(self, parent=None):
-        print("\n-> BlenderUpdater 실행 확인")
+        print("\n-> BlenderUpdater 실행")
 
         logger.info(f"Running version {appversion}")
         logger.debug("Constructing UI")

--- a/launcher_abler/AblerLauncher.py
+++ b/launcher_abler/AblerLauncher.py
@@ -31,7 +31,6 @@ import urllib.request
 import time
 from distutils.dir_util import copy_tree
 from AblerLauncherUtils import *
-from typing import Tuple, Optional
 from enum import Enum
 
 
@@ -137,7 +136,7 @@ class WorkerThread(QtCore.QThread):
 
 
 class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
-    def __init__(self, parent=None):
+    def __init__(self, parent=None) -> None:
         print("\n-> BlenderUpdater 실행")
 
         logger.info(f"Running version {appversion}")

--- a/launcher_abler/AblerLauncher.py
+++ b/launcher_abler/AblerLauncher.py
@@ -166,11 +166,12 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
                 self.entry = finallist[0]
             self.parse_launcher_state(state_ui)
 
-            # release가 없으면, ABLER 업데이트 확인 불필요
-            if state_ui == StateUI.no_release:
-                self.frm_start.show()
-                self.setup_execute_ui()
-                return
+            # release가 없는 빈 repo일 때, Launcher에서 확인되면
+            # ABLER 업데이트 확인 불필요
+            # if state_ui == StateUI.no_release:
+            #     self.frm_start.show()
+            #     self.setup_execute_ui()
+            #     return
 
             if not state_ui:
                 state_ui, finallist = UpdateAbler.check_abler(
@@ -192,6 +193,15 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
             )
             self.frm_start.show()
 
+        elif state_ui == StateUI.no_release:
+            # TODO: 빈 테스트 repo를 테스트할 때, self.setup_execute_ui()로
+            #       실행되는지 확인하기
+            self.frm_start.show()
+            self.btn_execute.show()
+            self.btn_update_launcher.hide()
+            self.btn_update.hide()
+            # self.setup_execute_ui()
+
         elif state_ui == StateUI.update_launcher:
             self.setup_update_launcher_ui()
 
@@ -207,6 +217,10 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
                 "Error reaching server - check your internet connection"
             )
             self.frm_start.show()
+
+        elif state_ui == StateUI.no_release:
+            self.frm_start.show()
+            self.setup_execute_ui()
 
         elif state_ui == StateUI.update_abler:
             self.setup_update_abler_ui()

--- a/launcher_abler/AblerLauncher.py
+++ b/launcher_abler/AblerLauncher.py
@@ -137,8 +137,6 @@ class WorkerThread(QtCore.QThread):
 
 class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
     def __init__(self, parent=None) -> None:
-        print("\n-> BlenderUpdater 실행")
-
         logger.info(f"Running version {appversion}")
         logger.debug("Constructing UI")
         super(BlenderUpdater, self).__init__(parent)

--- a/launcher_abler/AblerLauncherUtils.py
+++ b/launcher_abler/AblerLauncherUtils.py
@@ -10,13 +10,14 @@ if len(sys.argv) > 1:
     new_pre_rel = sys.argv[1] == "--new-repo-pre-release"
 
     print("\n-> AblerLauncherUtils.py")
-    print(f"--pre-release          : {pre_rel}")
-    print(f"--new-repo-release     : {new_rel}")
-    print(f"--new-repo-pre-release : {new_pre_rel}")
+    print(f"--pre-release          : {'O' if pre_rel else 'X'}")
+    print(f"--new-repo-release     : {'O' if new_rel else 'X'}")
+    print(f"--new-repo-pre-release : {'O' if new_pre_rel else 'X'}")
     print("\n")
 
 
 def set_url() -> str:
+    """GitHub Repo의 URL 세팅"""
     url = "https://api.github.com/repos/ACON3D/blender/releases/latest"
 
     if pre_rel:

--- a/launcher_abler/AblerLauncherUtils.py
+++ b/launcher_abler/AblerLauncherUtils.py
@@ -9,10 +9,10 @@ if len(sys.argv) > 1:
     new_rel = sys.argv[1] == "--new-repo-release"
     new_pre_rel = sys.argv[1] == "--new-repo-pre-release"
 
-    print("\n-> AblerLauncherUtils.py")
-    print(f"--pre-release          : {'O' if pre_rel else 'X'}")
-    print(f"--new-repo-release     : {'O' if new_rel else 'X'}")
-    print(f"--new-repo-pre-release : {'O' if new_pre_rel else 'X'}")
+    print("\n> release test argv 확인")
+    print(f"> --pre-release          : {'O' if pre_rel else 'X'}")
+    print(f"> --new-repo-release     : {'O' if new_rel else 'X'}")
+    print(f"> --new-repo-pre-release : {'O' if new_pre_rel else 'X'}")
     print("\n")
 
 

--- a/launcher_abler/AblerLauncherUtils.py
+++ b/launcher_abler/AblerLauncherUtils.py
@@ -3,6 +3,10 @@ import sys
 from enum import Enum, auto
 
 
+repo = len(sys.argv) > 1 and sys.argv[1] == "--repo"
+repo_pre = len(sys.argv) > 1 and sys.argv[1] == "--repo-pre"
+
+
 def get_datadir() -> pathlib.Path:
     """
     Returns a parent directory path

--- a/launcher_abler/AblerLauncherUtils.py
+++ b/launcher_abler/AblerLauncherUtils.py
@@ -13,6 +13,22 @@ if len(sys.argv) > 1:
     print(f"--pre-release          : {pre_rel}")
     print(f"--new-repo-release     : {new_rel}")
     print(f"--new-repo-pre-release : {new_pre_rel}")
+    print("\n")
+
+
+def set_url() -> str:
+    url = "https://api.github.com/repos/ACON3D/blender/releases/latest"
+
+    if pre_rel:
+        url = "https://api.github.com/repos/ACON3D/blender/releases"
+    elif new_rel:
+        url = "https://api.github.com/repos/ACON3D/launcherTestRepo/releases/latest"
+    elif new_pre_rel:
+        # 새 repo가 완전히 비어있을 때는 req에 정보가 없기 때문에 url 정보를 받을 수 없음
+        # 따라서 pre-release 생성했을 때만 테스트
+        url = "https://api.github.com/repos/ACON3D/launcherTestRepo/releases"
+
+    return url
 
 
 def get_datadir() -> pathlib.Path:

--- a/launcher_abler/AblerLauncherUtils.py
+++ b/launcher_abler/AblerLauncherUtils.py
@@ -3,8 +3,16 @@ import sys
 from enum import Enum, auto
 
 
-repo = len(sys.argv) > 1 and sys.argv[1] == "--repo"
-repo_pre = len(sys.argv) > 1 and sys.argv[1] == "--repo-pre"
+# 테스트용 argument 추가
+if len(sys.argv) > 1:
+    pre_rel = sys.argv[1] == "--pre-release"
+    new_rel = sys.argv[1] == "--new-repo-release"
+    new_pre_rel = sys.argv[1] == "--new-repo-pre-release"
+
+    print("\n-> AblerLauncherUtils.py")
+    print(f"--pre-release          : {pre_rel}")
+    print(f"--new-repo-release     : {new_rel}")
+    print(f"--new-repo-pre-release : {new_pre_rel}")
 
 
 def get_datadir() -> pathlib.Path:

--- a/launcher_abler/UpdateAbler.py
+++ b/launcher_abler/UpdateAbler.py
@@ -45,13 +45,7 @@ def check_abler(dir_: str, installedversion: str) -> Tuple[Enum, Optional[list]]
     print("    # url settings")
 
     # TODO: 새 arg 받아서 테스트 레포 url 업데이트
-    url = "https://api.github.com/repos/acon3d/blender/releases/latest"
-    if pre_rel:
-        url = "https://api.github.com/repos/acon3d/blender/releases"
-    if new_rel:
-        url = "https://api.github.com/repos/ACON3D/launcherTestRepo/releases/latest"
-    if new_pre_rel:
-        url = "https://api.github.com/repos/ACON3D/launcherTestRepo/releases/"
+    url = set_url()
 
     print(f"    # url : {url}")
 

--- a/launcher_abler/UpdateAbler.py
+++ b/launcher_abler/UpdateAbler.py
@@ -1,11 +1,9 @@
-import pathlib
 import requests
 import logging
 import os
 import os.path
 import sys
 from typing import Tuple, Optional
-from enum import Enum
 from distutils.version import StrictVersion
 import configparser
 from AblerLauncherUtils import *

--- a/launcher_abler/UpdateAbler.py
+++ b/launcher_abler/UpdateAbler.py
@@ -9,6 +9,7 @@ from enum import Enum
 from distutils.version import StrictVersion
 import configparser
 from AblerLauncherUtils import get_datadir, StateUI
+from AblerLauncherUtils import repo, repo_pre
 
 
 if sys.platform == "win32":
@@ -31,6 +32,9 @@ logging.basicConfig(
 
 logger = logging.getLogger()
 
+print("\n")
+print("UpdateAbler.py 들어갔는지 확인")
+
 
 def check_abler(dir_: str, installedversion: str) -> Tuple[Enum, Optional[list]]:
     """최신 릴리즈가 있는지 URL 주소로 확인"""
@@ -41,6 +45,10 @@ def check_abler(dir_: str, installedversion: str) -> Tuple[Enum, Optional[list]]
     url = "https://api.github.com/repos/acon3d/blender/releases/latest"
     if test_arg:
         url = "https://api.github.com/repos/acon3d/blender/releases"
+    if repo:
+        print("repo url 받아오는지 확인")
+        url = "https://api.github.com/repos/ACON3D/launcherTestRepo/releases/latest"
+        print(f"url : {url}")
     # TODO: 새 arg 받아서 테스트 레포 url 업데이트
 
     is_release, req, state_ui = get_req_from_url(url, state_ui, dir_)

--- a/launcher_abler/UpdateAbler.py
+++ b/launcher_abler/UpdateAbler.py
@@ -65,6 +65,7 @@ def check_abler(dir_: str, installedversion: str) -> Tuple[Enum, Optional[list]]
 
         # ABLER 릴리즈 버전 > 설치 버전
         if StrictVersion(results[0]["version"]) > StrictVersion(installedversion):
+            print(f"    # New ABLER Ver. : {results[0]['version']}")
             state_ui = StateUI.update_abler
             finallist = results
             return state_ui, finallist

--- a/launcher_abler/UpdateAbler.py
+++ b/launcher_abler/UpdateAbler.py
@@ -8,8 +8,7 @@ from typing import Tuple, Optional
 from enum import Enum
 from distutils.version import StrictVersion
 import configparser
-from AblerLauncherUtils import get_datadir, StateUI
-from AblerLauncherUtils import repo, repo_pre
+from AblerLauncherUtils import *
 
 
 if sys.platform == "win32":
@@ -20,7 +19,6 @@ os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"
 LOG_FORMAT = (
     "%(asctime)s,%(msecs)d %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s"
 )
-test_arg = len(sys.argv) > 1 and sys.argv[1] == "--test"
 os.makedirs(get_datadir() / "Blender/2.96", exist_ok=True)
 os.makedirs(get_datadir() / "Blender/2.96/updater", exist_ok=True)
 logging.basicConfig(
@@ -32,9 +30,6 @@ logging.basicConfig(
 
 logger = logging.getLogger()
 
-print("\n")
-print("UpdateAbler.py 들어갔는지 확인")
-
 
 def check_abler(dir_: str, installedversion: str) -> Tuple[Enum, Optional[list]]:
     """최신 릴리즈가 있는지 URL 주소로 확인"""
@@ -42,14 +37,23 @@ def check_abler(dir_: str, installedversion: str) -> Tuple[Enum, Optional[list]]
     finallist = None
     results = []
     state_ui = None
-    url = "https://api.github.com/repos/acon3d/blender/releases/latest"
-    if test_arg:
-        url = "https://api.github.com/repos/acon3d/blender/releases"
-    if repo:
-        print("repo url 받아오는지 확인")
-        url = "https://api.github.com/repos/ACON3D/launcherTestRepo/releases/latest"
-        print(f"url : {url}")
+
+    # URL settings
+    # Pre-Release 테스트 시에는 req = req[0]으로 pre-release 데이터 받아오기
+    print("\n-> UpdateAbler.py")
+    print("def check_abler():")
+    print("    # url settings")
+
     # TODO: 새 arg 받아서 테스트 레포 url 업데이트
+    url = "https://api.github.com/repos/acon3d/blender/releases/latest"
+    if pre_rel:
+        url = "https://api.github.com/repos/acon3d/blender/releases"
+    if new_rel:
+        url = "https://api.github.com/repos/ACON3D/launcherTestRepo/releases/latest"
+    if new_pre_rel:
+        url = "https://api.github.com/repos/ACON3D/launcherTestRepo/releases/"
+
+    print(f"    # url : {url}")
 
     is_release, req, state_ui = get_req_from_url(url, state_ui, dir_)
     if state_ui:
@@ -105,7 +109,8 @@ def get_req_from_url(
         logger.error(e)
         state_ui = StateUI.error
 
-    if test_arg:
+    # Pre-Release에서는 req[0]이 pre-release 정보를 가지고 있음
+    if pre_rel or new_pre_rel:
         req = req[0]
 
     is_release = True

--- a/launcher_abler/UpdateAbler.py
+++ b/launcher_abler/UpdateAbler.py
@@ -38,14 +38,8 @@ def check_abler(dir_: str, installedversion: str) -> Tuple[Enum, Optional[list]]
 
     # URL settings
     # Pre-Release 테스트 시에는 req = req[0]으로 pre-release 데이터 받아오기
-    print("\n-> UpdateAbler.py")
-    print("def check_abler():")
-    print("    # url settings")
-
-    # TODO: 새 arg 받아서 테스트 레포 url 업데이트
     url = set_url()
-
-    print(f"    # url : {url}")
+    print(f"> url : {url}")
 
     is_release, req, state_ui = get_req_from_url(url, state_ui, dir_)
     if state_ui:
@@ -63,7 +57,7 @@ def check_abler(dir_: str, installedversion: str) -> Tuple[Enum, Optional[list]]
 
         # ABLER 릴리즈 버전 > 설치 버전
         if StrictVersion(results[0]["version"]) > StrictVersion(installedversion):
-            print(f"    # New ABLER Ver. : {results[0]['version']}")
+            print(f"> New ABLER Ver. : {results[0]['version']}")
             state_ui = StateUI.update_abler
             finallist = results
             return state_ui, finallist

--- a/launcher_abler/UpdateLauncher.py
+++ b/launcher_abler/UpdateLauncher.py
@@ -1,11 +1,9 @@
-import pathlib
 import requests
 import logging
 import os
 import os.path
 import sys
 from typing import Tuple, Optional
-from enum import Enum
 from distutils.version import StrictVersion
 import configparser
 from AblerLauncherUtils import *

--- a/launcher_abler/UpdateLauncher.py
+++ b/launcher_abler/UpdateLauncher.py
@@ -9,6 +9,8 @@ from enum import Enum
 from distutils.version import StrictVersion
 import configparser
 from AblerLauncherUtils import get_datadir, StateUI
+from AblerLauncherUtils import repo, repo_pre
+
 
 if sys.platform == "win32":
     from win32com.client import Dispatch
@@ -30,6 +32,8 @@ logging.basicConfig(
 
 logger = logging.getLogger()
 
+print("UpdateLauncher.py 들어갔는지나 확인")
+
 
 def check_launcher(dir_: str, launcher_installed: str) -> Tuple[Enum, Optional[list]]:
     """최신 릴리즈가 있는지 URL 주소로 확인"""
@@ -40,16 +44,28 @@ def check_launcher(dir_: str, launcher_installed: str) -> Tuple[Enum, Optional[l
     url = "https://api.github.com/repos/acon3d/blender/releases/latest"
     if test_arg:
         url = "https://api.github.com/repos/acon3d/blender/releases"
+    if repo:
+        print("repo url 받아오는지 확인")
+        url = "https://api.github.com/repos/ACON3D/launcherTestRepo/releases/latest"
+        print(f"url : {url}")
+    if repo_pre:
+        url = "https://api.github.com/repos/ACON3D/launcherTestRepo/releases"
     # TODO: 새 arg 받아서 테스트 레포 url 업데이트
 
     is_release, req, state_ui, launcher_installed = get_req_from_url(
         url, state_ui, launcher_installed, dir_
     )
+
+    print(state_ui)
+    print(is_release)
+
     if state_ui == StateUI.error:
         return state_ui, finallist
 
     if not is_release:
+        print("is_release가 false면 여기로 들어감")
         state_ui = StateUI.no_release
+        print(f"check_launcher 나가기 전에 state_ui : {state_ui}")
         return state_ui, finallist
 
     else:
@@ -67,6 +83,7 @@ def check_launcher(dir_: str, launcher_installed: str) -> Tuple[Enum, Optional[l
 
         # Launcher 릴리즈 버전 == 설치 버전
         # -> finallist = None가 반환
+        print(f"launcher의 릴리즈 버전 == 설치 버전 state_ui 체크 {state_ui}")
         return state_ui, finallist
 
 
@@ -97,6 +114,9 @@ def get_req_from_url(
         state_ui = StateUI.error
 
     if test_arg:
+        req = req[0]
+
+    if repo_pre:
         req = req[0]
 
     is_release = True

--- a/launcher_abler/UpdateLauncher.py
+++ b/launcher_abler/UpdateLauncher.py
@@ -62,6 +62,7 @@ def check_launcher(dir_: str, launcher_installed: str) -> Tuple[Enum, Optional[l
 
     else:
         get_results_from_req(req, results)
+
         if results:
             if launcher_installed is None or launcher_installed == "":
                 launcher_installed = "0.0.0"
@@ -69,6 +70,7 @@ def check_launcher(dir_: str, launcher_installed: str) -> Tuple[Enum, Optional[l
             # Launcher 릴리즈 버전 > 설치 버전
             # -> finallist = results 반환
             if StrictVersion(results[0]["version"]) > StrictVersion(launcher_installed):
+                print(f"    # New Launcher Ver. : {results[0]['version']}")
                 state_ui = StateUI.update_launcher
                 finallist = results
                 return state_ui, finallist

--- a/launcher_abler/UpdateLauncher.py
+++ b/launcher_abler/UpdateLauncher.py
@@ -8,8 +8,7 @@ from typing import Tuple, Optional
 from enum import Enum
 from distutils.version import StrictVersion
 import configparser
-from AblerLauncherUtils import get_datadir, StateUI
-from AblerLauncherUtils import repo, repo_pre
+from AblerLauncherUtils import *
 
 
 if sys.platform == "win32":
@@ -20,7 +19,6 @@ os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"
 LOG_FORMAT = (
     "%(asctime)s,%(msecs)d %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s"
 )
-test_arg = len(sys.argv) > 1 and sys.argv[1] == "--test"
 os.makedirs(get_datadir() / "Blender/2.96", exist_ok=True)
 os.makedirs(get_datadir() / "Blender/2.96/updater", exist_ok=True)
 logging.basicConfig(
@@ -32,8 +30,6 @@ logging.basicConfig(
 
 logger = logging.getLogger()
 
-print("UpdateLauncher.py 들어갔는지나 확인")
-
 
 def check_launcher(dir_: str, launcher_installed: str) -> Tuple[Enum, Optional[list]]:
     """최신 릴리즈가 있는지 URL 주소로 확인"""
@@ -41,31 +37,33 @@ def check_launcher(dir_: str, launcher_installed: str) -> Tuple[Enum, Optional[l
     finallist = None
     results = []
     state_ui = None
-    url = "https://api.github.com/repos/acon3d/blender/releases/latest"
-    if test_arg:
-        url = "https://api.github.com/repos/acon3d/blender/releases"
-    if repo:
-        print("repo url 받아오는지 확인")
-        url = "https://api.github.com/repos/ACON3D/launcherTestRepo/releases/latest"
-        print(f"url : {url}")
-    if repo_pre:
-        url = "https://api.github.com/repos/ACON3D/launcherTestRepo/releases"
+
+    # URL settings
+    # Pre-Release 테스트 시에는 req = req[0]으로 pre-release 데이터 받아오기
+    print("\n-> UpdateLauncher.py")
+    print("def check_launcher():")
+    print("    # url settings")
+
     # TODO: 새 arg 받아서 테스트 레포 url 업데이트
+    url = "https://api.github.com/repos/acon3d/blender/releases/latest"
+    if pre_rel:
+        url = "https://api.github.com/repos/acon3d/blender/releases"
+    if new_rel:
+        url = "https://api.github.com/repos/ACON3D/launcherTestRepo/releases/latest"
+    if new_pre_rel:
+        url = "https://api.github.com/repos/ACON3D/launcherTestRepo/releases/"
+
+    print(f"    # url : {url}")
 
     is_release, req, state_ui, launcher_installed = get_req_from_url(
         url, state_ui, launcher_installed, dir_
     )
 
-    print(state_ui)
-    print(is_release)
-
     if state_ui == StateUI.error:
         return state_ui, finallist
 
     if not is_release:
-        print("is_release가 false면 여기로 들어감")
         state_ui = StateUI.no_release
-        print(f"check_launcher 나가기 전에 state_ui : {state_ui}")
         return state_ui, finallist
 
     else:
@@ -83,7 +81,6 @@ def check_launcher(dir_: str, launcher_installed: str) -> Tuple[Enum, Optional[l
 
         # Launcher 릴리즈 버전 == 설치 버전
         # -> finallist = None가 반환
-        print(f"launcher의 릴리즈 버전 == 설치 버전 state_ui 체크 {state_ui}")
         return state_ui, finallist
 
 
@@ -113,10 +110,8 @@ def get_req_from_url(
         logger.error(e)
         state_ui = StateUI.error
 
-    if test_arg:
-        req = req[0]
-
-    if repo_pre:
+    # Pre-Release에서는 req[0]이 pre-release 정보를 가지고 있음
+    if pre_rel or new_pre_rel:
         req = req[0]
 
     is_release = True

--- a/launcher_abler/UpdateLauncher.py
+++ b/launcher_abler/UpdateLauncher.py
@@ -38,14 +38,8 @@ def check_launcher(dir_: str, launcher_installed: str) -> Tuple[Enum, Optional[l
 
     # URL settings
     # Pre-Release 테스트 시에는 req = req[0]으로 pre-release 데이터 받아오기
-    print("\n-> UpdateLauncher.py")
-    print("def check_launcher():")
-    print("    # url settings")
-
-    # TODO: 새 arg 받아서 테스트 레포 url 업데이트
     url = set_url()
-
-    print(f"    # url : {url}")
+    print(f"> url : {url}")
 
     is_release, req, state_ui, launcher_installed = get_req_from_url(
         url, state_ui, launcher_installed, dir_
@@ -68,7 +62,7 @@ def check_launcher(dir_: str, launcher_installed: str) -> Tuple[Enum, Optional[l
             # Launcher 릴리즈 버전 > 설치 버전
             # -> finallist = results 반환
             if StrictVersion(results[0]["version"]) > StrictVersion(launcher_installed):
-                print(f"    # New Launcher Ver. : {results[0]['version']}")
+                print(f"> New Launcher Ver. : {results[0]['version']}")
                 state_ui = StateUI.update_launcher
                 finallist = results
                 return state_ui, finallist

--- a/launcher_abler/UpdateLauncher.py
+++ b/launcher_abler/UpdateLauncher.py
@@ -45,13 +45,7 @@ def check_launcher(dir_: str, launcher_installed: str) -> Tuple[Enum, Optional[l
     print("    # url settings")
 
     # TODO: 새 arg 받아서 테스트 레포 url 업데이트
-    url = "https://api.github.com/repos/acon3d/blender/releases/latest"
-    if pre_rel:
-        url = "https://api.github.com/repos/acon3d/blender/releases"
-    if new_rel:
-        url = "https://api.github.com/repos/ACON3D/launcherTestRepo/releases/latest"
-    if new_pre_rel:
-        url = "https://api.github.com/repos/ACON3D/launcherTestRepo/releases/"
+    url = set_url()
 
     print(f"    # url : {url}")
 


### PR DESCRIPTION
## 요약

- Pre-Release를 생성하거나 새 저장소로 옮길 때 런처를 통한 업데이트가 잘 되는지 테스트하는 과정이 필요
- URL 세팅으로 에이블러 저장소 (blender) 혹은 테스트 저장소 (launcherTestRepo) 의 릴리즈 정보를 받아올 수 있음
- 관련 Notion 문서: [새 repo로 런처, 에이블러 업데이트](https://www.notion.so/acon3d/repo-8f7449ca793d4e55b96bb0ebb03e0904)


## 새 GitHub 저장소에서 릴리즈 argument 추가

```bash
# [ 주의사항 ]
# 새 repo가 완전히 비어있을 때는 request에 정보가 없어 url 정보를 받을 수 없습니다.
# 따라서 --new-repo-pre-release는 pre-release 생성했을 때만 테스트 가능합니다.

# Windows (런처 v0.0.12 이상)
$ cd C:/Users/{username}/AppData/Roaming/Blender Foundation/Blender/2.96/updater
$ ./AblerLauncher.exe --new-repo-release
$ ./AblerLauncher.exe --new-repo-pre-release

# pyinstaller로 .exe 생성 후 테스트
$ cd ~/blender/launcher_abler
$ pyinstaller --icon=icon.ico --onefile --uac-admin AblerLauncher.py

# dist 폴더는 자동으로 생성
$ ./dist/AblerLauncher.exe --new-repo-release
$ ./dist/AblerLauncher.exe --new-repo-pre-release
```


## 기존 GitHub 저장소에서 릴리즈 argument 변경

```bash
# --test -> --pre-release
$ ./AblerLauncher.exe --pre-release
```