### PR TITLE
StateUI 내부 변수 이름 변경

### DIFF
--- a/launcher_abler/AblerLauncher.py
+++ b/launcher_abler/AblerLauncher.py
@@ -182,7 +182,7 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
             )
             self.frm_start.show()
 
-        elif state_ui == StateUI.no_release:
+        elif state_ui == StateUI.empty_repo:
             # TODO: 테스트 서버에서 릴리즈가 없이 테스트할 때 self.setup_execute_ui()에서
             #       click 빼야하는지, 있어도 되는지 확인하기
             self.frm_start.show()
@@ -206,7 +206,7 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
             )
             self.frm_start.show()
 
-        elif state_ui == StateUI.no_release:
+        elif state_ui == StateUI.empty_repo:
             self.frm_start.show()
             self.setup_execute_ui()
 

--- a/launcher_abler/AblerLauncherUtils.py
+++ b/launcher_abler/AblerLauncherUtils.py
@@ -34,7 +34,7 @@ def hbytes(num) -> str:
 
 class StateUI(Enum):
     check = auto()
-    no_release = auto()
+    empty_repo = auto()
     update_launcher = auto()
     update_abler = auto()
     execute = auto()

--- a/launcher_abler/UpdateAbler.py
+++ b/launcher_abler/UpdateAbler.py
@@ -48,7 +48,7 @@ def check_abler(dir_: str, installedversion: str) -> Tuple[Enum, Optional[list]]
         return state_ui, finallist
 
     if not is_release:
-        state_ui = StateUI.no_release
+        state_ui = StateUI.empty_repo
         return state_ui, finallist
 
     get_results_from_req(req, results)

--- a/launcher_abler/UpdateLauncher.py
+++ b/launcher_abler/UpdateLauncher.py
@@ -49,7 +49,7 @@ def check_launcher(dir_: str, launcher_installed: str) -> Tuple[Enum, Optional[l
         return state_ui, finallist
 
     if not is_release:
-        state_ui = StateUI.no_release
+        state_ui = StateUI.empty_repo
         return state_ui, finallist
 
     else:


### PR DESCRIPTION
## 요약

`StateUI.no_release`가 저장소에 릴리즈/프리-릴리즈가 아무것도 없는 빈 저장소라는 의미이지만, 새 릴리즈 (new version) 가 없다와 헷갈릴 수 있어 이름을 변경했습니다.