### PR TITLE
빈 저장소의 프리 릴리즈 request 에러 처리

### DIFF
--- a/launcher_abler/AblerLauncher.py
+++ b/launcher_abler/AblerLauncher.py
@@ -164,12 +164,8 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
                 self.entry = finallist[0]
             self.parse_launcher_state(state_ui)
 
-            # release가 없는 빈 repo일 때, Launcher에서 확인되면
-            # ABLER 업데이트 확인 불필요
-            # if state_ui == StateUI.no_release:
-            #     self.frm_start.show()
-            #     self.setup_execute_ui()
-            #     return
+            # Launcher에서 릴리즈가 없는 빈 저장소임을 확인하면 ABLER에서 확인할 필요 없음
+            state_ui = None if StateUI.empty_repo else state_ui
 
             if not state_ui:
                 state_ui, finallist = UpdateAbler.check_abler(
@@ -191,14 +187,9 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
             )
             self.frm_start.show()
 
-        elif state_ui == StateUI.no_release:
-            # TODO: 빈 테스트 repo를 테스트할 때, self.setup_execute_ui()로
-            #       실행되는지 확인하기
+        elif state_ui == StateUI.empty_repo:
             self.frm_start.show()
-            self.btn_execute.show()
-            self.btn_update_launcher.hide()
-            self.btn_update.hide()
-            # self.setup_execute_ui()
+            self.setup_execute_ui()
 
         elif state_ui == StateUI.update_launcher:
             self.setup_update_launcher_ui()
@@ -215,10 +206,6 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
                 "Error reaching server - check your internet connection"
             )
             self.frm_start.show()
-
-        elif state_ui == StateUI.empty_repo:
-            self.frm_start.show()
-            self.setup_execute_ui()
 
         elif state_ui == StateUI.update_abler:
             self.setup_update_abler_ui()

--- a/launcher_abler/AblerLauncher.py
+++ b/launcher_abler/AblerLauncher.py
@@ -216,7 +216,7 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
             )
             self.frm_start.show()
 
-        elif state_ui == StateUI.no_release:
+        elif state_ui == StateUI.empty_repo:
             self.frm_start.show()
             self.setup_execute_ui()
 

--- a/launcher_abler/AblerLauncher.py
+++ b/launcher_abler/AblerLauncher.py
@@ -413,14 +413,14 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
             if pre_rel:
                 _ = subprocess.Popen([path, "--pre-release"])
 
-            elif new_rel:
+            elif new_repo_rel:
                 # 빈 repo를 사용할 때는 pyinstaller를 계속 사용하기 때문에
                 # ~/blender/launcher_abler/dist/AblerLauncher.exe를 실행하면 파일 복사 불필요
                 # $ pyinstaller --icon=icon.ico --onefile --uac-admin AblerLauncher.py
                 path = f"{os.getcwd()}/dist/AblerLauncher.exe"
                 _ = subprocess.Popen([path, "--new-repo-release"])
 
-            elif new_pre_rel:
+            elif new_repo_pre_rel:
                 path = f"{os.getcwd()}/dist/AblerLauncher.exe"
                 _ = subprocess.Popen([path, "--new-repo-pre-release"])
 
@@ -435,12 +435,12 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
                 if pre_rel:
                     _ = subprocess.Popen([path, "--pre-release"])
 
-                elif new_rel:
+                elif new_repo_rel:
                     # try의 이유와 동일
                     path = f"{os.getcwd()}/dist/AblerLauncher.exe"
                     _ = subprocess.Popen([path, "--new-repo-release"])
 
-                elif new_pre_rel:
+                elif new_repo_pre_rel:
                     path = f"{os.getcwd()}/dist/AblerLauncher.exe"
                     _ = subprocess.Popen([path, "--new-repo-pre-release"])
 

--- a/launcher_abler/AblerLauncherUtils.py
+++ b/launcher_abler/AblerLauncherUtils.py
@@ -6,13 +6,13 @@ from enum import Enum, auto
 # 테스트용 argument 추가
 if len(sys.argv) > 1:
     pre_rel = sys.argv[1] == "--pre-release"
-    new_rel = sys.argv[1] == "--new-repo-release"
-    new_pre_rel = sys.argv[1] == "--new-repo-pre-release"
+    new_repo_rel = sys.argv[1] == "--new-repo-release"
+    new_repo_pre_rel = sys.argv[1] == "--new-repo-pre-release"
 
     print("\n> release test argv 확인")
     print(f"> --pre-release          : {'O' if pre_rel else 'X'}")
-    print(f"> --new-repo-release     : {'O' if new_rel else 'X'}")
-    print(f"> --new-repo-pre-release : {'O' if new_pre_rel else 'X'}")
+    print(f"> --new-repo-release     : {'O' if new_repo_rel else 'X'}")
+    print(f"> --new-repo-pre-release : {'O' if new_repo_pre_rel else 'X'}")
     print("\n")
 
 
@@ -22,11 +22,9 @@ def set_url() -> str:
 
     if pre_rel:
         url = "https://api.github.com/repos/ACON3D/blender/releases"
-    elif new_rel:
+    elif new_repo_rel:
         url = "https://api.github.com/repos/ACON3D/launcherTestRepo/releases/latest"
-    elif new_pre_rel:
-        # 새 repo가 완전히 비어있을 때는 req에 정보가 없기 때문에 url 정보를 받을 수 없음
-        # 따라서 pre-release 생성했을 때만 테스트
+    elif new_repo_pre_rel:
         url = "https://api.github.com/repos/ACON3D/launcherTestRepo/releases"
 
     return url

--- a/launcher_abler/AblerLauncherUtils.py
+++ b/launcher_abler/AblerLauncherUtils.py
@@ -63,7 +63,7 @@ def hbytes(num) -> str:
 
 class StateUI(Enum):
     check = auto()
-    no_release = auto()
+    empty_repo = auto()
     update_launcher = auto()
     update_abler = auto()
     execute = auto()

--- a/launcher_abler/UpdateAbler.py
+++ b/launcher_abler/UpdateAbler.py
@@ -46,7 +46,7 @@ def check_abler(dir_: str, installedversion: str) -> Tuple[Enum, Optional[list]]
         return state_ui, finallist
 
     if not is_release:
-        state_ui = StateUI.no_release
+        state_ui = StateUI.empty_repo
         return state_ui, finallist
 
     get_results_from_req(req, results)

--- a/launcher_abler/UpdateAbler.py
+++ b/launcher_abler/UpdateAbler.py
@@ -97,7 +97,7 @@ def get_req_from_url(
         state_ui = StateUI.error
 
     # Pre-Release에서는 req[0]이 pre-release 정보를 가지고 있음
-    if pre_rel or new_pre_rel:
+    if pre_rel or new_repo_pre_rel:
         req = req[0]
 
     is_release = True

--- a/launcher_abler/UpdateLauncher.py
+++ b/launcher_abler/UpdateLauncher.py
@@ -49,7 +49,7 @@ def check_launcher(dir_: str, launcher_installed: str) -> Tuple[Enum, Optional[l
         return state_ui, finallist
 
     if not is_release:
-        state_ui = StateUI.no_release
+        state_ui = StateUI.empty_repo
         return state_ui, finallist
 
     else:

--- a/launcher_abler/UpdateLauncher.py
+++ b/launcher_abler/UpdateLauncher.py
@@ -98,11 +98,16 @@ def get_req_from_url(
         logger.error(e)
         state_ui = StateUI.error
 
-    # Pre-Release에서는 req[0]이 pre-release 정보를 가지고 있음
-    if pre_rel or new_pre_rel:
-        req = req[0]
-
     is_release = True
+
+    # Pre-Release에서는 req[0]이 pre-release 정보를 가지고 있음
+    if pre_rel:
+        req = req[0]
+    elif new_repo_pre_rel:
+        # 새 저장소가 비어있으면 requests.get(url).json() 정보가 없어 req = []
+        # 따라서 len(req) == 0 이고, is_release를 False로 업데이트
+        is_release = False if len(req) == 0 else is_release
+
     try:
         is_release = req["message"] != "Not Found"
     except Exception as e:


### PR DESCRIPTION
## 요약

@sdkfile 과 페어 코딩 및 확안으로 브랜치 이름 변경 없이 PR 올립니다.
[#48 런처에 릴리즈 관련 argument 추가](https://github.com/ACON3D/blender/pull/48)에 rebase된 브랜치이기 때문에 해당 PR이 머지되고 확인하시면 될 것 같습니다.

- `StateUI.no_release` 의미가 직관적이지 않아서 `StateUI.empty_repo`로 수정
- 빈 저장소 테스트 argument 이름 변경
- 빈 저장소 pre-release 테스트에서 request의 에러 처리