### PR TITLE
런처 레포 테스트에 사용되는 변수 초기화

### DIFF
--- a/launcher_abler/AblerLauncherUtils.py
+++ b/launcher_abler/AblerLauncherUtils.py
@@ -4,6 +4,10 @@ from enum import Enum, auto
 
 
 # 테스트용 argument 추가
+pre_rel = None
+new_repo_rel = None
+new_repo_pre_rel = None
+
 if len(sys.argv) > 1:
     pre_rel = sys.argv[1] == "--pre-release"
     new_repo_rel = sys.argv[1] == "--new-repo-release"


### PR DESCRIPTION
## 요약

- 런처 레포 테스트에 사용되는 변수가 `len(argv) > 1`일 때만 생성되어서 다른 곳에서 변수를 찾을 수 없는 문제가 있었습니다.
- 관련 인자들을 `None`으로 초기화 시켜주었습니다.
