### PR TITLE
파일 열기 시 빈 곳을 더블 클릭하면 파일이 없는 문제

### DIFF
--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -29,7 +29,6 @@ bl_info = {
     "tracker_url": "",
     "category": "ACON3D",
 }
-
 import os
 
 import bpy
@@ -80,7 +79,7 @@ class ImportOperator(bpy.types.Operator, ImportHelper):
 
             found = any(coll.name == child for child in children_names)
             if coll.name == "Layers" or (
-                    "Layers." in coll.name and len(coll.name) == 10
+                "Layers." in coll.name and len(coll.name) == 10
             ):
                 for coll_2 in coll.children:
                     added_l_exclude = context.scene.l_exclude.add()

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -141,7 +141,6 @@ class FileOpenOperator(bpy.types.Operator, ImportHelper):
         if path.endswith('/') or path.endswith('\\') or path.endswith('//'):
             return {"FINISHED"}
         elif not os.path.isfile(path):
-            # TODO: translate messages in alert box
             bpy.ops.acon3d.alert(
                 "INVOKE_DEFAULT",
                 title="File not found",

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -30,10 +30,11 @@ bl_info = {
     "category": "ACON3D",
 }
 
-
 import os
+
 import bpy
 from bpy_extras.io_utils import ImportHelper
+
 from .lib import scenes
 from .lib.materials import materials_setup
 from .lib.tracker import tracker
@@ -79,7 +80,7 @@ class ImportOperator(bpy.types.Operator, ImportHelper):
 
             found = any(coll.name == child for child in children_names)
             if coll.name == "Layers" or (
-                "Layers." in coll.name and len(coll.name) == 10
+                    "Layers." in coll.name and len(coll.name) == 10
             ):
                 for coll_2 in coll.children:
                     added_l_exclude = context.scene.l_exclude.add()
@@ -136,8 +137,18 @@ class FileOpenOperator(bpy.types.Operator, ImportHelper):
     filter_glob: bpy.props.StringProperty(default="*.blend", options={"HIDDEN"})
 
     def execute(self, context):
-        FILEPATH = self.filepath
-        bpy.ops.wm.open_mainfile(filepath=FILEPATH)
+        path = self.filepath
+        if path.endswith('/') or path.endswith('\\') or path.endswith('//'):
+            return {"FINISHED"}
+        elif not os.path.isfile(path):
+            # TODO: translate messages in alert box
+            bpy.ops.acon3d.alert(
+                "INVOKE_DEFAULT",
+                title="File not found",
+                message_1="Selected file does not exist",
+            )
+            return {"FINISHED"}
+        bpy.ops.wm.open_mainfile(filepath=path)
 
         return {"FINISHED"}
 

--- a/release/scripts/startup/bl_ui/space_topbar.py
+++ b/release/scripts/startup/bl_ui/space_topbar.py
@@ -286,7 +286,7 @@ class TOPBAR_MT_file(Menu):
 
         layout.operator_context = 'INVOKE_AREA'
         layout.menu("TOPBAR_MT_file_new", text="New", icon='FILE_NEW')
-        layout.operator("wm.open_mainfile", text="Open...", icon='FILE_FOLDER')
+        layout.operator("acon3d.file_open", text="Open...", icon='FILE_FOLDER')
         layout.menu("TOPBAR_MT_file_open_recent")
         layout.operator("wm.revert_mainfile")
         layout.menu("TOPBAR_MT_file_recover")
@@ -733,7 +733,7 @@ class TOPBAR_MT_file_context_menu(Menu):
 
         layout.operator_context = 'INVOKE_AREA'
         layout.menu("TOPBAR_MT_file_new", text="New", icon='FILE_NEW')
-        layout.operator("wm.open_mainfile", text="Open...", icon='FILE_FOLDER')
+        layout.operator("acon3d.file_open", text="Open...", icon='FILE_FOLDER')
 
         layout.separator()
 


### PR DESCRIPTION
# 작업예정 내용
- [x]  빈 스트링이 들어가면 그냥 넘기도록 함
- [x]  파일이 존재하지 않는 이름이면 존재하지 않는 이름이라고 알림을 띄움
![image](https://user-images.githubusercontent.com/43770096/169936327-191b7c80-2720-41c8-83e5-ceab5cf2ca74.png)

- [ ]  메시지박스에 들어가는 내용 번역 추가

# 현재까지 작업된 코드 내용
https://github.com/ACON3D/blender/blob/4dadd22a2ef9c68476dc0749b3279697ceece1ac/release/scripts/startup/abler/general.py#L139-L153

# 노션 카드 링크
[링크](https://www.notion.so/acon3d/01932ec7155441e798cd4f1b072b40d2)