### PR TITLE
Active Object가 없을 때 오브젝트 설정 UI 변경

### DIFF
--- a/release/scripts/startup/abler/object_control.py
+++ b/release/scripts/startup/abler/object_control.py
@@ -167,9 +167,6 @@ class Acon3dObjectPanel(bpy.types.Panel):
         col.separator()
         col = row.column()
 
-        # context.object로 조건문을 두면 선택된 개체가 없어도 버튼을 누를 수 있음
-        # prop에선 선택된 개체가 없을 때 바로 안 보여야 유저가 헷갈리지 않기 때문에
-        # 조건문에서 context.selected_objects로 설정
         if context.selected_objects:
             row = col.row()
             row.prop(
@@ -204,7 +201,8 @@ class ObjectSubPanel(bpy.types.Panel):
         layout.use_property_split = True
         layout.use_property_decorate = True
 
-        if obj := context.object:
+        if context.selected_objects:
+            obj = context.object
             prop = obj.ACON_prop
 
             layout.active = prop.use_state and bool(len(context.selected_objects))
@@ -227,7 +225,8 @@ class Acon3dGroupNavigaionPanel(bpy.types.Panel):
     bl_options = {"DEFAULT_CLOSED"}
 
     def draw(self, context):
-        if obj := context.object:
+        if context.selected_objects:
+            obj = context.object
             prop = obj.ACON_prop
             layout = self.layout
 

--- a/release/scripts/startup/abler/object_control.py
+++ b/release/scripts/startup/abler/object_control.py
@@ -177,7 +177,7 @@ class Acon3dObjectPanel(bpy.types.Panel):
         else:
             row = col.row(align=True)
             row.enabled = False
-            row.label(text="Look at me", icon="CHECKBOX_DEHLT")
+            row.label(text="Look at me", icon="SELECT_SET")
 
 
 class ObjectSubPanel(bpy.types.Panel):

--- a/release/scripts/startup/abler/object_control.py
+++ b/release/scripts/startup/abler/object_control.py
@@ -43,10 +43,6 @@ class GroupNavigateTopOperator(bpy.types.Operator):
     bl_label = "Group Navigate Top"
     bl_translation_context = "*"
 
-    @classmethod
-    def poll(cls, context):
-        return context.object
-
     def execute(self, context):
         tracker.group_navigate_top()
         layers.selectByGroup("TOP")
@@ -59,10 +55,6 @@ class GroupNavigateUpOperator(bpy.types.Operator):
     bl_idname = "acon3d.group_navigate_up"
     bl_label = "Group Navigate Up"
     bl_translation_context = "*"
-
-    @classmethod
-    def poll(cls, context):
-        return context.object
 
     def execute(self, context):
         tracker.group_navigate_up()
@@ -77,10 +69,6 @@ class GroupNavigateDownOperator(bpy.types.Operator):
     bl_label = "Group Navigate Down"
     bl_translation_context = "*"
 
-    @classmethod
-    def poll(cls, context):
-        return context.object
-
     def execute(self, context):
         tracker.group_navigate_down()
         layers.selectByGroup("DOWN")
@@ -93,10 +81,6 @@ class GroupNavigateBottomOperator(bpy.types.Operator):
     bl_idname = "acon3d.group_navigate_bottom"
     bl_label = "Group Navigate Bottom"
     bl_translation_context = "*"
-
-    @classmethod
-    def poll(cls, context):
-        return context.object
 
     def execute(self, context):
         tracker.group_navigate_bottom()

--- a/release/scripts/startup/abler/object_control.py
+++ b/release/scripts/startup/abler/object_control.py
@@ -185,9 +185,9 @@ class ObjectSubPanel(bpy.types.Panel):
     bl_region_type = "UI"
     bl_options = {"DEFAULT_CLOSED"}
 
-    @classmethod
-    def poll(cls, context):
-        return context.object
+    # @classmethod
+    # def poll(cls, context):
+    #     return context.object
 
     def draw_header(self, context):
         if obj := context.object:
@@ -201,14 +201,17 @@ class ObjectSubPanel(bpy.types.Panel):
         layout.use_property_split = True
         layout.use_property_decorate = True
 
-        obj = context.object
-        prop = obj.ACON_prop
+        if obj := context.object:
+            prop = obj.ACON_prop
 
-        layout.active = prop.use_state and bool(len(context.selected_objects))
-        layout.enabled = layout.active
-        row = layout.row(align=True)
-        row.prop(prop, "state_slider", slider=True)
-        row.operator("acon3d.state_update", text="", icon="FILE_REFRESH")
+            layout.active = prop.use_state and bool(len(context.selected_objects))
+            layout.enabled = layout.active
+            row = layout.row(align=True)
+            row.prop(prop, "state_slider", slider=True)
+            row.operator("acon3d.state_update", text="", icon="FILE_REFRESH")
+        else:
+            row = layout.row(align=True)
+            row.label(text="No Selected Object")
 
 
 class Acon3dGroupNavigaionPanel(bpy.types.Panel):

--- a/release/scripts/startup/abler/object_control.py
+++ b/release/scripts/startup/abler/object_control.py
@@ -167,7 +167,7 @@ class Acon3dObjectPanel(bpy.types.Panel):
         col.separator()
         col = row.column()
 
-        if context.object:
+        if context.selected_objects:
             row = col.row()
             row.prop(
                 context.object.ACON_prop,

--- a/release/scripts/startup/abler/object_control.py
+++ b/release/scripts/startup/abler/object_control.py
@@ -167,6 +167,9 @@ class Acon3dObjectPanel(bpy.types.Panel):
         col.separator()
         col = row.column()
 
+        # context.object로 조건문을 두면 선택된 개체가 없어도 버튼을 누를 수 있음
+        # prop에선 선택된 개체가 없을 때 바로 안 보여야 유저가 헷갈리지 않기 때문에
+        # 조건문에서 context.selected_objects로 설정
         if context.selected_objects:
             row = col.row()
             row.prop(

--- a/release/scripts/startup/abler/object_control.py
+++ b/release/scripts/startup/abler/object_control.py
@@ -212,7 +212,7 @@ class ObjectSubPanel(bpy.types.Panel):
             row.operator("acon3d.state_update", text="", icon="FILE_REFRESH")
         else:
             row = layout.row(align=True)
-            row.label(text="No Selected Object")
+            row.label(text="No selected object")
 
 
 class Acon3dGroupNavigaionPanel(bpy.types.Panel):
@@ -240,7 +240,7 @@ class Acon3dGroupNavigaionPanel(bpy.types.Panel):
         else:
             layout = self.layout
             row = layout.row(align=True)
-            row.label(text="No Selected Object")
+            row.label(text="No selected object")
 
 
 classes = (

--- a/release/scripts/startup/abler/object_control.py
+++ b/release/scripts/startup/abler/object_control.py
@@ -174,6 +174,10 @@ class Acon3dObjectPanel(bpy.types.Panel):
                 "constraint_to_camera_rotation_z",
                 text="Look at me",
             )
+        else:
+            row = col.row(align=True)
+            row.enabled = False
+            row.label(text="Look at me", icon="CHECKBOX_DEHLT")
 
 
 class ObjectSubPanel(bpy.types.Panel):
@@ -184,10 +188,6 @@ class ObjectSubPanel(bpy.types.Panel):
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
     bl_options = {"DEFAULT_CLOSED"}
-
-    # @classmethod
-    # def poll(cls, context):
-    #     return context.object
 
     def draw_header(self, context):
         if obj := context.object:
@@ -223,22 +223,22 @@ class Acon3dGroupNavigaionPanel(bpy.types.Panel):
     bl_region_type = "UI"
     bl_options = {"DEFAULT_CLOSED"}
 
-    @classmethod
-    def poll(cls, context):
-        return context.object
-
     def draw(self, context):
-        obj = context.active_object
-        prop = obj.ACON_prop
-        layout = self.layout
+        if obj := context.object:
+            prop = obj.ACON_prop
+            layout = self.layout
 
-        row = layout.row(align=True)
-        row.enabled = "Groups" in context.collection.children.keys()
-        row.prop(prop, "group_list", text="")
-        row.operator("acon3d.group_navigate_top", text="", icon="TRIA_UP_BAR")
-        row.operator("acon3d.group_navigate_up", text="", icon="TRIA_UP")
-        row.operator("acon3d.group_navigate_down", text="", icon="TRIA_DOWN")
-        row.operator("acon3d.group_navigate_bottom", text="", icon="TRIA_DOWN_BAR")
+            row = layout.row(align=True)
+            row.enabled = "Groups" in context.collection.children.keys()
+            row.prop(prop, "group_list", text="")
+            row.operator("acon3d.group_navigate_top", text="", icon="TRIA_UP_BAR")
+            row.operator("acon3d.group_navigate_up", text="", icon="TRIA_UP")
+            row.operator("acon3d.group_navigate_down", text="", icon="TRIA_DOWN")
+            row.operator("acon3d.group_navigate_bottom", text="", icon="TRIA_DOWN_BAR")
+        else:
+            layout = self.layout
+            row = layout.row(align=True)
+            row.label(text="No Selected Object")
 
 
 classes = (


### PR DESCRIPTION
<img width="220" alt="스크린샷 2022-05-27 오후 1 42 07" src="https://user-images.githubusercontent.com/87409148/170638146-337aa2cc-e507-4f17-a8c2-85e4824cf164.png">

@classmethod는 아예 오퍼레이터를 지워버리므로 draw 내부에서 Active Object가 없을 때에 대한 처리를 해주는 것으로 변경.
look at me에서 context.object로 조건문을 두면 선택된 개체가 없어도 버튼을 누를 수 있기 때문에 prop에선 선택된 개체가 없을 때 바로 안 보여야 유저가 헷갈리지 않아 조건문에서 context.selected_objects로 설정(해당 내용 코드 주석으로도 넣었습니다)

기능적으로 이상 없으면 번역 PR 추후에 올리겠습니다.

노션카드 : https://www.notion.so/acon3d/UI-f8ce6048da1e4636a11e1ca6d66b4aa0