### PR TITLE
render all scenes 이후 초기 씬으로 업데이트

### DIFF
--- a/release/scripts/startup/abler/render_control.py
+++ b/release/scripts/startup/abler/render_control.py
@@ -98,6 +98,8 @@ class Acon3dRenderOperator(bpy.types.Operator):
         self.render_canceled = True
 
     def on_render_finish(self, context):
+        # set initial_scene
+        bpy.data.window_managers["WinMan"].ACON_prop.scene = self.initial_scene.name
         return {"FINISHED"}
 
     def prepare_queue(self, context):


### PR DESCRIPTION
이전에 self.initial_scene.name으로 업데이트 해주는 코드는 Acon3dRenderOperator에서 상속받은 Acon3dRenderTempSceneFileOperator/Acon3dRenderTempSceneDirOperator 클래스(쉐도우, 라인, 스닙렌더 구현을 위한 클래스)에서 구현을 해 Acon3dRenderOperator에서 바로 동작하는 render all scenes에선 업데이트가 안되는 문제였습니다.
Acon3dRenderOperator에서 렌더가 끝난 시점인 on_render_finish 함수에 self.initial_scene.name로 업데이트 하는 코드 추가해주었습니다.

노션 카드 : https://www.notion.so/acon3d/Render-All-Scene-4274bbfb8c514a29bbd5a4d06f94ec20