### PR TITLE
snip 렌더 밝기 오류

### DIFF
--- a/release/scripts/startup/abler/lib/render.py
+++ b/release/scripts/startup/abler/lib/render.py
@@ -39,15 +39,7 @@ def setupSnipCompositor(
     node_setAlpha = nodes.new("CompositorNodeSetAlpha")
     tree.links.new(node_left, node_setAlpha.inputs[0])
     tree.links.new(node_rlayer.outputs[1], node_setAlpha.inputs[1])
-
-    node_image = nodes.new("CompositorNodeImage")
-    node_image.image = shade_image
-
-    node_multiply = nodes.new("CompositorNodeMixRGB")
-    node_multiply.blend_type = "MULTIPLY"
-    tree.links.new(node_setAlpha.outputs[0], node_multiply.inputs[1])
-    tree.links.new(node_image.outputs[0], node_multiply.inputs[2])
-    tree.links.new(node_multiply.outputs[0], node_right)
+    tree.links.new(node_setAlpha.outputs[0], node_right)
 
 
 def setupBackgroundImagesCompositor(node_left=None, node_right=None, scene=None):

--- a/release/scripts/startup/abler/render_control.py
+++ b/release/scripts/startup/abler/render_control.py
@@ -504,10 +504,6 @@ class Acon3dRenderSnipOperator(Acon3dRenderTempSceneDirOperator):
 
         scene = context.scene.copy()
         scene.name = f"{context.scene.name}_snipped"
-        prop = scene.ACON_prop
-        prop.toggle_texture = False
-        prop.toggle_shading = False
-        prop.toggle_toon_edge = False
         self.render_queue.append(scene)
         self.temp_scenes.append(scene)
 


### PR DESCRIPTION
노션에 해당 발생 오류 및 개선 방법 정리했습니다.
https://www.notion.so/acon3d/3D-f893a1ccecf4494cb0594a49d46c8107?p=f9b9799dc6c54732b94d488febc2e203

밝기가 차이나는 현상은 Compositor-MIX nodes에서 bloom의 밝기가 mix되기 때문이었고, Compositor-MIX nodes 없이 바로 렌더해도 view_layer에서 영역만큼 잘라내기 때문에 이상 없습니다!
