### PR TITLE
"Layers" 이름의 콜렉션 확인으로 에이블러 파일인지 확인

### DIFF
--- a/release/scripts/startup/abler/layer_control.py
+++ b/release/scripts/startup/abler/layer_control.py
@@ -170,14 +170,13 @@ class Acon3dLayerPanel(bpy.types.Panel):
         return index
 
     def draw(self, context):
-        layout = self.layout
-        layout.use_property_split = False
-        box = layout.box()
-
         view = context.space_data
         view_layer = context.view_layer
 
         if "Layers" in view_layer.layer_collection.children:
+            layout = self.layout
+            layout.use_property_split = False
+            box = layout.box()
 
             self._draw_collection(
                 box,

--- a/release/scripts/startup/abler/layer_control.py
+++ b/release/scripts/startup/abler/layer_control.py
@@ -185,6 +185,10 @@ class Acon3dLayerPanel(bpy.types.Panel):
                 view_layer.layer_collection.children["Layers"],
                 1,
             )
+        else:
+            layout = self.layout
+            row = layout.row(align=True)
+            row.label(text="No 'Layers' collection in Outliner")
 
 
 classes = (

--- a/release/scripts/startup/abler/lib/post_open.py
+++ b/release/scripts/startup/abler/lib/post_open.py
@@ -38,11 +38,16 @@ def update_scene() -> None:
 def update_layers():
     # 파일 오픈시 Layer패널 업데이트
     context = bpy.context
-    if not context.scene.l_exclude and bpy.data.collections["Layers"]:
-        for child in bpy.data.collections["Layers"].children:
-            added_l_exclude = context.scene.l_exclude.add()
-            added_l_exclude.name = child.name
-            added_l_exclude.value = True
+    if not context.scene.l_exclude:
+        if "Layers" in bpy.data.collections:
+            for child in bpy.data.collections["Layers"].children:
+                added_l_exclude = context.scene.l_exclude.add()
+                added_l_exclude.name = child.name
+                added_l_exclude.value = True
+        else:
+            # "Layers" 컬렉션이 없으면 에이블러 전용 파일이 아니므로
+            # l_exclude를 지워서 Layer Control 패널을 비활성화시킴
+            bpy.context.scene.l_exclude.clear()
 
 
 def hide_adjust_last_operation_panel():

--- a/release/scripts/startup/abler/lib/post_open.py
+++ b/release/scripts/startup/abler/lib/post_open.py
@@ -38,8 +38,10 @@ def update_scene() -> None:
 def update_layers():
     # 파일 오픈시 Layer패널 업데이트
     context = bpy.context
+    view_layer = context.view_layer
+
     if not context.scene.l_exclude:
-        if "Layers" in bpy.data.collections:
+        if "Layers" in view_layer.layer_collection.children:
             for child in bpy.data.collections["Layers"].children:
                 added_l_exclude = context.scene.l_exclude.add()
                 added_l_exclude.name = child.name


### PR DESCRIPTION
에이블러 전용 파일이 아닌 블렌더 파일엔 "Layers" 콜렉션이 없어서 에러가 발생했습니다.
아래처럼 "Layers" 콜렉션이 있는지 확인 후 없으면 l_exclude를 모두 지워버려 레이어 패널을 비활성화하도록 suppress 처리해주었습니다.
<img width="842" alt="스크린샷 2022-06-13 오전 11 51 17" src="https://user-images.githubusercontent.com/87409148/173282871-48ef7157-197a-4f8b-bbd5-bdbbd82ed807.png">

노션문서 : https://www.notion.so/acon3d/blend-Layers-1844e2b19ed24098b6dd67bd40626119

