### PR TITLE
불량 그림자 문제 조사 및 해결

### DIFF
--- a/release/scripts/startup/abler/lib/shadow.py
+++ b/release/scripts/startup/abler/lib/shadow.py
@@ -78,7 +78,7 @@ def setupClearShadow():
         acon_sun.data.angle = 0
 
     # 오브젝트의 그림자가 아닌 옵션에 의한 그림자는 "불량 그림자"로 판단하고 해당 옵션 off
-    # 그림자가 생기는 면과 붙어 있지 않고 떠있는 느낌을 지우기 위해 bias를 최소치로 조정
+    # 그림자가 생기는 면과 붙어 있지 않고 떠있는 느낌을 지우기 위해 bias를 오류가 나지 않을 정도로 조정
     # createAconSun(), startup.blend에도 같은 작업 수행
     acon_sun.data.use_contact_shadow = False
     acon_sun.data.shadow_buffer_bias = 0.1

--- a/release/scripts/startup/abler/lib/shadow.py
+++ b/release/scripts/startup/abler/lib/shadow.py
@@ -81,7 +81,7 @@ def setupClearShadow():
     # 그림자가 생기는 면과 붙어 있지 않고 떠있는 느낌을 지우기 위해 bias를 최소치로 조정
     # createAconSun(), startup.blend에도 같은 작업 수행
     acon_sun.data.use_contact_shadow = False
-    acon_sun.data.shadow_buffer_bias = 0.001
+    acon_sun.data.shadow_buffer_bias = 0.1
 
 
 def createAconSun() -> Object:
@@ -93,7 +93,7 @@ def createAconSun() -> Object:
     acon_sun.rotation_euler.y = 0
     acon_sun.rotation_euler.z = math.radians(65)
     acon_sun.data.use_contact_shadow = False
-    acon_sun.data.shadow_buffer_bias = 0.001
+    acon_sun.data.shadow_buffer_bias = 0.1
 
     bpy.context.scene.collection.objects.link(acon_sun)
 

--- a/release/scripts/startup/abler/lib/shadow.py
+++ b/release/scripts/startup/abler/lib/shadow.py
@@ -76,7 +76,12 @@ def setupSharpShadow():
         acon_sun = createAconSun()
     if acon_sun.data.type == "SUN":
         acon_sun.data.angle = 0
-        acon_sun.data.use_contact_shadow = 1
+
+    # 오브젝트의 그림자가 아닌 옵션에 의한 그림자는 "불량 그림자"로 판단하고 해당 옵션 off
+    # 그림자가 생기는 면과 붙어 있지 않고 떠있는 느낌을 지우기 위해 bias를 최소치로 조정
+    # createAconSun(), startup.blend에도 같은 작업 수행
+    acon_sun.data.use_contact_shadow = False
+    acon_sun.data.shadow_buffer_bias = 0.001
 
 
 def createAconSun() -> Object:
@@ -86,6 +91,8 @@ def createAconSun() -> Object:
     acon_sun.rotation_euler.x = math.radians(90 - 35)
     acon_sun.rotation_euler.y = 0
     acon_sun.rotation_euler.z = math.radians(65)
+    acon_sun.data.use_contact_shadow = False
+    acon_sun.data.shadow_buffer_bias = 0.001
     bpy.context.scene.collection.objects.link(acon_sun)
 
     return acon_sun

--- a/release/scripts/startup/abler/lib/shadow.py
+++ b/release/scripts/startup/abler/lib/shadow.py
@@ -65,7 +65,7 @@ def toggleShadow(self, context: Context) -> None:
         acon_sun.data.use_shadow = prop.toggle_shadow
 
 
-def setupSharpShadow():
+def setupClearShadow():
     bpy.context.scene.eevee.shadow_cube_size = "4096"
     bpy.context.scene.eevee.shadow_cascade_size = "4096"
     bpy.context.scene.eevee.use_soft_shadows = True

--- a/release/scripts/startup/abler/lib/shadow.py
+++ b/release/scripts/startup/abler/lib/shadow.py
@@ -87,12 +87,14 @@ def setupSharpShadow():
 def createAconSun() -> Object:
     acon_sun_data: Light = bpy.data.lights.new("ACON_sun", type="SUN")
     acon_sun_data.energy = 1
+
     acon_sun: Object = bpy.data.objects.new("ACON_sun", acon_sun_data)
     acon_sun.rotation_euler.x = math.radians(90 - 35)
     acon_sun.rotation_euler.y = 0
     acon_sun.rotation_euler.z = math.radians(65)
     acon_sun.data.use_contact_shadow = False
     acon_sun.data.shadow_buffer_bias = 0.001
+
     bpy.context.scene.collection.objects.link(acon_sun)
 
     return acon_sun

--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -49,7 +49,7 @@ def load_handler(dummy):
         cameras.makeSureCameraExists()
         cameras.switchToRendredView()
         cameras.turnOnCameraView(False)
-        shadow.setupSharpShadow()
+        shadow.setupClearShadow()
         render.setupBackgroundImagesCompositor()
         materials_setup.applyAconToonStyle()
         for scene in bpy.data.scenes:


### PR DESCRIPTION
## 문제 내용

뷰포트 그림자에 알 수 없는 그림자 노이즈가 같이 생기고 있었습니다.
- 해당 Notion 문서: [불량 그림자 문제 조사 및 해결](https://www.notion.so/acon3d/58acc16606864bc8a14ec48615f2e6ad)

<img src="https://user-images.githubusercontent.com/52474700/173561313-2b0931d5-95fd-4f91-873b-4bf46420358c.png" width="400"/>


## 원인 & 해결 방안

ACON_sun의 Shadow -> `Contact Shadows` 옵션이 On 되어 있었고, 이 옵션이 생성하는 그림자가 **불량 그림자** 라고 정의되던 그림자였습니다.
그래서 해당 옵션을 끄고, Shadow -> `Bias` 옵션을 **1.0 -> 0.1**로 주었습니다.


## 수정 사항

- startup.blend에서 Shadow → Bias = 0.001, Contact Shadows Off
- lib/shadows.py에서
    ```python
    def setupSharpShadow():
        # 파일이 로딩될 때, Bias = 0.1, Contact Shadows Off
        acon_sun.data.use_contact_shadow = False
        acon_sun.data.shadow_buffer_bias = 0.1
    
    def createAconSun() -> Object:
        # ACON_sun이 생성될 때, Bias = 0.1, Contact Shadows Off
        acon_sun.data.use_contact_shadow = False
        acon_sun.data.shadow_buffer_bias = 0.1
    ```
- Black 적용


## 추가 문제

- [x] Bias를 두는 이유가 있는데, Bias를 너무 줄이면 오브젝트 자기 자신이 검게 되는 현상이 발생함
- [x] 기존 Blender에서는 `Bias = 1.000` 임
- [ ] 거리가 먼 오브젝트에 대해서 부식 현상 발생