### PR TITLE
숫자 앞에 0 표기 오류

### DIFF
--- a/source/blender/editors/interface/interface.c
+++ b/source/blender/editors/interface/interface.c
@@ -3059,6 +3059,10 @@ bool ui_but_string_eval_number(bContext *C, const uiBut *but, const char *str, d
     *r_value = 0.0;
     return true;
   }
+  // added while loop to strip leading zeros in str
+  while (str[0] == '0'){
+    str = str + 1;
+  }
 
   PropertySubType subtype = PROP_NONE;
   if (but->rnaprop) {


### PR DESCRIPTION
[노션 카드](https://www.notion.so/acon3d/Sentry-0-2281601ae6764f6ab7123458eb2d4cae)
[센트리 오류](https://sentry.io/organizations/carpenstreet/issues/2789541463/?project=6046815)

해당 오류는 아래와 같이 파이썬에서 기본으로 발생하는 오류였음
<img width="883" alt="스크린샷 2022-06-29 오후 7 55 38" src="https://user-images.githubusercontent.com/43770096/176603056-959d5e4b-adeb-4b64-b115-74a7112e62fa.png">

- 파이썬으로 블렌더가 넘기기 전에 앞에 있는 0들을 모두 strip 해버리는 기작을 추가하면 될 것이라고 생각함.
- UI에서 python으로 숫자를 넘기기 직전의 상태의 함수에서 변경사항과 같은 기작을 추가해서 leading zero를 참조하지 않도록 pointer를 옮김
