### PR TITLE
믹스패널 국가별 트래킹

### DIFF
--- a/release/scripts/startup/abler/credential_modal.py
+++ b/release/scripts/startup/abler/credential_modal.py
@@ -39,7 +39,6 @@ from .lib.remember_username import (
     read_remembered_username,
 )
 from .lib.tracker import tracker
-from .lib.tracker._get_ip import get_ip
 
 
 class Acon3dAlertOperator(bpy.types.Operator):
@@ -362,7 +361,8 @@ class LoginTask(AsyncTask):
 
     def _on_success(self):
 
-        tracker.login(self.username, ip=get_ip())
+        tracker.login()
+        tracker.update_profile(self.username)
 
         prop = self.prop
         path = bpy.utils.resource_path("USER")

--- a/release/scripts/startup/abler/credential_modal.py
+++ b/release/scripts/startup/abler/credential_modal.py
@@ -39,6 +39,7 @@ from .lib.remember_username import (
     read_remembered_username,
 )
 from .lib.tracker import tracker
+from .lib.tracker._get_ip import get_ip
 
 
 class Acon3dAlertOperator(bpy.types.Operator):
@@ -360,7 +361,8 @@ class LoginTask(AsyncTask):
         )
 
     def _on_success(self):
-        tracker.login(self.username)
+
+        tracker.login(self.username, ip=get_ip())
 
         prop = self.prop
         path = bpy.utils.resource_path("USER")

--- a/release/scripts/startup/abler/credential_modal.py
+++ b/release/scripts/startup/abler/credential_modal.py
@@ -484,6 +484,9 @@ def open_credential_modal(dummy):
 
     if prop.remember_username:
         prop.username = read_remembered_username()
+        # login_auto시 read_remembered_username()에서 username을 받아 
+        # update_profile로 ip -> mixpanel
+        tracker.update_profile(prop.username)
 
 
 @persistent

--- a/release/scripts/startup/abler/credential_modal.py
+++ b/release/scripts/startup/abler/credential_modal.py
@@ -39,7 +39,7 @@ from .lib.remember_username import (
     read_remembered_username,
 )
 from .lib.tracker import tracker
-from .lib.tracker._get_ip import get_ip
+from .lib.tracker._get_ip import user_ip
 
 
 class Acon3dAlertOperator(bpy.types.Operator):
@@ -363,7 +363,7 @@ class LoginTask(AsyncTask):
     def _on_success(self):
 
         tracker.login()
-        tracker.update_profile(self.username, get_ip())
+        tracker.update_profile(self.username, user_ip)
 
         prop = self.prop
         path = bpy.utils.resource_path("USER")

--- a/release/scripts/startup/abler/credential_modal.py
+++ b/release/scripts/startup/abler/credential_modal.py
@@ -39,6 +39,7 @@ from .lib.remember_username import (
     read_remembered_username,
 )
 from .lib.tracker import tracker
+from .lib.tracker._get_ip import get_ip
 
 
 class Acon3dAlertOperator(bpy.types.Operator):
@@ -362,7 +363,7 @@ class LoginTask(AsyncTask):
     def _on_success(self):
 
         tracker.login()
-        tracker.update_profile(self.username)
+        tracker.update_profile(self.username, get_ip())
 
         prop = self.prop
         path = bpy.utils.resource_path("USER")
@@ -484,9 +485,6 @@ def open_credential_modal(dummy):
 
     if prop.remember_username:
         prop.username = read_remembered_username()
-        # login_auto시 read_remembered_username()에서 username을 받아 
-        # update_profile로 ip -> mixpanel
-        tracker.update_profile(prop.username)
 
 
 @persistent

--- a/release/scripts/startup/abler/lib/tracker/_get_ip.py
+++ b/release/scripts/startup/abler/lib/tracker/_get_ip.py
@@ -1,0 +1,13 @@
+from requests import get
+
+
+def get_ip():
+    try:
+        ip = get("https://api.ipify.org").text
+        return ip
+    except ConnectionError:
+        # If you get here, then some ipify exception occurred.
+        print("Unable to reach the ipify service")
+    except:
+        # If you get here, some non-ipify related exception occurred.
+        print("Non ipify related exception occured")

--- a/release/scripts/startup/abler/lib/tracker/_get_ip.py
+++ b/release/scripts/startup/abler/lib/tracker/_get_ip.py
@@ -1,10 +1,9 @@
 from requests import get
 
 
-def get_ip():
+def get_ip() -> str:
     try:
-        ip = get("https://api.ipify.org").text
-        return ip
+        return get("https://api.ipify.org").text
     except ConnectionError:
         # If you get here, then some ipify exception occurred.
         print("Unable to reach the ipify service")

--- a/release/scripts/startup/abler/lib/tracker/_get_ip.py
+++ b/release/scripts/startup/abler/lib/tracker/_get_ip.py
@@ -1,7 +1,8 @@
+from typing import Optional
 from requests import get
 
 
-def get_ip() -> str:
+def get_ip() -> Optional[str]:
     try:
         return get("https://api.ipify.org").text
     except ConnectionError:

--- a/release/scripts/startup/abler/lib/tracker/_get_ip.py
+++ b/release/scripts/startup/abler/lib/tracker/_get_ip.py
@@ -4,7 +4,7 @@ from requests import get
 
 def get_ip() -> Optional[str]:
     try:
-        return get("https://api.ipify.org").text
+        return get("https://api.ipify.org", timeout=3).text
     except ConnectionError:
         # If you get here, then some ipify exception occurred.
         print("Unable to reach the ipify service")

--- a/release/scripts/startup/abler/lib/tracker/_get_ip.py
+++ b/release/scripts/startup/abler/lib/tracker/_get_ip.py
@@ -9,3 +9,6 @@ def get_ip() -> Optional[str]:
         print("Unable to reach the ipify service")
     except:
         print("Non ipify related exception occured")
+
+
+user_ip = get_ip()

--- a/release/scripts/startup/abler/lib/tracker/_get_ip.py
+++ b/release/scripts/startup/abler/lib/tracker/_get_ip.py
@@ -6,8 +6,6 @@ def get_ip() -> Optional[str]:
     try:
         return get("https://api.ipify.org", timeout=3).text
     except ConnectionError:
-        # If you get here, then some ipify exception occurred.
         print("Unable to reach the ipify service")
     except:
-        # If you get here, some non-ipify related exception occurred.
         print("Non ipify related exception occured")

--- a/release/scripts/startup/abler/lib/tracker/_mixpanel.py
+++ b/release/scripts/startup/abler/lib/tracker/_mixpanel.py
@@ -116,7 +116,7 @@ class MixpanelTracker(Tracker):
         self._r.mp.track(self._r.tid, event_name, properties)
 
     @_nonblock
-    def _enqueue_email_update(self, email: str):
+    def _enqueue_email_update(self, email: str, ip: str):
         self._ensure_resource()
-        self._r.mp.people_set_once(self._r.tid, {"$email": email})
+        self._r.mp.people_set(self._r.tid, {"$email": email, "$ip": ip})
         self._r.mp.alias(self._r.tid, email)

--- a/release/scripts/startup/abler/lib/tracker/_mixpanel.py
+++ b/release/scripts/startup/abler/lib/tracker/_mixpanel.py
@@ -8,7 +8,6 @@ from mixpanel import Mixpanel, BufferedConsumer
 import bpy
 
 from ._tracker import Tracker
-from ._get_ip import get_ip
 
 
 _user_path = bpy.utils.resource_path("USER")

--- a/release/scripts/startup/abler/lib/tracker/_mixpanel.py
+++ b/release/scripts/startup/abler/lib/tracker/_mixpanel.py
@@ -120,4 +120,4 @@ class MixpanelTracker(Tracker):
     def _enqueue_profile_update(self, email: str, ip: str):
         self._ensure_resource()
         self._r.mp.people_set(self._r.tid, {"$email": email}, meta={"$ip": ip})
-        self._r.mp.alias(self._r.tid, email)
+        self._r.mp.alias(self._r.tid, email, meta={"$ip": ip})

--- a/release/scripts/startup/abler/lib/tracker/_mixpanel.py
+++ b/release/scripts/startup/abler/lib/tracker/_mixpanel.py
@@ -116,7 +116,7 @@ class MixpanelTracker(Tracker):
         self._r.mp.track(self._r.tid, event_name, properties)
 
     @_nonblock
-    def _enqueue_email_update(self, email: str, ip: str):
+    def _enqueue_profile_update(self, email: str, ip: str):
         self._ensure_resource()
         self._r.mp.people_set(self._r.tid, {"$email": email}, meta={"$ip": ip})
         self._r.mp.alias(self._r.tid, email)

--- a/release/scripts/startup/abler/lib/tracker/_mixpanel.py
+++ b/release/scripts/startup/abler/lib/tracker/_mixpanel.py
@@ -8,6 +8,7 @@ from mixpanel import Mixpanel, BufferedConsumer
 import bpy
 
 from ._tracker import Tracker
+from ._get_ip import get_ip
 
 
 _user_path = bpy.utils.resource_path("USER")
@@ -113,10 +114,13 @@ class MixpanelTracker(Tracker):
     @_nonblock
     def _enqueue_event(self, event_name: str, properties: dict[str, Any]):
         self._ensure_resource()
+        # track()에서 ip 추적하는건 properties에 "ip"키로 추가
+        properties["ip"] = get_ip()
         self._r.mp.track(self._r.tid, event_name, properties)
 
     @_nonblock
     def _enqueue_profile_update(self, email: str, ip: str):
         self._ensure_resource()
+        # people_set()에서 ip 추적하는건 meta에 "ip"키로 추가
         self._r.mp.people_set(self._r.tid, {"$email": email}, meta={"$ip": ip})
         self._r.mp.alias(self._r.tid, email)

--- a/release/scripts/startup/abler/lib/tracker/_mixpanel.py
+++ b/release/scripts/startup/abler/lib/tracker/_mixpanel.py
@@ -114,13 +114,10 @@ class MixpanelTracker(Tracker):
     @_nonblock
     def _enqueue_event(self, event_name: str, properties: dict[str, Any]):
         self._ensure_resource()
-        # track()에서 ip 추적하는건 properties에 "ip"키로 추가
-        properties["ip"] = get_ip()
         self._r.mp.track(self._r.tid, event_name, properties)
 
     @_nonblock
     def _enqueue_profile_update(self, email: str, ip: str):
         self._ensure_resource()
-        # people_set()에서 ip 추적하는건 meta에 "ip"키로 추가
         self._r.mp.people_set(self._r.tid, {"$email": email}, meta={"$ip": ip})
         self._r.mp.alias(self._r.tid, email)

--- a/release/scripts/startup/abler/lib/tracker/_mixpanel.py
+++ b/release/scripts/startup/abler/lib/tracker/_mixpanel.py
@@ -118,5 +118,5 @@ class MixpanelTracker(Tracker):
     @_nonblock
     def _enqueue_email_update(self, email: str, ip: str):
         self._ensure_resource()
-        self._r.mp.people_set(self._r.tid, {"$email": email, "$ip": ip})
+        self._r.mp.people_set(self._r.tid, {"$email": email}, meta={"$ip": ip})
         self._r.mp.alias(self._r.tid, email)

--- a/release/scripts/startup/abler/lib/tracker/_sentry.py
+++ b/release/scripts/startup/abler/lib/tracker/_sentry.py
@@ -22,7 +22,7 @@ class SentryTracker(Tracker):
             category="event", message=event_name, timestamp=time.time()
         )
 
-    def _enqueue_email_update(self, email: str, ip: str):
+    def _enqueue_profile_update(self, email: str, ip: str):
         sentry_sdk.set_user({"email": email})
 
 

--- a/release/scripts/startup/abler/lib/tracker/_sentry.py
+++ b/release/scripts/startup/abler/lib/tracker/_sentry.py
@@ -22,7 +22,7 @@ class SentryTracker(Tracker):
             category="event", message=event_name, timestamp=time.time()
         )
 
-    def _enqueue_email_update(self, email: str):
+    def _enqueue_email_update(self, email: str, ip: str):
         sentry_sdk.set_user({"email": email})
 
 

--- a/release/scripts/startup/abler/lib/tracker/_tracker.py
+++ b/release/scripts/startup/abler/lib/tracker/_tracker.py
@@ -135,8 +135,8 @@ class Tracker(metaclass=ABCMeta):
     def login(self):
         self._track(EventKind.login.value)
 
-    def update_profile(self, email: str):
-        self._enqueue_profile_update(email, ip=get_ip())
+    def update_profile(self, email: str, ip: str):
+        self._enqueue_profile_update(email, ip)
 
     def login_fail(self, reason: str):
         self._track(EventKind.login_fail.value, {"reason": reason})

--- a/release/scripts/startup/abler/lib/tracker/_tracker.py
+++ b/release/scripts/startup/abler/lib/tracker/_tracker.py
@@ -85,6 +85,9 @@ class Tracker(metaclass=ABCMeta):
         else:
             self._default_properties["version"] = "development"
 
+        if ip := get_ip():
+            self._default_properties["ip"] = ip
+
     def turn_on(self):
         self._enabled = True
 

--- a/release/scripts/startup/abler/lib/tracker/_tracker.py
+++ b/release/scripts/startup/abler/lib/tracker/_tracker.py
@@ -101,9 +101,9 @@ class Tracker(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def _enqueue_email_update(self, email: str, ip: str):
+    def _enqueue_profile_update(self, email: str, ip: str):
         """
-        Enqueue update of user email.
+        Enqueue update of user email and ip.
 
         Implementations must be asynchronous.
         """
@@ -133,7 +133,7 @@ class Tracker(metaclass=ABCMeta):
         self._track(EventKind.login.value)
 
     def update_profile(self, email: str):
-        self._enqueue_email_update(email, ip=get_ip())
+        self._enqueue_profile_update(email, ip=get_ip())
 
     def login_fail(self, reason: str):
         self._track(EventKind.login_fail.value, {"reason": reason})
@@ -235,7 +235,7 @@ class DummyTracker(Tracker):
     def _enqueue_event(self, event_name: str, properties: dict[str, Any]):
         pass
 
-    def _enqueue_email_update(self, email: str, ip: str):
+    def _enqueue_profile_update(self, email: str, ip: str):
         pass
 
 
@@ -248,6 +248,6 @@ class AggregateTracker(Tracker):
         for t in self.trackers:
             t._enqueue_event(event_name, properties)
 
-    def _enqueue_email_update(self, email: str, ip: str):
+    def _enqueue_profile_update(self, email: str, ip: str):
         for t in self.trackers:
-            t._enqueue_email_update(email, ip)
+            t._enqueue_profile_update(email, ip)

--- a/release/scripts/startup/abler/lib/tracker/_tracker.py
+++ b/release/scripts/startup/abler/lib/tracker/_tracker.py
@@ -74,8 +74,6 @@ def accumulate(interval=0):
 
 
 class Tracker(metaclass=ABCMeta):
-    ip = user_ip
-
     def __init__(self):
         self._agreed = True
         self._default_properties = {}
@@ -87,8 +85,8 @@ class Tracker(metaclass=ABCMeta):
         else:
             self._default_properties["version"] = "development"
 
-        if self.ip is not None:
-            self._default_properties["ip"] = self.ip
+        if user_ip is not None:
+            self._default_properties["ip"] = user_ip
 
     def turn_on(self):
         self._enabled = True

--- a/release/scripts/startup/abler/lib/tracker/_tracker.py
+++ b/release/scripts/startup/abler/lib/tracker/_tracker.py
@@ -100,7 +100,7 @@ class Tracker(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def _enqueue_email_update(self, email: str):
+    def _enqueue_email_update(self, email: str, ip: str):
         """
         Enqueue update of user email.
 
@@ -128,9 +128,9 @@ class Tracker(metaclass=ABCMeta):
         else:
             return True
 
-    def login(self, email: str):
+    def login(self, email: str, ip: str):
         if self._track(EventKind.login.value):
-            self._enqueue_email_update(email)
+            self._enqueue_email_update(email, ip)
 
     def login_fail(self, reason: str):
         self._track(EventKind.login_fail.value, {"reason": reason})
@@ -232,7 +232,7 @@ class DummyTracker(Tracker):
     def _enqueue_event(self, event_name: str, properties: dict[str, Any]):
         pass
 
-    def _enqueue_email_update(self, email: str):
+    def _enqueue_email_update(self, email: str, ip: str):
         pass
 
 
@@ -245,6 +245,6 @@ class AggregateTracker(Tracker):
         for t in self.trackers:
             t._enqueue_event(event_name, properties)
 
-    def _enqueue_email_update(self, email: str):
+    def _enqueue_email_update(self, email: str, ip: str):
         for t in self.trackers:
-            t._enqueue_email_update(email)
+            t._enqueue_email_update(email, ip)

--- a/release/scripts/startup/abler/lib/tracker/_tracker.py
+++ b/release/scripts/startup/abler/lib/tracker/_tracker.py
@@ -74,6 +74,8 @@ def accumulate(interval=0):
 
 
 class Tracker(metaclass=ABCMeta):
+    ip = get_ip()
+
     def __init__(self):
         self._agreed = True
         self._default_properties = {}
@@ -85,8 +87,8 @@ class Tracker(metaclass=ABCMeta):
         else:
             self._default_properties["version"] = "development"
 
-        if ip := get_ip():
-            self._default_properties["ip"] = ip
+        if self.ip is not None:
+            self._default_properties["ip"] = self.ip
 
     def turn_on(self):
         self._enabled = True

--- a/release/scripts/startup/abler/lib/tracker/_tracker.py
+++ b/release/scripts/startup/abler/lib/tracker/_tracker.py
@@ -5,6 +5,7 @@ from typing import Any, Optional
 import bpy
 
 from ._versioning import get_version
+from ._get_ip import get_ip
 
 
 class EventKind(enum.Enum):
@@ -128,9 +129,11 @@ class Tracker(metaclass=ABCMeta):
         else:
             return True
 
-    def login(self, email: str, ip: str):
-        if self._track(EventKind.login.value):
-            self._enqueue_email_update(email, ip)
+    def login(self):
+        self._track(EventKind.login.value)
+
+    def update_profile(self, email: str):
+        self._enqueue_email_update(email, ip=get_ip())
 
     def login_fail(self, reason: str):
         self._track(EventKind.login_fail.value, {"reason": reason})

--- a/release/scripts/startup/abler/lib/tracker/_tracker.py
+++ b/release/scripts/startup/abler/lib/tracker/_tracker.py
@@ -5,7 +5,7 @@ from typing import Any, Optional
 import bpy
 
 from ._versioning import get_version
-from ._get_ip import get_ip
+from ._get_ip import user_ip
 
 
 class EventKind(enum.Enum):
@@ -74,7 +74,7 @@ def accumulate(interval=0):
 
 
 class Tracker(metaclass=ABCMeta):
-    ip = get_ip()
+    ip = user_ip
 
     def __init__(self):
         self._agreed = True


### PR DESCRIPTION
(이전 2.93버전에서 작업한 내용 cherry-pick으로 가져왔습니당)

![image](https://user-images.githubusercontent.com/87409148/176605748-a3305cce-f4bf-4cad-950c-97b803652537.png)
get_ip 함수에서 `try : ip = get("https://api.ipify.org").text`로 ip를 받아오고 _mixpanel.py의 _enqueue_email_update 함수에 ip를 meta데이터에 심어주면 믹스패널에서 자동으로 국가별 트래킹을 해줍니닷!
