### PR TITLE
config 파일 업데이트 시, pre-release 받아오기

### DIFF
--- a/launcher_abler/ConfigUpdater.py
+++ b/launcher_abler/ConfigUpdater.py
@@ -108,10 +108,10 @@ class ConfigSelector:
         Auto update with args
         """
         if "abler" in args.update:
-            self.abler_ver = "0.0.1"
+            self.abler_ver = "0.0.0"
 
         if "launcher" in args.update:
-            self.launcher_ver = "0.0.1"
+            self.launcher_ver = "0.0.0"
 
 
 def main():

--- a/launcher_abler/ConfigUpdater.py
+++ b/launcher_abler/ConfigUpdater.py
@@ -16,7 +16,7 @@ class ConfigSelector:
         self.updater = os.path.join(
             self.home, "AppData\\Roaming\\Blender Foundation\\Blender\\2.96\\updater"
         )
-        self.launcher = os.path.join(self.updater, "AblerLauncher.exe")
+        self.launcher = os.path.join(self.updater, "AblerLauncher.exe --pre-release")
         self.config = os.path.join(self.updater, "config.ini")
         self.config_bak = os.path.join(self.updater, "config.ini.bak")
         self.config_data = []


### PR DESCRIPTION
## 요약

런처에서 `ConfigUpdater.py` 로 업데이트를 할 때, Pre-release를 받아오지 못하고 있어 해당 내용 추가하기
Notion: [런처로 업데이트 할 때 Pre-release 정보 받아오기](https://www.notion.so/acon3d/Pre-release-0b76a4b1240a4f94bb79c07f0bc2856b)


## 수정 사항

- `config.ini` 수정 시, 다운그레이드 버전 0.0.1 → 0.0.0 으로 수정.
- AblerLauncher.exe 실행할 때, `--pre-release` 옵션을 추가해서 프리릴리즈의 설치 정보를 받아올 수 있게함