### PR TITLE
:bug: ADD Accumulate Decorator for preventing multiple use-state tracking

### DIFF
--- a/release/scripts/startup/abler/lib/tracker/_tracker.py
+++ b/release/scripts/startup/abler/lib/tracker/_tracker.py
@@ -181,9 +181,11 @@ class Tracker(metaclass=ABCMeta):
     def fly_mode(self):
         self._track(EventKind.fly_mode.value)
 
+    @accumulate()
     def use_state_on(self):
         self._track(EventKind.use_state_on.value)
 
+    @accumulate()
     def use_state_off(self):
         self._track(EventKind.use_state_off.value)
 


### PR DESCRIPTION
Use State 토글 시 선택된 object 마다 트래킹을 모두 보내서,
해당 부분에 accumulate decorator 를 넣어서 과도하게 트래킹 이벤트를 보내는 것을 방지하였습니다.