### PR TITLE
전체 선택 후 삭제 시 카메라와 Sun은 남기도록 만들기

### DIFF
--- a/release/scripts/presets/keyconfig/keymap_data/abler_default.py
+++ b/release/scripts/presets/keyconfig/keymap_data/abler_default.py
@@ -4093,7 +4093,7 @@ def km_object_mode(params):
     items.extend([
         *_template_items_proportional_editing(
             params, connected=False, toggle_data_path='tool_settings.use_proportional_edit_objects'),
-        *_template_items_select_actions(params, "object.select_all"),
+        *_template_items_select_actions(params, "acon3d.object_select_all"),
         ("acon3d.state_action", {"type": 'E', "value": 'PRESS'},
          {"properties": [("step", 0.25)]}),
         ("acon3d.state_action", {"type": 'E', "value": 'PRESS', "shift": True},

--- a/release/scripts/startup/abler/object_control.py
+++ b/release/scripts/startup/abler/object_control.py
@@ -246,6 +246,41 @@ class Acon3dGroupNavigaionPanel(bpy.types.Panel):
             row.label(text="No selected object")
 
 
+# Camera, Sun 제외 전체 선택
+class ObjectAllSelectOperator(bpy.types.Operator):
+    """Select all objects"""
+
+    bl_idname = "acon3d.object_select_all"
+    bl_label = "Object All Select"
+    bl_translation_context = "*"
+    bl_options = {"REGISTER", "UNDO"}
+    action = ""
+
+    def invoke(self, context, event):
+        key_type = event.type
+        key_value = event.value
+
+        if (key_type == "A" and key_value == "DOUBLE_CLICK") or (
+            key_type == "ESC" and key_value == "PRESS"
+        ):
+            self.action = "DESELECT"
+        elif key_type == "I" and key_value == "PRESS":
+            self.action = "INVERT"
+        elif key_type == "A" and key_value == "PRESS":
+            self.action = "SELECT"
+
+        return self.execute(context)
+
+    def execute(self, context):
+        if self.action == "SELECT":
+            bpy.ops.object.select_by_type(False, type="MESH")
+        # INVERT 는 현재 사용되지 않음
+        elif self.action == "DESELECT" or self.action == "INVERT":
+            bpy.ops.object.select_all(action=self.action)
+
+        return {"FINISHED"}
+
+
 classes = (
     GroupNavigateUpOperator,
     GroupNavigateTopOperator,
@@ -256,6 +291,7 @@ classes = (
     Acon3dObjectPanel,
     ObjectSubPanel,
     Acon3dGroupNavigaionPanel,
+    ObjectAllSelectOperator,
 )
 
 

--- a/release/scripts/startup/abler/object_control.py
+++ b/release/scripts/startup/abler/object_control.py
@@ -275,7 +275,6 @@ class ObjectAllSelectOperator(bpy.types.Operator):
         if self.action == "SELECT":
             bpy.ops.object.select_by_type(extend=False, type="EMPTY")
             bpy.ops.object.select_by_type(extend=True, type="MESH")
-
         # INVERT 는 현재 사용되지 않음
         elif self.action == "DESELECT" or self.action == "INVERT":
             bpy.ops.object.select_all(action=self.action)

--- a/release/scripts/startup/abler/object_control.py
+++ b/release/scripts/startup/abler/object_control.py
@@ -273,7 +273,9 @@ class ObjectAllSelectOperator(bpy.types.Operator):
 
     def execute(self, context):
         if self.action == "SELECT":
-            bpy.ops.object.select_by_type(False, type="MESH")
+            bpy.ops.object.select_by_type(extend=False, type="EMPTY")
+            bpy.ops.object.select_by_type(extend=True, type="MESH")
+
         # INVERT 는 현재 사용되지 않음
         elif self.action == "DESELECT" or self.action == "INVERT":
             bpy.ops.object.select_all(action=self.action)


### PR DESCRIPTION
`ObjectAllSelectOperator` 를 추가하여, 키맵에서 기존에 사용되던 블렌더 내장 `object.select_all` 과 교체하였습니다.

<이슈>
keymap 파일 (`abler_defaults.py`) 에서 넣어주는 `properties` 를 오퍼레이터에서 사용하는 방법을 찾지 못해서, `invoke` 함수를 추가하여, 해당 함수에서 key event 별로 `action`을 나누고, `action` 에 따라 `execute` 시 동작을 분기하였습니다.
