### PR TITLE
새로운 그룹 구조에 맞는 그룹내비게이션 로직으로 수정

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -23,3 +23,6 @@
 	url = https://github.com/ACON3D/QT-Launcher.git
 	branch = main
 	ignore = all
+[submodule "release/scripts/addons_abler/io_skp"]
+	path = release/scripts/addons_abler/io_skp
+	url = git@github.com:ACON3D/SKP_Converter.git

--- a/abler_requirements.txt
+++ b/abler_requirements.txt
@@ -1,3 +1,4 @@
+psd-tools
 mixpanel==4.9.0
 keyboard
 sentry-sdk==1.4.3

--- a/release/scripts/modules/addon_utils.py
+++ b/release/scripts/modules/addon_utils.py
@@ -55,6 +55,9 @@ def paths():
     # if folder addons_contrib/ exists, scripts in there will be loaded too
     addon_paths += _bpy.utils.script_paths(subdir="addons_contrib")
 
+    # ABLER SCRIPTS: customed scripts for abler
+    addon_paths += _bpy.utils.script_paths(subdir="addons_abler")
+
     return addon_paths
 
 

--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -21,6 +21,7 @@ import bpy
 from math import radians
 from .lib import scenes, cameras, shadow, objects
 from .lib.materials import materials_handler
+from . import object_control
 
 
 class AconWindowManagerProperty(bpy.types.PropertyGroup):
@@ -494,8 +495,8 @@ class AconObjectProperty(bpy.types.PropertyGroup):
     group: bpy.props.CollectionProperty(type=AconObjectGroupProperty)
 
     group_list: bpy.props.EnumProperty(
-        name="View",
-        items=objects.add_group_list_from_collection,
+        name="",
+        items=object_control.add_group_list_from_collection,
     )
 
     constraint_to_camera_rotation_z: bpy.props.BoolProperty(

--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -19,6 +19,7 @@
 
 import bpy
 from math import radians
+from .lib.layers import get_first_layer_name_of_object
 from .lib import scenes, cameras, shadow, objects
 from .lib.materials import materials_handler
 from . import object_control
@@ -55,24 +56,77 @@ class CollectionLayerExcludeProperties(bpy.types.PropertyGroup):
         del bpy.types.Scene.l_exclude
 
     def updateLayerVis(self, context):
+        l_exclude = bpy.context.scene.l_exclude
         target_layer = bpy.data.collections[self.name]
-        for objs in target_layer.objects:
-            belonging_col_names = {
-                collection.name for collection in objs.users_collection
-            }
-            should_show = all(
-                layer.value
-                for layer in bpy.context.scene.l_exclude
-                if layer.name in belonging_col_names
-            )
 
-            objs.hide_viewport = not should_show
-            objs.hide_render = not should_show
+        visited = set()
+
+        # 시작 오브젝트의 부모 오브젝트의 상태
+        def get_parent_value(obj):
+            cur = obj.parent
+            while cur:
+                if cur.hide_viewport:
+                    return False
+                cur = cur.parent
+            return True
+
+        # 부모 오브젝트 off => 항상 off,  부모 오브젝트 on => 현재 값으로 결정
+        def update_objects(obj, value: bool):
+            if obj.name in visited:
+                return
+            visited.add(obj.name)
+
+            if value:
+                for l in l_exclude:
+                    if l.name == get_first_layer_name_of_object(obj) and not l.value:
+                        value = False
+                        break
+
+            obj.hide_viewport = not value
+            obj.hide_render = not value
+
+            for o in obj.children:
+                update_objects(o, value)
+
+        for obj in target_layer.objects:
+            value = get_parent_value(obj) and self.value
+            update_objects(obj, value)
 
     def updateLayerLock(self, context):
+        l_exclude = bpy.context.scene.l_exclude
         target_layer = bpy.data.collections[self.name]
-        for objs in target_layer.objects:
-            objs.hide_select = self.lock
+
+        visited = set()
+
+        # 시작 오브젝트의 부모 오브젝트의 상태
+        def get_parent_lock(obj):
+            cur = obj.parent
+            while cur:
+                if cur.hide_select:
+                    return True
+                cur = cur.parent
+            return False
+
+        # 부모 오브젝트 off => 항상 off,  부모 오브젝트 on => 현재 값으로 결정
+        def update_objects(obj, lock: bool):
+            if obj.name in visited:
+                return
+            visited.add(obj.name)
+
+            if not lock:
+                for l in l_exclude:
+                    if l.name == get_first_layer_name_of_object(obj) and l.lock:
+                        lock = True
+                        break
+
+            obj.hide_select = lock
+
+            for o in obj.children:
+                update_objects(o, lock)
+
+        for obj in target_layer.objects:
+            lock = get_parent_lock(obj) or self.lock
+            update_objects(obj, lock)
 
     name: bpy.props.StringProperty(name="Layer Name", default="")
 

--- a/release/scripts/startup/abler/lib/layers.py
+++ b/release/scripts/startup/abler/lib/layers.py
@@ -23,25 +23,94 @@ from bpy.types import Collection, Object
 from typing import Any, List, Optional, Tuple, Union
 
 
-def handleLayerVisibilityOnSceneChange(oldScene, newScene):
+def get_first_layer_name_of_object(obj: Object):
+    collections = obj.users_collection
+    layer_collection = bpy.data.collections.get("Layers")
 
+    if not layer_collection:
+        return None
+
+    for c in collections:
+        if c.name in layer_collection.children:
+            return c.name
+
+    return None
+
+
+def handleLayerVisibilityOnSceneChange(oldScene, newScene):
     if not oldScene or not newScene:
         print("Invalid oldScene / newScene given")
         return
 
-    for i, oldProp in enumerate(oldScene.l_exclude):
-        newProp = newScene.l_exclude[i]
+    visited = set()
 
-        if oldProp.value is not newProp.value:
-            target_layer = bpy.data.collections[newProp.name]
-            for objs in target_layer.objects:
-                objs.hide_viewport = not (newProp.value)
-                objs.hide_render = not (newProp.value)
+    def get_parent_values(obj: Object):
+        cur = obj.parent
+        parent_value = True
+        parent_lock = False
 
-        if oldProp.lock is not newProp.lock:
-            target_layer = bpy.data.collections[newProp.name]
-            for objs in target_layer.objects:
-                objs.hide_select = newProp.lock
+        while cur:
+            if parent_value or not parent_lock:
+                # new scene 에서 변경될 object 의 레이어 정보를 가져옴
+                new_scene_layer = None
+                for l in newScene.l_exclude:
+                    if l.name == get_first_layer_name_of_object(cur):
+                        new_scene_layer = l
+                        break
+                if new_scene_layer:
+                    if parent_value:
+                        parent_value = parent_value and new_scene_layer.value
+                    if not parent_lock:
+                        parent_lock = parent_lock or new_scene_layer.lock
+
+            if not parent_value and parent_lock:
+                return parent_value, parent_lock
+            cur = cur.parent
+        return parent_value, parent_lock
+
+    def update_info(obj: Object, new_value: bool, new_lock: bool):
+        if obj.name in visited:
+            return
+        visited.add(obj.name)
+
+        if new_value is not None:
+            for l in newScene.l_exclude:
+                if l.name == get_first_layer_name_of_object(obj) and not l.value:
+                    new_value = False
+                    break
+
+            obj.hide_viewport = not new_value
+            obj.hide_render = not new_value
+
+        if new_lock is not None:
+            if not new_lock:
+                for l in newScene.l_exclude:
+                    if l.name == get_first_layer_name_of_object(obj) and l.lock:
+                        new_lock = True
+                        break
+
+            obj.hide_select = new_lock
+
+        for o in obj.children:
+            update_info(o, new_value, new_lock)
+
+    for i, oldInfo in enumerate(oldScene.l_exclude):
+        newInfo = newScene.l_exclude[i]
+
+        is_value_equal = oldInfo.value is newInfo.value
+        is_lock_equal = oldInfo.lock is newInfo.lock
+
+        if not is_value_equal or not is_lock_equal:
+            target_layer = bpy.data.collections[newInfo.name]
+
+            new_value = newInfo.value if not is_value_equal else None
+            new_lock = newInfo.lock if not is_lock_equal else None
+
+            for obj in target_layer.objects:
+                parent_value, parent_lock = get_parent_values(obj)
+                new_value = new_value and parent_value
+                new_lock = new_lock or parent_lock
+                update_info(obj, new_value, new_lock)
 
 
 def up(group_list: List[Collection], group_item: Collection) -> Optional[Collection]:

--- a/release/scripts/startup/abler/lib/render.py
+++ b/release/scripts/startup/abler/lib/render.py
@@ -166,13 +166,6 @@ def clearCompositor(scene=None):
 
 
 def matchObjectVisibility():
-
-    for l_prop in bpy.context.scene.l_exclude:
-        if layer := bpy.data.collections.get(l_prop.name):
-            for objs in layer.objects:
-                objs.hide_viewport = not (l_prop.value)
-                objs.hide_render = not (l_prop.value)
-
     for obj in bpy.data.objects:
         if obj.hide_get():
             obj.hide_render = True

--- a/release/scripts/startup/abler/lib/shadow.py
+++ b/release/scripts/startup/abler/lib/shadow.py
@@ -65,7 +65,7 @@ def toggleShadow(self, context: Context) -> None:
         acon_sun.data.use_shadow = prop.toggle_shadow
 
 
-def setupSharpShadow():
+def setupClearShadow():
     bpy.context.scene.eevee.shadow_cube_size = "4096"
     bpy.context.scene.eevee.shadow_cascade_size = "4096"
     bpy.context.scene.eevee.use_soft_shadows = True
@@ -76,16 +76,25 @@ def setupSharpShadow():
         acon_sun = createAconSun()
     if acon_sun.data.type == "SUN":
         acon_sun.data.angle = 0
-        acon_sun.data.use_contact_shadow = 1
+
+    # 오브젝트의 그림자가 아닌 옵션에 의한 그림자는 "불량 그림자"로 판단하고 해당 옵션 off
+    # 그림자가 생기는 면과 붙어 있지 않고 떠있는 느낌을 지우기 위해 bias를 오류가 나지 않을 정도로 조정
+    # createAconSun(), startup.blend에도 같은 작업 수행
+    acon_sun.data.use_contact_shadow = False
+    acon_sun.data.shadow_buffer_bias = 0.1
 
 
 def createAconSun() -> Object:
     acon_sun_data: Light = bpy.data.lights.new("ACON_sun", type="SUN")
     acon_sun_data.energy = 1
+
     acon_sun: Object = bpy.data.objects.new("ACON_sun", acon_sun_data)
     acon_sun.rotation_euler.x = math.radians(90 - 35)
     acon_sun.rotation_euler.y = 0
     acon_sun.rotation_euler.z = math.radians(65)
+    acon_sun.data.use_contact_shadow = False
+    acon_sun.data.shadow_buffer_bias = 0.1
+
     bpy.context.scene.collection.objects.link(acon_sun)
 
     return acon_sun

--- a/release/scripts/startup/abler/object_control.py
+++ b/release/scripts/startup/abler/object_control.py
@@ -131,6 +131,11 @@ class GroupNavigationManager:
 
 
 class ProgrammaticSelectionScope:
+    """
+    msgbus 콜백이 다음 이벤트 루프에 실행되는 문제가 있어서,
+    실행을 지연시키기 위하여 실행 블록을 잡아주는 클래스
+    """
+
     def __init__(self, manager: GroupNavigationManager):
         self._manager = manager
 
@@ -139,7 +144,6 @@ class ProgrammaticSelectionScope:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         def delayed():
-            """msgbus 콜백이 다음 이벤트 루프에 실행되는 문제가 있어서, 실행을 지연시킴"""
             self._manager._user_event_disabled = False
 
         bpy.app.timers.register(delayed, first_interval=0.01)

--- a/release/scripts/startup/abler/object_control.py
+++ b/release/scripts/startup/abler/object_control.py
@@ -70,24 +70,6 @@ class GroupNavigationManager:
     def __repr__(self):
         return repr(self._selection_undo_stack)
 
-    def install_handler(self):
-        subscribe_to = bpy.types.LayerObjects, "active"
-
-        bpy.msgbus.subscribe_rna(
-            key=subscribe_to,
-            owner=self,
-            args=(),
-            notify=lambda: self.on_active_object_changed())
-
-    def uninstall_handler(self):
-        bpy.msgbus.clear_by_owner(self)
-
-    def on_active_object_changed(self):
-        if self._user_event_disabled:
-            return
-        self._selection_undo_stack.clear()
-        select_active_and_descendants()
-
     def go_top(self):
         obj = bpy.context.active_object
         if obj.parent:

--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -49,7 +49,7 @@ def load_handler(dummy):
         cameras.makeSureCameraExists()
         cameras.switchToRendredView()
         cameras.turnOnCameraView(False)
-        shadow.setupSharpShadow()
+        shadow.setupClearShadow()
         render.setupBackgroundImagesCompositor()
         materials_setup.applyAconToonStyle()
         for scene in bpy.data.scenes:


### PR DESCRIPTION
## 변경 내용
- Parent-Child 구조의 그룹 구조에 알맞게 작동하도록 기 작동하던 그룹내비게이션 로직을 수정했습니다.
## 기대 효과
- 아래에 있는 링크에 있는 변경내역이 적용되어도 문제없이 그룹 내비게이션이 사용될 수 있도록 함
## 테스트 시나리오
- 아래에 있는 링크의 최신 상태로 io_skp 레포를 업데이트한다.
- 빌드를 하고 실행한다.
- import_skp를 이용해서 skp 파일을 임포트 한다.
- 오브젝트를 선택하고나서 Object Control 패널 아래에 있는 Group Navigation 화살표 버튼들을 이용해서 최상위, 상위, 하위, 최하위 그룹들을 선택한다.


https://github.com/ACON3D/SKP_Converter/pull/63


### 주의: **아직은 머지금지!**
