### PR TITLE
최근 파일 열기를 커스텀 오퍼레이터로 교체

### DIFF
--- a/release/scripts/presets/keyconfig/keymap_data/abler_default.py
+++ b/release/scripts/presets/keyconfig/keymap_data/abler_default.py
@@ -414,7 +414,7 @@ def km_window(params):
     items.extend([
         # File operations
         op_menu("TOPBAR_MT_file_new", {"type": 'N', "value": 'PRESS', "ctrl": True}),
-        op_menu("ACON3D_TOPBAR_MT_open_recent_files", {"type": 'O', "value": 'PRESS', "shift": True, "ctrl": True}),
+        op_menu("TOPBAR_MT_ACON3D_open_recent_files", {"type": 'O', "value": 'PRESS', "shift": True, "ctrl": True}),
         ("acon3d.file_open", {"type": 'O', "value": 'PRESS', "ctrl": True}, None),
         ("acon3d.save", {"type": 'S', "value": 'PRESS', "ctrl": True}, None),
         ("acon3d.save_as", {"type": 'S', "value": 'PRESS', "shift": True, "ctrl": True}, None),

--- a/release/scripts/presets/keyconfig/keymap_data/abler_default.py
+++ b/release/scripts/presets/keyconfig/keymap_data/abler_default.py
@@ -414,7 +414,7 @@ def km_window(params):
     items.extend([
         # File operations
         op_menu("TOPBAR_MT_file_new", {"type": 'N', "value": 'PRESS', "ctrl": True}),
-        op_menu("TOPBAR_MT_file_open_recent", {"type": 'O', "value": 'PRESS', "shift": True, "ctrl": True}),
+        op_menu("ACON3D_TOPBAR_MT_open_recent_files", {"type": 'O', "value": 'PRESS', "shift": True, "ctrl": True}),
         ("acon3d.file_open", {"type": 'O', "value": 'PRESS', "ctrl": True}, None),
         ("acon3d.save", {"type": 'S', "value": 'PRESS', "ctrl": True}, None),
         ("acon3d.save_as", {"type": 'S', "value": 'PRESS', "shift": True, "ctrl": True}, None),

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -200,7 +200,6 @@ class FileRecentOpenOperator(bpy.types.Operator, BaseFileOpenOperator):
     bl_idname = "acon3d.recent_file_open"
     bl_label = ""
     bl_translation_context = "*"
-    bl_description = "Hello"
 
     @classmethod
     def description(cls, context, properties):

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -205,6 +205,9 @@ class FileRecentOpenOperator(bpy.types.Operator, BaseFileOpenOperator):
     def description(cls, context, properties):
         filepath = properties.filepath
 
+        if not os.path.isfile(filepath):
+            return "File not found"
+
         modified_datetime = datetime.fromtimestamp(os.path.getmtime(filepath))
         time_distance = datetime.today().date() - modified_datetime.date()
 

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -208,7 +208,7 @@ class FileRecentOpenOperator(bpy.types.Operator, BaseFileOpenOperator):
         filepath = properties.filepath
 
         if not os.path.isfile(filepath):
-            return "File not found"
+            return f"{filepath}\n\nFile Not Found"
 
         modified_datetime = datetime.fromtimestamp(os.path.getmtime(filepath))
         time_distance = datetime.today().date() - modified_datetime.date()

--- a/release/scripts/startup/bl_ui/space_topbar.py
+++ b/release/scripts/startup/bl_ui/space_topbar.py
@@ -17,6 +17,7 @@
 # ##### END GPL LICENSE BLOCK #####
 
 # <pep8 compliant>
+import os
 import bpy
 from bpy.types import Header, Menu, Panel
 
@@ -288,7 +289,7 @@ class TOPBAR_MT_file(Menu):
         layout.operator_context = 'INVOKE_AREA'
         layout.menu("TOPBAR_MT_file_new", text="New", icon='FILE_NEW')
         layout.operator("acon3d.file_open", text="Open...", icon='FILE_FOLDER')
-        layout.menu("TOPBAR_MT_file_open_recent")
+        layout.menu("ACON3D_TOPBAR_MT_open_recent_files")
         layout.operator("wm.revert_mainfile")
         layout.menu("TOPBAR_MT_file_recover")
 
@@ -394,6 +395,22 @@ class TOPBAR_MT_file_new(Menu):
 
     def draw(self, context):
         TOPBAR_MT_file_new.draw_ex(self.layout, context)
+
+class ACON3D_TOPBAR_MT_open_recent_files(Menu):
+    bl_label = "Open Recent"
+
+    def draw(self, _context):
+        layout = self.layout
+
+        history_path = bpy.utils.user_resource("CONFIG") + "/recent-files.txt"
+
+        with open(history_path, "r") as f:
+            recent_filepaths = f.read().splitlines()
+
+        for filepath in recent_filepaths:
+            filename = os.path.basename(filepath)
+            layouts = layout.operator("acon3d.recent_file_open", text=filename, icon='FILE_BLEND')
+            layouts.filepath = filepath
 
 
 class TOPBAR_MT_file_recover(Menu):
@@ -869,6 +886,7 @@ classes = (
     TOPBAR_MT_blender_system,
     TOPBAR_MT_file,
     TOPBAR_MT_file_new,
+    ACON3D_TOPBAR_MT_open_recent_files,
     TOPBAR_MT_file_recover,
     TOPBAR_MT_file_defaults,
     TOPBAR_MT_templates_more,

--- a/release/scripts/startup/bl_ui/space_topbar.py
+++ b/release/scripts/startup/bl_ui/space_topbar.py
@@ -404,13 +404,20 @@ class TOPBAR_MT_ACON3D_open_recent_files(Menu):
 
         history_path = bpy.utils.user_resource("CONFIG") + "/recent-files.txt"
 
-        with open(history_path, "r") as f:
-            recent_filepaths = f.read().splitlines()
+        try:
+            with open(history_path, "r") as f:
+                recent_filepaths = f.read().splitlines()
+
+            if len(recent_filepaths) == 0:
+                raise
+        except:
+            layout.label(text='No Recent Files')
+            return
 
         for filepath in recent_filepaths:
             filename = os.path.basename(filepath)
-            layouts = layout.operator("acon3d.recent_file_open", text=filename, icon='FILE_BLEND')
-            layouts.filepath = filepath
+            sublayout = layout.operator("acon3d.recent_file_open", text=filename, icon='FILE_BLEND')
+            sublayout.filepath = filepath
 
 
 class TOPBAR_MT_file_recover(Menu):

--- a/release/scripts/startup/bl_ui/space_topbar.py
+++ b/release/scripts/startup/bl_ui/space_topbar.py
@@ -289,7 +289,7 @@ class TOPBAR_MT_file(Menu):
         layout.operator_context = 'INVOKE_AREA'
         layout.menu("TOPBAR_MT_file_new", text="New", icon='FILE_NEW')
         layout.operator("acon3d.file_open", text="Open...", icon='FILE_FOLDER')
-        layout.menu("ACON3D_TOPBAR_MT_open_recent_files")
+        layout.menu("TOPBAR_MT_ACON3D_open_recent_files")
         layout.operator("wm.revert_mainfile")
         layout.menu("TOPBAR_MT_file_recover")
 
@@ -396,7 +396,7 @@ class TOPBAR_MT_file_new(Menu):
     def draw(self, context):
         TOPBAR_MT_file_new.draw_ex(self.layout, context)
 
-class ACON3D_TOPBAR_MT_open_recent_files(Menu):
+class TOPBAR_MT_ACON3D_open_recent_files(Menu):
     bl_label = "Open Recent"
 
     def draw(self, _context):
@@ -886,7 +886,7 @@ classes = (
     TOPBAR_MT_blender_system,
     TOPBAR_MT_file,
     TOPBAR_MT_file_new,
-    ACON3D_TOPBAR_MT_open_recent_files,
+    TOPBAR_MT_ACON3D_open_recent_files,
     TOPBAR_MT_file_recover,
     TOPBAR_MT_file_defaults,
     TOPBAR_MT_templates_more,


### PR DESCRIPTION
믹스패널 트래킹을 위해 "최근 파일 열기"를 커스텀 오퍼레이터로 교체하였습니다.

기존 "최근 파일 열기" 기능과 최대한 디자인을 비슷하게 유지시켰습니다.

![기존](https://user-images.githubusercontent.com/39782865/179897526-a35f498f-ae47-411a-afc0-66fe74f00798.png)
기존

![이번 브랜치](https://user-images.githubusercontent.com/39782865/179897643-7015da42-48d0-4b28-ac8d-5305ef1a1cee.png)
이번 브랜치

