### PR TITLE
배경이미지 Custom Image 버튼 추가 및 UI 변경

### DIFF
--- a/release/scripts/startup/abler/camera_control.py
+++ b/release/scripts/startup/abler/camera_control.py
@@ -300,10 +300,10 @@ class Acon3dBackgroundPanel(bpy.types.Panel):
         layout.use_property_decorate = False
 
         if camObj is not None:
-            cam = camObj.data
+            background_images = camObj.data.background_images
 
-            l = len(cam.background_images)
-            for i, bg in enumerate(reversed(cam.background_images)):
+            l = len(background_images)
+            for i, bg in enumerate(reversed(background_images)):
                 count = l - i - 1
 
                 box = layout.box()

--- a/release/scripts/startup/abler/camera_control.py
+++ b/release/scripts/startup/abler/camera_control.py
@@ -290,19 +290,9 @@ class Acon3dBackgroundPanel(bpy.types.Panel):
     bl_region_type = "UI"
     bl_options = {"DEFAULT_CLOSED"}
 
-    def draw_header(self, context):
-        toggle_texture = context.scene.ACON_prop.toggle_texture
-
-        if context.scene.camera is not None and toggle_texture:
-            scene = context.scene
-            self.layout.prop(scene.ACON_prop, "show_background_images", text="")
-        else:
-            self.layout.active = False
-
     def draw(self, context):
         layout = self.layout
         layout.operator("view3d.background_image_add", text="Add Image", text_ctxt="*")
-        layout.enabled = context.scene.ACON_prop.show_background_images
 
         camObj = context.scene.camera
         active = camObj and camObj.data.show_background_images
@@ -311,9 +301,7 @@ class Acon3dBackgroundPanel(bpy.types.Panel):
         layout.use_property_split = True
         layout.use_property_decorate = False
 
-        toggle_texture = context.scene.ACON_prop.toggle_texture
-
-        if context.scene.camera is not None and toggle_texture:
+        if context.scene.camera is not None:
             cam = context.scene.camera.data
 
             for i, bg in enumerate(cam.background_images):

--- a/release/scripts/startup/abler/camera_control.py
+++ b/release/scripts/startup/abler/camera_control.py
@@ -263,7 +263,6 @@ class OpenCustomBackgroundOperator(bpy.types.Operator, ImportHelper):
 
     index: bpy.props.IntProperty(name="Index", default=0, options={"HIDDEN"})
     filter_glob: bpy.props.StringProperty(default="*.png", options={"HIDDEN"})
-    filepath: bpy.props.StringProperty()
 
     def execute(self, context):
         new_image = bpy.data.images.load(self.filepath)
@@ -271,21 +270,15 @@ class OpenCustomBackgroundOperator(bpy.types.Operator, ImportHelper):
         image.image = new_image
         return {"FINISHED"}
 
-    def invoke(self, context, event):
-        path_abler = bpy.utils.preset_paths("abler")[0]
-        self.filepath = path_abler + "/Background_Image/"
-        wm = context.window_manager.fileselect_add(self)
-        return {"RUNNING_MODAL"}
-
     def draw(self, context):
         # FileBrowser UI 변경
         space = context.space_data
         params = space.params
 
         params.display_type = "THUMBNAIL"
+        params.sort_method = "FILE_SORT_TIME"
+        params.use_sort_invert = True
         space.show_region_tool_props = False
-        space.show_region_ui = False
-        space.show_region_toolbar = False
 
 
 class Acon3dBackgroundPanel(bpy.types.Panel):
@@ -349,7 +342,6 @@ class Acon3dBackgroundPanel(bpy.types.Panel):
                     row.operator(
                         "acon3d.custom_background_image_open", text="Custom Image"
                     ).index = i
-                    row.operator("")
                     row = box.row()
                     row.prop(bg, "alpha")
                     row = box.row()

--- a/release/scripts/startup/abler/camera_control.py
+++ b/release/scripts/startup/abler/camera_control.py
@@ -295,14 +295,12 @@ class Acon3dBackgroundPanel(bpy.types.Panel):
         layout.operator("view3d.background_image_add", text="Add Image", text_ctxt="*")
 
         camObj = context.scene.camera
-        active = camObj and camObj.data.show_background_images
 
-        layout.active = active
         layout.use_property_split = True
         layout.use_property_decorate = False
 
-        if context.scene.camera is not None:
-            cam = context.scene.camera.data
+        if camObj is not None:
+            cam = camObj.data
 
             l = len(cam.background_images)
             for i, bg in enumerate(reversed(cam.background_images)):

--- a/release/scripts/startup/abler/camera_control.py
+++ b/release/scripts/startup/abler/camera_control.py
@@ -261,8 +261,9 @@ class OpenCustomBackgroundOperator(bpy.types.Operator, ImportHelper):
     bl_translation_context = "*"
     bl_options = {"REGISTER", "UNDO"}
 
+    image_extension = "*.png;*.jpg;*psd"
     index: bpy.props.IntProperty(name="Index", default=0, options={"HIDDEN"})
-    filter_glob: bpy.props.StringProperty(default="*.png", options={"HIDDEN"})
+    filter_glob: bpy.props.StringProperty(default=image_extension, options={"HIDDEN"})
 
     def execute(self, context):
         new_image = bpy.data.images.load(self.filepath)

--- a/release/scripts/startup/abler/camera_control.py
+++ b/release/scripts/startup/abler/camera_control.py
@@ -218,11 +218,46 @@ class RemoveBackgroundOperator(bpy.types.Operator):
         return {"FINISHED"}
 
 
-class OpenBackgroundOperator(bpy.types.Operator, ImportHelper):
-    """Open Background Image"""
+class OpenDefaultBackgroundOperator(bpy.types.Operator, ImportHelper):
+    """Open Default Background Image"""
 
-    bl_idname = "acon3d.background_image_open"
-    bl_label = "Open Image"
+    bl_idname = "acon3d.default_background_image_open"
+    bl_label = "Default Image"
+    bl_translation_context = "*"
+    bl_options = {"REGISTER", "UNDO"}
+
+    index: bpy.props.IntProperty(name="Index", default=0, options={"HIDDEN"})
+    filter_glob: bpy.props.StringProperty(default="*.png", options={"HIDDEN"})
+    filepath: bpy.props.StringProperty()
+
+    def execute(self, context):
+        new_image = bpy.data.images.load(self.filepath)
+        image = context.scene.camera.data.background_images[self.index]
+        image.image = new_image
+        return {"FINISHED"}
+
+    def invoke(self, context, event):
+        path_abler = bpy.utils.preset_paths("abler")[0]
+        self.filepath = path_abler + "/Background_Image/"
+        wm = context.window_manager.fileselect_add(self)
+        return {"RUNNING_MODAL"}
+
+    def draw(self, context):
+        # FileBrowser UI 변경
+        space = context.space_data
+        params = space.params
+
+        params.display_type = "THUMBNAIL"
+        space.show_region_tool_props = False
+        space.show_region_ui = False
+        space.show_region_toolbar = False
+
+
+class OpenCustomBackgroundOperator(bpy.types.Operator, ImportHelper):
+    """Open Custom Background Image"""
+
+    bl_idname = "acon3d.custom_background_image_open"
+    bl_label = "Custom Image"
     bl_translation_context = "*"
     bl_options = {"REGISTER", "UNDO"}
 
@@ -308,7 +343,13 @@ class Acon3dBackgroundPanel(bpy.types.Panel):
 
                 if bg.show_expanded:
                     row = box.row()
-                    row.operator("acon3d.background_image_open", text="Open").index = i
+                    row.operator(
+                        "acon3d.default_background_image_open", text="Default Image"
+                    ).index = i
+                    row.operator(
+                        "acon3d.custom_background_image_open", text="Custom Image"
+                    ).index = i
+                    row.operator("")
                     row = box.row()
                     row.prop(bg, "alpha")
                     row = box.row()
@@ -333,7 +374,8 @@ classes = (
     DeleteCameraOperator,
     Acon3dDOFPanel,
     RemoveBackgroundOperator,
-    OpenBackgroundOperator,
+    OpenDefaultBackgroundOperator,
+    OpenCustomBackgroundOperator,
     Acon3dBackgroundPanel,
 )
 

--- a/release/scripts/startup/abler/camera_control.py
+++ b/release/scripts/startup/abler/camera_control.py
@@ -304,7 +304,10 @@ class Acon3dBackgroundPanel(bpy.types.Panel):
         if context.scene.camera is not None:
             cam = context.scene.camera.data
 
-            for i, bg in enumerate(cam.background_images):
+            l = len(cam.background_images)
+            for i, bg in enumerate(reversed(cam.background_images)):
+                count = l - i - 1
+
                 box = layout.box()
                 row = box.row(align=True)
                 row.prop(bg, "show_expanded", text="", emboss=False)
@@ -320,16 +323,16 @@ class Acon3dBackgroundPanel(bpy.types.Panel):
 
                 row.operator(
                     "acon3d.background_image_remove", text="", emboss=False, icon="X"
-                ).index = i
+                ).index = count
 
                 if bg.show_expanded:
                     row = box.row()
                     row.operator(
                         "acon3d.default_background_image_open", text="Default Image"
-                    ).index = i
+                    ).index = count
                     row.operator(
                         "acon3d.custom_background_image_open", text="Custom Image"
-                    ).index = i
+                    ).index = count
                     row = box.row()
                     row.prop(bg, "alpha")
                     row = box.row()

--- a/release/scripts/startup/abler/lib/post_open.py
+++ b/release/scripts/startup/abler/lib/post_open.py
@@ -52,11 +52,14 @@ def hide_adjust_last_operation_panel():
 
 
 def add_dummy_background_image():
-    # 배경이미지 토글을 열었을 때 패널이 이미 존재하게 하기 위해
-    # 빈 배경이미지를 하나 추가
+    # 배경이미지 토글을 열었을 때 패널이 이미 존재하게 하기 위해 빈 배경이미지를 하나 추가
     for area in bpy.context.screen.areas:
         if area.type == "VIEW_3D":
+            # 마우스 위치가 VIEW_3D가 아닌경우 poll()에러가 뜨므로 override해서 현재 가리키고 있는 위치를 조작
+            # https://blender.stackexchange.com/questions/6101/poll-failed-context-incorrect-example-bpy-ops-view3d-background-image-add
             override = bpy.context.copy()
             override["area"] = area
             bpy.ops.view3d.background_image_add(override, name="", filepath="")
             break
+
+    bpy.context.scene.camera.data.show_background_images = True

--- a/release/scripts/startup/abler/lib/post_open.py
+++ b/release/scripts/startup/abler/lib/post_open.py
@@ -53,13 +53,16 @@ def hide_adjust_last_operation_panel():
 
 def add_dummy_background_image():
     # 배경이미지 토글을 열었을 때 패널이 이미 존재하게 하기 위해 빈 배경이미지를 하나 추가
-    for area in bpy.context.screen.areas:
-        if area.type == "VIEW_3D":
-            # 마우스 위치가 VIEW_3D가 아닌경우 poll()에러가 뜨므로 override해서 현재 가리키고 있는 위치를 조작
-            # https://blender.stackexchange.com/questions/6101/poll-failed-context-incorrect-example-bpy-ops-view3d-background-image-add
-            override = bpy.context.copy()
-            override["area"] = area
-            bpy.ops.view3d.background_image_add(override, name="", filepath="")
-            break
+
+    context = bpy.context
+    if not len(context.scene.camera.data.background_images):
+        for area in context.screen.areas:
+            if area.type == "VIEW_3D":
+                # 마우스 위치가 VIEW_3D가 아닌경우 poll()에러가 뜨므로 override해서 현재 가리키고 있는 위치를 조작
+                # https://blender.stackexchange.com/questions/6101/poll-failed-context-incorrect-example-bpy-ops-view3d-background-image-add
+                override = bpy.context.copy()
+                override["area"] = area
+                bpy.ops.view3d.background_image_add(override, name="", filepath="")
+                break
 
     bpy.context.scene.camera.data.show_background_images = True

--- a/release/scripts/startup/abler/lib/post_open.py
+++ b/release/scripts/startup/abler/lib/post_open.py
@@ -49,3 +49,14 @@ def hide_adjust_last_operation_panel():
             for space in area.spaces:
                 if space.type == "VIEW_3D":
                     space.show_region_hud = False
+
+
+def add_dummy_background_image():
+    # 배경이미지 토글을 열었을 때 패널이 이미 존재하게 하기 위해
+    # 빈 배경이미지를 하나 추가
+    for area in bpy.context.screen.areas:
+        if area.type == "VIEW_3D":
+            override = bpy.context.copy()
+            override["area"] = area
+            bpy.ops.view3d.background_image_add(override, name="", filepath="")
+            break

--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -63,6 +63,7 @@ def load_handler(dummy):
         post_open.update_scene()
         post_open.update_layers()
         post_open.hide_adjust_last_operation_panel()
+        post_open.add_dummy_background_image()
     finally:
         tracker.turn_on()
 


### PR DESCRIPTION

<img width="213" alt="스크린샷 2022-07-22 오후 3 44 25" src="https://user-images.githubusercontent.com/87409148/180379680-308819a1-66eb-4f81-bfe1-839c7cdfa808.png">

- [x] Default Image 버튼 옆 Custom Image 버튼을 추가
- [x] Background Images를 항상 활성화 상태로 두고 체크박스를 없앤다
- [x] 토글이 최초로 열렸을 때 배경이미지 패널이 이미 존재하도록 한다
- [x] Background Images 토글 하위에서 ‘Add Images’를 클릭할 경우 새로 생성되는 배경이미지 패널은 최신순이 위로 오도록 정렬한다
- [ ] Recent 토글만 닫은 채로 제공한다 -> 개발공수가 오버된다고 판단돼 빼기로 얘기했습니다.(노션문서 참고)

노션 문서 : https://www.notion.so/acon3d/ABLER-b404afd77b0c4ec8ab4c581e85a29541
