### PR TITLE
최근 파일 리스트 갱신 안되는 오류

### DIFF
--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -224,6 +224,23 @@ class ToggleToolbarOperator(bpy.types.Operator):
         return {"FINISHED"}
 
 
+def delete_path_from_recent_files(target_path):
+    history_path = bpy.utils.user_resource("CONFIG") + "/recent-files.txt"
+
+    try:
+        with open(history_path) as fin:
+            recent_filepaths_except_target = [
+                path for path in fin.read().splitlines() if path != target_path
+            ]
+
+        with open(history_path, "wt") as fout:
+            fout.write("\n".join(recent_filepaths_except_target))
+
+    except Exception as e:
+        print(e)
+        return
+
+
 class BaseFileOpenOperator:
     filepath: bpy.props.StringProperty(name="text", default="")
 
@@ -239,6 +256,7 @@ class BaseFileOpenOperator:
                     title="File not found",
                     message_1="Selected file does not exist",
                 )
+                delete_path_from_recent_files(path)
                 tracker.file_open_fail()
                 return
 

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -243,7 +243,7 @@ class BaseFileOpenOperator:
                 return
 
             bpy.ops.wm.open_mainfile(
-                "INVOKE_DEFAULT", filepath=path, display_file_selector=False
+                "INVOKE_DEFAULT", True, filepath=path, display_file_selector=False
             )
 
         except:
@@ -381,7 +381,9 @@ class SaveAsOperator(bpy.types.Operator, ExportHelper):
 
             self.filepath = f"{numbered_filepath}{self.filename_ext}"
 
-            bpy.ops.wm.save_as_mainfile({"dict": "override"}, filepath=self.filepath)
+            bpy.ops.wm.save_as_mainfile(
+                {"dict": "override"}, True, filepath=self.filepath
+            )
             self.report({"INFO"}, f'Saved "{numbered_filename}{self.filename_ext}"')
 
         except Exception as e:

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -360,7 +360,9 @@ class SaveOperator(bpy.types.Operator, ExportHelper):
                 self.filepath = context.blend_data.filepath
                 dirname, basename = split_filepath(self.filepath)
 
-                bpy.ops.wm.save_mainfile({"dict": "override"}, filepath=self.filepath)
+                bpy.ops.wm.save_mainfile(
+                    {"dict": "override"}, True, filepath=self.filepath
+                )
                 self.report({"INFO"}, f'Saved "{basename}{self.filename_ext}"')
 
             else:
@@ -370,7 +372,9 @@ class SaveOperator(bpy.types.Operator, ExportHelper):
 
                 self.filepath = f"{numbered_filepath}{self.filename_ext}"
 
-                bpy.ops.wm.save_mainfile({"dict": "override"}, filepath=self.filepath)
+                bpy.ops.wm.save_mainfile(
+                    {"dict": "override"}, True, filepath=self.filepath
+                )
                 self.report({"INFO"}, f'Saved "{numbered_filename}{self.filename_ext}"')
 
         except Exception as e:


### PR DESCRIPTION
[노션 링크](https://www.notion.so/acon3d/4c95cdda7e1f4144b767ca72e66e1fc7)

## 발제/내용

### **어떤 현상이 발생하고 있었나요? 가능하다면 스크린샷/영상을 첨부해주세요.**

- 블렌더와 다르게, 에이블러 내에서
Save as, Open File (v.0.2.3)
Save as, Open File, Open Recent (ABLER/main)
동작 시 최근 파일 리스트가 갱신되고 있지 않습니다.

![image](https://user-images.githubusercontent.com/39782865/181216861-67897f93-0d27-42af-bc05-f2c293a6b745.png)

|  | ABLER (as-is) | BLENDER (to-be) | Custom Operator 사용 여부 |
| --- | --- | --- | --- |
| Open (Recent) File | X | O (리스트 최상단) | O |
| Open (Recent) File - 변경사항 있을 때 (모달 띄워질 때) | O | O (리스트 최상단) | O |
| Open Recent - File Not Found | X | O (리스트에서 삭제) | O |
| Save as | X | O (리스트 최상단) | O |
| 파일로 프로그램을 여는 경우 | O | O (리스트 최상단) | X |

## 대응

### **재현 방법이 어떻게 되나요?**

- Save as, Open File (v.0.2.3)
Save as, Open File, Open Recent (ABLER/main) 동작 수행
- File → Open Recent 내의 파일들이 갱신되었는지 확인한다.

### 그래서 이 현상은 1)언제부터 2)어디에서 3)어떤 이유로 생겼나요?

- 기존 블렌더의 동작을 저희 커스텀 오퍼레이터로 교체하면서 생긴 이슈 같습니다.

### 어떤 조치를 취했나요?
- bpy.wm.open_mainfile, bpy.wm.save_as_mainfile 에 True 를 추가하였습니다.
- delete_path_from_recent_files 함수를 만들어서 파일이 없는 경우 최근 파일에서 지우도록 했습니다.