### PR TITLE
[QA] bloom property ACON_prop으로 교체

### DIFF
--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -402,6 +402,42 @@ class AconSceneProperty(bpy.types.PropertyGroup):
         update=bloom.change_bloom_threshold,
     )
 
+    bloom_knee: bpy.props.FloatProperty(
+        name="",
+        description="Makes transition between under/over-threshold gradual",
+        default=0.5,
+        min=0,
+        max=1.0,
+        update=bloom.change_bloom_knee,
+    )
+
+    bloom_radius: bpy.props.FloatProperty(
+        name="",
+        description="Bloom spread distance",
+        default=4.0,
+        min=0,
+        max=10.0,
+        update=bloom.change_bloom_radius,
+    )
+
+    bloom_intensity: bpy.props.FloatProperty(
+        name="",
+        description="Blend factor",
+        default=0.05,
+        min=0,
+        max=1.0,
+        update=bloom.change_bloom_intensity,
+    )
+
+    bloom_clamp: bpy.props.FloatProperty(
+        name="",
+        description="Maximum intensity a bloom pixel can have (0 to disabled)",
+        default=0,
+        min=0,
+        max=1000.0,
+        update=bloom.change_bloom_clamp,
+    )
+
 
 class AconMaterialProperty(bpy.types.PropertyGroup):
     @classmethod

--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -19,7 +19,7 @@
 
 import bpy
 from math import radians
-from .lib import scenes, cameras, shadow, objects
+from .lib import scenes, cameras, shadow, objects, bloom
 from .lib.materials import materials_handler
 from .lib.read_cookies import *
 
@@ -391,6 +391,15 @@ class AconSceneProperty(bpy.types.PropertyGroup):
         description="Create a shining effect with high luminance pixels",
         default=True,
         update=scenes.change_bloom,
+    )
+
+    bloom_threshold: bpy.props.FloatProperty(
+        name="",
+        description="Filters out pixels under this level of brightness",
+        default=1.0,
+        min=0,
+        max=10.0,
+        update=bloom.change_bloom_threshold,
     )
 
 

--- a/release/scripts/startup/abler/face_control.py
+++ b/release/scripts/startup/abler/face_control.py
@@ -233,11 +233,11 @@ class Acon3dBloomPanel(bpy.types.Panel):
         layout.active = props.use_bloom
         col = layout.column()
         col.prop(prop, "bloom_threshold", text="Threshold", slider=True)
-        col.prop(props, "bloom_knee")
-        col.prop(props, "bloom_radius")
+        col.prop(prop, "bloom_knee", text="Knee", slider=True)
+        col.prop(prop, "bloom_radius", text="Radius", slider=True)
         col.prop(props, "bloom_color")
-        col.prop(props, "bloom_intensity")
-        col.prop(props, "bloom_clamp")
+        col.prop(prop, "bloom_intensity", text="Intensity", slider=True)
+        col.prop(prop, "bloom_clamp", text="Clamp", slider=True)
 
 
 classes = (

--- a/release/scripts/startup/abler/face_control.py
+++ b/release/scripts/startup/abler/face_control.py
@@ -227,15 +227,15 @@ class Acon3dBloomPanel(bpy.types.Panel):
         layout.use_property_decorate = False  # No animation.
 
         scene = context.scene
-        props = scene.eevee
+        eevee_prop = scene.eevee
         prop = scene.ACON_prop
 
-        layout.active = props.use_bloom
+        layout.active = eevee_prop.use_bloom
         col = layout.column()
         col.prop(prop, "bloom_threshold", text="Threshold", slider=True)
         col.prop(prop, "bloom_knee", text="Knee", slider=True)
         col.prop(prop, "bloom_radius", text="Radius", slider=True)
-        col.prop(props, "bloom_color")
+        col.prop(eevee_prop, "bloom_color")
         col.prop(prop, "bloom_intensity", text="Intensity", slider=True)
         col.prop(prop, "bloom_clamp", text="Clamp", slider=True)
 

--- a/release/scripts/startup/abler/face_control.py
+++ b/release/scripts/startup/abler/face_control.py
@@ -224,13 +224,15 @@ class Acon3dBloomPanel(bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
         layout.use_property_split = True
+        layout.use_property_decorate = False  # No animation.
 
         scene = context.scene
         props = scene.eevee
+        prop = scene.ACON_prop
 
         layout.active = props.use_bloom
         col = layout.column()
-        col.prop(props, "bloom_threshold")
+        col.prop(prop, "bloom_threshold", text="Threshold", slider=True)
         col.prop(props, "bloom_knee")
         col.prop(props, "bloom_radius")
         col.prop(props, "bloom_color")

--- a/release/scripts/startup/abler/lib/bloom.py
+++ b/release/scripts/startup/abler/lib/bloom.py
@@ -1,11 +1,42 @@
 import bpy
-from bpy.types import FloatProperty, PropertyGroup
+from bpy.types import Context
 
 
-def change_bloom_threshold(self, context):
+def change_bloom_threshold(self, context: Context) -> None:
     props = context.scene.eevee
-
     prop = context.scene.ACON_prop
     value = prop.bloom_threshold
 
     props.bloom_threshold = value
+
+
+def change_bloom_knee(self, context: Context) -> None:
+    props = context.scene.eevee
+    prop = context.scene.ACON_prop
+    value = prop.bloom_knee
+
+    props.bloom_knee = value
+
+
+def change_bloom_radius(self, context: Context) -> None:
+    props = context.scene.eevee
+    prop = context.scene.ACON_prop
+    value = prop.bloom_radius
+
+    props.bloom_radius = value
+
+
+def change_bloom_intensity(self, context: Context) -> None:
+    props = context.scene.eevee
+    prop = context.scene.ACON_prop
+    value = prop.bloom_intensity
+
+    props.bloom_intensity = value
+
+
+def change_bloom_clamp(self, context: Context) -> None:
+    props = context.scene.eevee
+    prop = context.scene.ACON_prop
+    value = prop.bloom_clamp
+
+    props.bloom_clamp = value

--- a/release/scripts/startup/abler/lib/bloom.py
+++ b/release/scripts/startup/abler/lib/bloom.py
@@ -1,0 +1,11 @@
+import bpy
+from bpy.types import FloatProperty, PropertyGroup
+
+
+def change_bloom_threshold(self, context):
+    props = context.scene.eevee
+
+    prop = context.scene.ACON_prop
+    value = prop.bloom_threshold
+
+    props.bloom_threshold = value

--- a/release/scripts/startup/abler/lib/bloom.py
+++ b/release/scripts/startup/abler/lib/bloom.py
@@ -3,40 +3,40 @@ from bpy.types import Context
 
 
 def change_bloom_threshold(self, context: Context) -> None:
-    props = context.scene.eevee
+    eevee_prop = context.scene.eevee
     prop = context.scene.ACON_prop
     value = prop.bloom_threshold
 
-    props.bloom_threshold = value
+    eevee_prop.bloom_threshold = value
 
 
 def change_bloom_knee(self, context: Context) -> None:
-    props = context.scene.eevee
+    eevee_prop = context.scene.eevee
     prop = context.scene.ACON_prop
     value = prop.bloom_knee
 
-    props.bloom_knee = value
+    eevee_prop.bloom_knee = value
 
 
 def change_bloom_radius(self, context: Context) -> None:
-    props = context.scene.eevee
+    eevee_prop = context.scene.eevee
     prop = context.scene.ACON_prop
     value = prop.bloom_radius
 
-    props.bloom_radius = value
+    eevee_prop.bloom_radius = value
 
 
 def change_bloom_intensity(self, context: Context) -> None:
-    props = context.scene.eevee
+    eevee_prop = context.scene.eevee
     prop = context.scene.ACON_prop
     value = prop.bloom_intensity
 
-    props.bloom_intensity = value
+    eevee_prop.bloom_intensity = value
 
 
 def change_bloom_clamp(self, context: Context) -> None:
-    props = context.scene.eevee
+    eevee_prop = context.scene.eevee
     prop = context.scene.ACON_prop
     value = prop.bloom_clamp
 
-    props.bloom_clamp = value
+    eevee_prop.bloom_clamp = value


### PR DESCRIPTION
QA에서 나온 이슈 중 bloom의 property가 max값 이상으로 입력이 되는 에러가 발생하고 있습니다.
bloom의 property는 블렌더에 있는 scene.eevee의 property를 그대로 쓰고 있어서 오버라이딩을 하기 위해 ACON_prop으로 한번 감싸서 default, min, max값을 지정해줬습니다.

노션 문서 : https://www.notion.so/acon3d/Bloom-min-max-min-max-2fabf435e75046d3b5b3521383fe4a8d
