### PR TITLE
[0.2.4 QA] 저장, 다른 이름으로 저장, 파일 열기 시 최근 파일 목록 갱신하는 함수 생성

### DIFF
--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -244,7 +244,7 @@ def update_recent_files(target_path, is_add=False):
             recent_filepaths_except_target.insert(0, target_path)
 
             if len(recent_filepaths_except_target) > 10:
-                recent_filepaths_except_target.pop()
+                recent_filepaths_except_target = recent_filepaths_except_target[:10]
 
         with open(history_path, "wt") as fout:
             fout.write("\n".join(recent_filepaths_except_target))

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -224,7 +224,14 @@ class ToggleToolbarOperator(bpy.types.Operator):
         return {"FINISHED"}
 
 
-def delete_path_from_recent_files(target_path):
+def update_recent_files(target_path, mode):
+    """
+    Update Recent Files in User Resources
+
+    target_path: path to update
+    mode: 'pop' or 'push'
+    """
+
     history_path = bpy.utils.user_resource("CONFIG") + "/recent-files.txt"
 
     try:
@@ -232,6 +239,12 @@ def delete_path_from_recent_files(target_path):
             recent_filepaths_except_target = [
                 path for path in fin.read().splitlines() if path != target_path
             ]
+
+        if mode == "push":
+            recent_filepaths_except_target.insert(0, target_path)
+
+            if len(recent_filepaths_except_target) == 10:
+                recent_filepaths_except_target.pop()
 
         with open(history_path, "wt") as fout:
             fout.write("\n".join(recent_filepaths_except_target))
@@ -256,13 +269,14 @@ class BaseFileOpenOperator:
                     title="File not found",
                     message_1="Selected file does not exist",
                 )
-                delete_path_from_recent_files(path)
+                update_recent_files(path, mode="pop")
                 tracker.file_open_fail()
                 return
 
             bpy.ops.wm.open_mainfile(
-                "INVOKE_DEFAULT", True, filepath=path, display_file_selector=False
+                "INVOKE_DEFAULT", filepath=path, display_file_selector=False
             )
+            update_recent_files(path, mode="push")
 
         except:
             tracker.file_open_fail()
@@ -360,9 +374,8 @@ class SaveOperator(bpy.types.Operator, ExportHelper):
                 self.filepath = context.blend_data.filepath
                 dirname, basename = split_filepath(self.filepath)
 
-                bpy.ops.wm.save_mainfile(
-                    {"dict": "override"}, True, filepath=self.filepath
-                )
+                bpy.ops.wm.save_mainfile({"dict": "override"}, filepath=self.filepath)
+                update_recent_files(self.filepath, mode="push")
                 self.report({"INFO"}, f'Saved "{basename}{self.filename_ext}"')
 
             else:
@@ -372,9 +385,8 @@ class SaveOperator(bpy.types.Operator, ExportHelper):
 
                 self.filepath = f"{numbered_filepath}{self.filename_ext}"
 
-                bpy.ops.wm.save_mainfile(
-                    {"dict": "override"}, True, filepath=self.filepath
-                )
+                bpy.ops.wm.save_mainfile({"dict": "override"}, filepath=self.filepath)
+                update_recent_files(self.filepath, mode="push")
                 self.report({"INFO"}, f'Saved "{numbered_filename}{self.filename_ext}"')
 
         except Exception as e:
@@ -403,9 +415,8 @@ class SaveAsOperator(bpy.types.Operator, ExportHelper):
 
             self.filepath = f"{numbered_filepath}{self.filename_ext}"
 
-            bpy.ops.wm.save_as_mainfile(
-                {"dict": "override"}, True, filepath=self.filepath
-            )
+            bpy.ops.wm.save_as_mainfile({"dict": "override"}, filepath=self.filepath)
+            update_recent_files(self.filepath, mode="push")
             self.report({"INFO"}, f'Saved "{numbered_filename}{self.filename_ext}"')
 
         except Exception as e:

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -242,9 +242,7 @@ def update_recent_files(target_path, is_add=False):
 
         if is_add:
             recent_filepaths_except_target.insert(0, target_path)
-
-            if len(recent_filepaths_except_target) > 10:
-                recent_filepaths_except_target = recent_filepaths_except_target[:10]
+            recent_filepaths_except_target = recent_filepaths_except_target[:10]
 
         with open(history_path, "wt") as fout:
             fout.write("\n".join(recent_filepaths_except_target))

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -224,12 +224,12 @@ class ToggleToolbarOperator(bpy.types.Operator):
         return {"FINISHED"}
 
 
-def update_recent_files(target_path, mode):
+def update_recent_files(target_path, is_add=False):
     """
     Update Recent Files in User Resources
 
     target_path: path to update
-    mode: 'pop' or 'push'
+    is_add: if True, add target_path to first of the recent files list
     """
 
     history_path = bpy.utils.user_resource("CONFIG") + "/recent-files.txt"
@@ -240,10 +240,10 @@ def update_recent_files(target_path, mode):
                 path for path in fin.read().splitlines() if path != target_path
             ]
 
-        if mode == "push":
+        if is_add:
             recent_filepaths_except_target.insert(0, target_path)
 
-            if len(recent_filepaths_except_target) == 10:
+            if len(recent_filepaths_except_target) > 10:
                 recent_filepaths_except_target.pop()
 
         with open(history_path, "wt") as fout:
@@ -269,14 +269,14 @@ class BaseFileOpenOperator:
                     title="File not found",
                     message_1="Selected file does not exist",
                 )
-                update_recent_files(path, mode="pop")
+                update_recent_files(path)
                 tracker.file_open_fail()
                 return
 
             bpy.ops.wm.open_mainfile(
                 "INVOKE_DEFAULT", filepath=path, display_file_selector=False
             )
-            update_recent_files(path, mode="push")
+            update_recent_files(path, is_add=True)
 
         except:
             tracker.file_open_fail()
@@ -375,7 +375,7 @@ class SaveOperator(bpy.types.Operator, ExportHelper):
                 dirname, basename = split_filepath(self.filepath)
 
                 bpy.ops.wm.save_mainfile({"dict": "override"}, filepath=self.filepath)
-                update_recent_files(self.filepath, mode="push")
+                update_recent_files(self.filepath, is_add=True)
                 self.report({"INFO"}, f'Saved "{basename}{self.filename_ext}"')
 
             else:
@@ -386,7 +386,7 @@ class SaveOperator(bpy.types.Operator, ExportHelper):
                 self.filepath = f"{numbered_filepath}{self.filename_ext}"
 
                 bpy.ops.wm.save_mainfile({"dict": "override"}, filepath=self.filepath)
-                update_recent_files(self.filepath, mode="push")
+                update_recent_files(self.filepath, is_add=True)
                 self.report({"INFO"}, f'Saved "{numbered_filename}{self.filename_ext}"')
 
         except Exception as e:
@@ -416,7 +416,7 @@ class SaveAsOperator(bpy.types.Operator, ExportHelper):
             self.filepath = f"{numbered_filepath}{self.filename_ext}"
 
             bpy.ops.wm.save_as_mainfile({"dict": "override"}, filepath=self.filepath)
-            update_recent_files(self.filepath, mode="push")
+            update_recent_files(self.filepath, is_add=True)
             self.report({"INFO"}, f'Saved "{numbered_filename}{self.filename_ext}"')
 
         except Exception as e:


### PR DESCRIPTION
[QA 링크 (노션)](https://www.notion.so/acon3d/Issue-07_-Open-Recent-Open-Recent-6a265e02d9f442ccb71e9dc06cd76d4b)

# 문제점
최근 파일 열기에서 없는 파일을 선택하면 최근 파일 리스트에서 해당 파일이 지워지는데, 그 후에 다른 프로젝트를 열면 지워졌던 파일이 다시 나타납니다.

# 조사
- 저장 및 파일 열 때의 최근 파일 리스트 갱신은 블렌더의 내장 c 함수를 사용하지만, 해당 파일이 없어서 지우는 경우에는 에이블러의 커스텀 함수를 사용합니다.
- 블렌더의 내장 c 함수는 최근 파일 리스트를 변수 형태로 저장하고, 해당 리스트 변경이 필요할 때 **변수**와 **파일** 둘다 변경하도록 짜여있습니다.
- 에이블러의 커스텀 함수는 위 **변수**를 변경하지 않아서 File Not Found 후 다른 파일을 열면 에이블러의 변경사항이 반영되지 않는 것으로 보입니다.

# 개선
- 최근 파일 수정하는 로직을 모두 블렌더 기본 동작이 아닌, 에이블러 내에서 동작하도록 변경하도록 하였습니다.

# 참고
- 최근 파일 리스트는 최대 10개 유지되고, 제일 오래된 순으로 리스트에서 지워집니다. (실제 블렌더 동작을 참고하였습니다.)
