### PR TITLE
[0.2.4 QA] 런처로 최초 실행 시 노출

### DIFF
--- a/release/scripts/startup/abler/lib/read_cookies.py
+++ b/release/scripts/startup/abler/lib/read_cookies.py
@@ -39,7 +39,7 @@ def remember_show_guide(self, context) -> None:
 
 def read_remembered_show_guide() -> bool:
     if not os.path.isfile(path_cookies_tutorial_guide):
-        return False
+        return True
     with open(path_cookies_tutorial_guide, "rb") as fr:
         data = pickle.load(fr)
     return data


### PR DESCRIPTION
path_cookies_tutorial_guide 파일이 없을 때도 튜토리얼 가이드 실행되게끔 return값을 True로 돌렸습니당
