### PR TITLE
[0.2.4 QA] UI Number Input에 원하지 않는 인풋이 입력되었을 경우를 필터링함

### DIFF
--- a/source/blender/editors/interface/interface.c
+++ b/source/blender/editors/interface/interface.c
@@ -3057,7 +3057,9 @@ bool ui_but_string_eval_number(bContext *C, const uiBut *but, const char *str, d
 {
   // string literal이 들어가는 경우를 방지하기 위해서 아래와 같은 for loop를 추가함
   for (int i = 0; i < strlen(str); i++) {
-    if (!isdigit(str[i]) && str[i] != '.' && str[i] != '-' && str[i] != '+') {
+    char digit = str[i];
+    // -가 literal의 처음에 들어가는 경우를 제외하고는 다 false 처라하기 위해서 다음과 같이 처리함
+    if ((!isdigit(digit) && digit != '.' && digit != '-' && digit != '+') || (i > 0 && digit == '-')) {
       return false;
     }
   }
@@ -3067,11 +3069,9 @@ bool ui_but_string_eval_number(bContext *C, const uiBut *but, const char *str, d
   }
   // "--003"와 같은 케이스가 "-3"으로 들어가기 위해서 아래 내용을 적음
   bool isNegative = false;
+  // added while loop to strip leading '-' characters in str
   if (str[0] == '-'){
     isNegative = true;
-  }
-  // added while loop to strip leading '-' characters in str
-  while (str[0] == '-'){
     str++;
   }
   // added while loop to strip leading zeros in str

--- a/source/blender/editors/interface/interface.c
+++ b/source/blender/editors/interface/interface.c
@@ -3055,13 +3055,35 @@ static bool ui_number_from_string_percentage(bContext *C, const char *str, doubl
 
 bool ui_but_string_eval_number(bContext *C, const uiBut *but, const char *str, double *r_value)
 {
+  // string literal이 들어가는 경우를 방지하기 위해서 아래와 같은 for loop를 추가함
+  for (int i = 0; i < strlen(str); i++) {
+    if (!isdigit(str[i]) && str[i] != '.' && str[i] != '-' && str[i] != '+') {
+      return false;
+    }
+  }
   if (str[0] == '\0') {
     *r_value = 0.0;
     return true;
   }
+  // "--003"와 같은 케이스가 "-3"으로 들어가기 위해서 아래 내용을 적음
+  bool isNegative = false;
+  if (str[0] == '-'){
+    isNegative = true;
+  }
+  // added while loop to strip leading '-' characters in str
+  while (str[0] == '-'){
+    str++;
+  }
   // added while loop to strip leading zeros in str
   while (str[0] == '0'){
-    str = str + 1;
+    str++;
+  }
+  // 음수인 경우에는 현재 str의 앞에 -를 붙여준다
+  char* str_new = malloc(strlen(str) + 1);
+  if (isNegative){
+    strcpy(str_new, "-");
+    strcat(str_new, str);
+    str = str_new;
   }
 
   PropertySubType subtype = PROP_NONE;


### PR DESCRIPTION
## 이슈 내용

### 재현 환경

- 윈도우11
- 0.2.4

### 재현 경로

- Image Adjustment > Brightness / Contrast
    - Contrast 에 -001 입력

### 현재 상태

- 오류 발생

  ![image](https://user-images.githubusercontent.com/43770096/182294088-5b2fbfa6-8473-4d8d-bcd6-4629019e3fec.png)


- -1 입력시에는 오류 발생하지 않음.
- 문제 발생 가능 필드
    - Image Adjustment > Brightness / Contrast
        - Brightness
        - Contrast
    - Shadow / Light Control > Shadow
        - Altitude
        - Azimuth
    - Camera Control > Background Images
        - Offset X
        - Offset Y
        - Rotation

## 코드 수정 내용
아래의 적정상태에 맞도록 개선하였습니다.
### 적정 상태

1. `-` 문자가 n개 들어가는 경우 : `-`를 하나만 붙이고 leading zeros도 걸러진 숫자와 합쳐서 python으로 전달
2. string literal이 입력 되었을 때의 경우 (`-`, `+`, `.`제외) : 아무 행동도 하지 않도록 반환