### PR TITLE
배경 이미지 추가/삭제/수정 시 기존 이미지를 삭제하는 로직 추가

### DIFF
--- a/release/scripts/startup/abler/camera_control.py
+++ b/release/scripts/startup/abler/camera_control.py
@@ -211,6 +211,8 @@ class RemoveBackgroundOperator(bpy.types.Operator):
         # self.index를 유저가 마음대로 바꿀 수 있는 패널로 인해 try/except로 감쌈
         try:
             image = context.scene.camera.data.background_images[self.index]
+            if image.image:
+                bpy.data.images.remove(image.image)
             image.image = None
             bpy.context.scene.camera.data.background_images.remove(image)
         except:
@@ -233,6 +235,8 @@ class OpenDefaultBackgroundOperator(bpy.types.Operator, ImportHelper):
     def execute(self, context):
         new_image = bpy.data.images.load(self.filepath)
         image = context.scene.camera.data.background_images[self.index]
+        if image.image:
+            bpy.data.images.remove(image.image)
         image.image = new_image
         return {"FINISHED"}
 
@@ -268,6 +272,8 @@ class OpenCustomBackgroundOperator(bpy.types.Operator, ImportHelper):
     def execute(self, context):
         new_image = bpy.data.images.load(self.filepath)
         image = context.scene.camera.data.background_images[self.index]
+        if image.image:
+            bpy.data.images.remove(image.image)
         image.image = new_image
         return {"FINISHED"}
 


### PR DESCRIPTION
사용하지 않는 이미지가 파일 내에 계속 쌓이는 버그가 있어서,
사용하지 않는 이미지를 삭제하는 로직을 배경이미지 추가/삭제 오퍼레이터에 추가하였습니다.