### PR TITLE
[Splash Screen] 일부 Operator 에 대해서 Tooltip이 정의되어있지 않아, (undocumented operator) 툴팁이 노출됨

### DIFF
--- a/release/scripts/startup/abler/credential_modal.py
+++ b/release/scripts/startup/abler/credential_modal.py
@@ -137,6 +137,7 @@ class Acon3dNoticeInvokeOperator(bpy.types.Operator):
 class Acon3dNoticeOperator(bpy.types.Operator):
     bl_idname = "acon3d.notice"
     bl_label = ""
+    bl_description = "ABLER Service Notice"
     title: bpy.props.StringProperty(name="Title")
     content: bpy.props.StringProperty(name="Content", description="content")
     link: bpy.props.StringProperty(name="Link", description="link")
@@ -431,6 +432,14 @@ class Acon3dAnchorOperator(bpy.types.Operator):
     bl_translation_context = "*"
 
     href: bpy.props.StringProperty(name="href", description="href")
+    description_text: bpy.props.StringProperty(name="description_text", description="description_text")
+
+    @classmethod
+    def description(cls, context, properties):
+        if properties.description_text:
+            return bpy.app.translations.pgettext(properties.description_text)
+        else:
+            return None
 
     def execute(self, context):
         webbrowser.open(self.href)

--- a/release/scripts/startup/bl_operators/wm.py
+++ b/release/scripts/startup/bl_operators/wm.py
@@ -3100,7 +3100,9 @@ class WM_MT_splash(Menu):
         col1 = split.column()
         anchor = col1.operator("acon3d.anchor", text="See ACON3D models!", icon='EVENT_A')
         anchor.href = 'https://acon3d.com'
+        anchor.description_text = "Link to ACON3D"
         anchor = col1.operator("acon3d.anchor", text="Don't have an ACON3D account?", icon='USER')
+        anchor.description_text = "Sign up for ACON3D"
         anchor.href = 'https://www.acon3d.com/member/join'
 
         col2 = split.column()


### PR DESCRIPTION
[QA 이슈 링크](https://www.notion.so/acon3d/Issue-05_-Splash-Screen-Operator-Tooltip-undocumented-operator-454ec25791194698bf902a130b9b039d)

각 버튼에 대해 요청받은 툴팁은 다음과 같습니다.

`See ACON3D models!`
- 국문 : 에이콘3D 보러가기
- 영문 : Link to ACON3D

`Don't have an ACON3D account?`
- 국문 : 에이콘3D 회원가입
- 영문 : Sign up for ACON3D

Notice 항목
- 국문 : 에이블러 서비스 공지사항
- 영문 : ABLER Service Notice


<img width="573" alt="image" src="https://user-images.githubusercontent.com/767106/182329917-5aa75a4c-2b55-48e5-97cb-1e441674499f.png">

- 공지사항 항목은 기존에 하던 방식대로 bl_description 을 추가했습니다.

<img width="560" alt="image" src="https://user-images.githubusercontent.com/767106/182329990-97d9a6c9-84bb-4e99-9cc9-36f6e0b7e1fa.png">

- AnchorOperator 의 툴팁은, 워니님이 알려주신 description class method 를 이용해서 추가했습니다. 이 때 번역을 하기 위해 [pgettext](https://docs.blender.org/api/current/bpy.app.translations.html#bpy.app.translations.pgettext) 를 사용했습니다.

