### PR TITLE
[0.2.4 QA] 스플래시가 닫히기 전에 튜토리얼 팝업이 뜨는 문제 수정

### DIFF
--- a/release/scripts/startup/abler/credential_modal.py
+++ b/release/scripts/startup/abler/credential_modal.py
@@ -242,7 +242,14 @@ class Acon3dModalOperator(bpy.types.Operator):
                 shift_state = (result & 0xFF00) >> 8
                 return result & 0xFF
 
-        if userInfo and userInfo.ACON_prop.login_status == "SUCCESS":
+        splash_closing = event.type in (
+            "LEFTMOUSE",
+            "MIDDLEMOUSE",
+            "RIGHTMOUSE",
+            "ESC",
+            "ENTER",
+        )
+        if userInfo and userInfo.ACON_prop.login_status == "SUCCESS" and splash_closing:
             if read_remembered_show_guide():
                 bpy.ops.acon3d.tutorial_guide_popup()
 


### PR DESCRIPTION
[QA 이슈 링크](https://www.notion.so/acon3d/Issue-04_-Show-Abler-Start-Splash-d0d936458268411cabe584df47cab862)

- modal 메소드는 여러 사용자 이벤트(클릭, 창전환 등)가 발생할 때마다 실행되는데, 
- 자동로그인이 되어있는 경우, 기존 코드의 if 문은 항상 통과될 수밖에 없기 때문에 스플래시가 닫히기 전에 튜토리얼 팝업이 뜨는 문제가 발생했습니다.
- 따라서, event.type 값이 명시적으로 좌클릭이어야 스플래시가 닫히게 수정해서, 스플래시가 닫히기 전에 튜토리얼 팝업이 뜨는 문제를 회피했습니다.

이렇게 수정했을 때 발생하는 부작용이 있는데,

- 기존에는 스플래시 스크린을 ESC 같은 키를 눌러서 닫는 것과 클릭해서 닫는 것에는 별 차이가 없었지만
- 수정 후에는
  - 클릭을 해서 스플래시 화면을 닫았을 때는 튜토리얼 팝업이 바로 뜸
  - ESC 같은 키를 눌러서 스플래시를 닫았을 때는 한 번 클릭을 해야 튜토리얼 팝업이 뜸

위와 같은 부작용이 생기지만, 애초에 스플래시 화면에 클릭을 하라는 문구가 포함되어있기 때문에 큰 문제가 되지 않을 것으로 판단했습니다.

<img width="529" alt="image" src="https://user-images.githubusercontent.com/767106/182521453-2951437b-cd57-46fa-8edf-f825b14a4d57.png">
