### PR TITLE
[0.2.4 QA] 파일 오픈 에러 메세지 출력

### DIFF
--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -276,9 +276,9 @@ class BaseFileOpenOperator:
             )
             update_recent_files(path, is_add=True)
 
-        except:
+        except Exception as e:
             tracker.file_open_fail()
-            self.report({"ERROR"}, "Please check file extension(.blend)")
+            self.report({"ERROR"}, message=str(e))
         else:
             tracker.file_open()
 

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -278,6 +278,7 @@ class BaseFileOpenOperator:
 
         except:
             tracker.file_open_fail()
+            self.report({"ERROR"}, "Please check file extension(.blend)")
         else:
             tracker.file_open()
 

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -261,15 +261,6 @@ class BaseFileOpenOperator:
 
             if path.endswith("/") or path.endswith("\\") or path.endswith("//"):
                 return
-            elif not os.path.isfile(path):
-                bpy.ops.acon3d.alert(
-                    "INVOKE_DEFAULT",
-                    title="File not found",
-                    message_1="Selected file does not exist",
-                )
-                update_recent_files(path)
-                tracker.file_open_fail()
-                return
 
             bpy.ops.wm.open_mainfile(
                 "INVOKE_DEFAULT", filepath=path, display_file_selector=False

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -268,7 +268,9 @@ class BaseFileOpenOperator:
             update_recent_files(path, is_add=True)
 
         except Exception as e:
+            update_recent_files(path)
             tracker.file_open_fail()
+
             self.report({"ERROR"}, message=str(e))
         else:
             tracker.file_open()


### PR DESCRIPTION
파일 오픈 관련된 에러 메세지를 `self.report`에 넣어서 출력하도록 변경했습니다.

추가로 스듴님이 이전에 작업하신 파일 경로에 파일이 없는 경우 코드도 `self.report`에 합칠 수 있어서 삭제한 뒤, 워니님께서 작업해주신 파일이 없는 경우 최근 파일 목록에서 제거시키는 `update_recent_files`를 except에 넣었습니다.

노션 문서 : https://www.notion.so/acon3d/open-import-OSError-710d4ce21a4643bbaf4bf81a44de23d9