### PR TITLE
Revert "숫자 앞에 0 표기 오류"

### DIFF
--- a/source/blender/editors/interface/interface.c
+++ b/source/blender/editors/interface/interface.c
@@ -3059,10 +3059,6 @@ bool ui_but_string_eval_number(bContext *C, const uiBut *but, const char *str, d
     *r_value = 0.0;
     return true;
   }
-  // added while loop to strip leading zeros in str
-  while (str[0] == '0'){
-    str = str + 1;
-  }
 
   PropertySubType subtype = PROP_NONE;
   if (but->rnaprop) {


### PR DESCRIPTION
ACON3D/blender#102 에 대하여 논의 중 leading zero 자체를 오류로 보자는 방향으로 논의가 되어서 ACON3D/blender#71 까지 revert하기로 결정됨.

이슈 링크 : https://www.notion.so/acon3d/Issue-12-Input-Field-001-0-4cb03f010222462ebd6c6f8574502d16

