### PR TITLE
[0.2.4 QA] 첫 설치 후, 혹은 recent-files.txt 삭제 후 정상적으로 최근 파일 리스트가 보이지 않는 문제

### DIFF
--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -235,6 +235,9 @@ def update_recent_files(target_path, is_add=False):
     history_path = bpy.utils.user_resource("CONFIG") + "/recent-files.txt"
 
     try:
+        # create history_path if not exists
+        open(history_path, "a").close()
+
         with open(history_path) as fin:
             recent_filepaths_except_target = [
                 path for path in fin.read().splitlines() if path != target_path


### PR DESCRIPTION
[태스크 카드 링크 (노션)](https://www.notion.so/acon3d/Open-Recent-recent-files-txt-fd0f55895d1e4ebaac1c993943f08c91)

## 발제/내용

### **어떤 현상이 발생하고 있었나요? 가능하다면 스크린샷/영상을 첨부해주세요.**

- 첫 설치 후, 혹은 recent-files.txt 를 삭제 한 후 최근 파일 리스트에 접근이 불가해집니다.

### **어떤 경로를 통해서 인지하게 되었나요? 내부인원 이용, CS인입 등**

- 0.2.4 QA

## 대응

### **재현 방법이 어떻게 되나요?**

- 에이블러를 처음 설치한다.
    - 혹은 recent-files.txt 를 삭제한다.
    - macOs
        - `/Users/$USER/Library/Application Support/Blender/{version}/recent-files.txt`
    - window
        - `%USERPROFILE%/AppData/Roaming/Blender Foundation/Blender/{version}/recent-files.txt`

### 그래서 이 현상은 1)언제부터 2)어디에서 3)어떤 이유로 생겼나요?

- 0.2.4 QA 이후로 생긴 것 같습니다.

### 어떤 조치를 취했나요?

- 매 저장, 파일 Open 시마다 recent-files.txt 를 체크해서 없으면 생성하도록 하였습니다.