### PR TITLE
[0.2.4 QA] .blend1 파일이 생성되지 않게 Save Version 비활성

### DIFF
--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -39,6 +39,7 @@ def init_setting(dummy):
     prefs_view.show_developer_ui = False
     prefs_view.show_tooltips_python = False
     prefs_paths.use_load_ui = False
+    prefs_paths.save_version = 0
 
 
 @persistent


### PR DESCRIPTION
## 개요

`.blend1` 파일은 백업 기능을 가지고는 있지만, 대부분의 경우에서 사용되지 않고 용량을 두 배를 차지하게됨. 그리고 사용성에 이질감이나 뭔가 잘못되었다는 느낌을 줄 수 있기 때문에 관련 파일을 생성하지 않게함
관련 Notion 문서: [.blend1 파일이 생성되지 않게 Save Version 비활성](https://www.notion.so/acon3d/blend1-Save-Version-8f03c0a6a3ec414c9208108b9372fa85)


## 진행 상황

- [ ]  코드 일관성을 위해 userpref.py 에 default = 0으로 세팅
    - userpref.py 에서 Save Version 관련 내용을 찾을 수 없음. (PreferencesFilePaths 포함)
- [x]  [pref.py](http://pref.py/) > init_setting > 값 체크 후 0으로 바꾸기
    ```python
    # pref.py
    def init_setting(dummy):
        prefs = bpy.context.preferences
        prefs_paths = prefs.filepaths
        ...
        prefs_paths.save_version = 0
    ```
- [x]  다른 값으로 세팅하고 다시 켰을 때 0인지 확인


## 결과

- 파일 저장 시 `.blend1` 파일이 생성되지 않음
- Edif > Preferences > Save & Load > Save Version 에서 다른 값으로 설정하고 종료 or 저장 후 종료를 해도 다시 실행했을 때, Save Version = 0 으로 설정됨
