### PR TITLE
엔터키로 스플래시가 닫히지 않는 문제 수정

### DIFF
--- a/release/scripts/startup/abler/credential_modal.py
+++ b/release/scripts/startup/abler/credential_modal.py
@@ -248,7 +248,7 @@ class Acon3dModalOperator(bpy.types.Operator):
             "MIDDLEMOUSE",
             "RIGHTMOUSE",
             "ESC",
-            "ENTER",
+            "RET",
         )
         if userInfo and userInfo.ACON_prop.login_status == "SUCCESS" and splash_closing:
             if read_remembered_show_guide():


### PR DESCRIPTION
[관련 이슈 링크](https://www.notion.so/acon3d/Issue-04_-Show-Abler-Start-Splash-d0d936458268411cabe584df47cab862?d=2e38398e21b64fef944cfe89ff870465)

댓글 중에 "엔터키로 스플래시가 닫히지 않는다"는 제보가 들어와서 보니, 엔터키로 스플래시가 닫히게 하려면 "ENTER" 대신 "RET" 을 써야 했습니다 흑흑.. 왜 된다고 생각했던 거지

리뷰 & 테스트 부탁드립니다. 