### PR TITLE
psd 배경 파일을 불러올 수 있는 이슈

### DIFF
--- a/release/scripts/startup/abler/camera_control.py
+++ b/release/scripts/startup/abler/camera_control.py
@@ -15,7 +15,7 @@
 #  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 # ##### END GPL LICENSE BLOCK #####
-
+import os
 
 bl_info = {
     "name": "ACON3D Panel",
@@ -218,6 +218,20 @@ class RemoveBackgroundOperator(bpy.types.Operator):
         return {"FINISHED"}
 
 
+def is_valid_extension(target_path, accepted):
+    _, ext = os.path.splitext(target_path)
+
+    if ext.lower() not in accepted:
+        bpy.ops.acon3d.alert(
+            "INVOKE_DEFAULT",
+            title="Check Background Image File",
+            message_1="Failed to load background image file:",
+            message_2=f"{target_path}",
+        )
+        return False
+    return True
+
+
 class OpenDefaultBackgroundOperator(bpy.types.Operator, ImportHelper):
     """Open Default Background Image"""
 
@@ -231,6 +245,9 @@ class OpenDefaultBackgroundOperator(bpy.types.Operator, ImportHelper):
     filepath: bpy.props.StringProperty()
 
     def execute(self, context):
+        if not is_valid_extension(self.filepath, (".png", ".jpg")):
+            return {"FINISHED"}
+
         new_image = bpy.data.images.load(self.filepath)
         image = context.scene.camera.data.background_images[self.index]
         image.image = new_image
@@ -267,6 +284,9 @@ class OpenCustomBackgroundOperator(bpy.types.Operator, ImportHelper):
     filter_glob: bpy.props.StringProperty(default=image_extension, options={"HIDDEN"})
 
     def execute(self, context):
+        if not is_valid_extension(self.filepath, (".png", ".jpg")):
+            return {"FINISHED"}
+
         new_image = bpy.data.images.load(self.filepath)
         image = context.scene.camera.data.background_images[self.index]
         image.image = new_image


### PR DESCRIPTION
필터를 해제하고도 psd 배경 파일을 불러올 수 있는 이슈가 있어서,
확장자 검사를 하는 로직을 Custom, Default Background Open Operator 에 추가했습니다.