### PR TITLE
.blend 파일을 열어도 바로 Tutorial 스플래시가 나올 수 있도록 수정함

### DIFF
--- a/release/scripts/startup/abler/credential_modal.py
+++ b/release/scripts/startup/abler/credential_modal.py
@@ -251,9 +251,9 @@ class Acon3dModalOperator(bpy.types.Operator):
             "ESC",
             "RET",
         )
-        is_blend_open = False
+        is_blend_open: bool = False
         for arg in sys.argv:
-            if ".blend" in arg:
+            if arg.lower().endswith(".blend"):
                 is_blend_open = True
                 break
 

--- a/release/scripts/startup/abler/credential_modal.py
+++ b/release/scripts/startup/abler/credential_modal.py
@@ -21,6 +21,7 @@ import ctypes
 import os
 import pickle
 import platform
+import sys
 import textwrap
 import webbrowser
 from json import JSONDecodeError
@@ -250,7 +251,13 @@ class Acon3dModalOperator(bpy.types.Operator):
             "ESC",
             "RET",
         )
-        if userInfo and userInfo.ACON_prop.login_status == "SUCCESS" and splash_closing:
+        is_blend_open = False
+        for arg in sys.argv:
+            if ".blend" in arg:
+                is_blend_open = True
+                break
+
+        if userInfo and userInfo.ACON_prop.login_status == "SUCCESS" and (splash_closing or is_blend_open):
             if read_remembered_show_guide():
                 bpy.ops.acon3d.tutorial_guide_popup()
 


### PR DESCRIPTION
### 수정 내용
sys.argv를 이용해서 .blend를 아규먼트로 여는지 (.blend 파일 더블 클릭해서 여는지) 확인하고, 그렇지 않다면 스플래시 스크린이 뜨지 않아도, 클릭을 하지 않아도 바로 Tutorial이 뜨도록 함 (Tutorial 여는 체크박스가 체크 되어있는 상황에서만)

### 재현 환경

- 윈도우11
- 0.2.4버전

### 재현 경로

- Show ABLER start 가 체크상태 (에이블러 실행 시 자동 튜토리얼 노출 상태)
- 블렌더 파일(file_open_test.blend)을 더블클릭하여 에이블러 실행

### 현재 상태

- 파일 오픈 시, 튜토리얼 팝업이 노출되지 않음
 
   ![image](https://user-images.githubusercontent.com/43770096/183014445-3a42d898-1e16-46de-ad37-a50e6c3ccd85.png)


- 해당 화면에서 어느 곳이든 1회 클릭 시, 튜토리얼 팝업 노출됨 (클릭, 우클릭, 휠클릭, ESC, Enter 모두 동일)   
   ![image](https://user-images.githubusercontent.com/43770096/183014496-b1c227e2-4cc0-484f-86b0-d6559b4455f0.png)


### 적정 상태

- show ABLER start = True 일 시, .blend파일을 더블클릭으로 오픈 시에도 동일하게 튜토리얼 팝업이 바로 노출되어야 합니다.
    - Plan B : .blend 파일 더블클릭으로 오픈 시, 튜토리얼 팝업 노출되지 않음