### PR TITLE
password를 입력했을 때 해당 내용이 그대로 undo history에 노출 되는 현상

### DIFF
--- a/source/blender/editors/interface/interface_handlers.c
+++ b/source/blender/editors/interface/interface_handlers.c
@@ -939,6 +939,10 @@ static void ui_apply_but_undo(uiBut *but)
       str_len_clip = strlen(str);
     }
 
+    const char* rna_id = RNA_property_identifier(but->rnaprop);
+    if (strcmp(rna_id, "password") || strcmp(rna_id, "password_shown") || strcmp(rna_id, "username")){
+      skip_undo = true;
+    }
     /* Optionally override undo when undo system doesn't support storing properties. */
     if (but->rnapoin.owner_id) {
       /* Exception for renaming ID data, we always need undo pushes in this case,

--- a/source/blender/editors/interface/interface_handlers.c
+++ b/source/blender/editors/interface/interface_handlers.c
@@ -544,7 +544,7 @@ static CurveProfile but_copypaste_profile = {0};
 static bool but_copypaste_profile_alive = false;
 
 /** \} */
-
+const char *SkipIdentifierKeywords[] = {"password", "password_shown", "username"};
 /* -------------------------------------------------------------------- */
 /** \name UI Queries
  * \{ */
@@ -940,8 +940,11 @@ static void ui_apply_but_undo(uiBut *but)
     }
 
     const char* rna_id = RNA_property_identifier(but->rnaprop);
-    if (strcmp(rna_id, "password") || strcmp(rna_id, "password_shown") || strcmp(rna_id, "username")){
-      skip_undo = true;
+    for (int i = 0; i < sizeof(SkipIdentifierKeywords) / sizeof(SkipIdentifierKeywords[0]); i++) {
+      if (strcmp(rna_id, SkipIdentifierKeywords[i])) {
+        skip_undo = true;
+        break;
+      }
     }
     /* Optionally override undo when undo system doesn't support storing properties. */
     if (but->rnapoin.owner_id) {


### PR DESCRIPTION
UI 업데이트 시에 rnaProperty의 identifier가 password, password_shown, username 이면 undo stack에 쌓이지 않도록 수정
