### PR TITLE
import시 File dialog에서 빈 곳을 클릭하면 뜨는 버그를 resolve

### DIFF
--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -38,6 +38,7 @@ from .lib import scenes
 from .lib.materials import materials_setup
 from .lib.tracker import tracker
 from .lib.read_cookies import read_remembered_show_guide
+from .lib.import_file import AconImportHelper
 
 
 def split_filepath(filepath):
@@ -132,7 +133,7 @@ class AconTutorialGuide3Operator(bpy.types.Operator):
         return {"FINISHED"}
 
 
-class ImportOperator(bpy.types.Operator, ImportHelper):
+class ImportOperator(bpy.types.Operator, AconImportHelper):
     """Import file according to the current settings"""
 
     bl_idname = "acon3d.import_blend"
@@ -143,15 +144,7 @@ class ImportOperator(bpy.types.Operator, ImportHelper):
 
     def execute(self, context):
         try:
-            path = self.filepath
-            if path.endswith('/') or path.endswith('\\') or path.endswith('//'):
-                return {"FINISHED"}
-            elif not os.path.isfile(path):
-                bpy.ops.acon3d.alert(
-                    "INVOKE_DEFAULT",
-                    title="File not found",
-                    message_1="Selected file does not exist",
-                )
+            if AconImportHelper.execute(self, context) is not None:
                 return {"FINISHED"}
 
             for obj in bpy.data.objects:
@@ -290,7 +283,7 @@ class BaseFileOpenOperator:
             tracker.file_open()
 
 
-class FileOpenOperator(bpy.types.Operator, ImportHelper, BaseFileOpenOperator):
+class FileOpenOperator(bpy.types.Operator, AconImportHelper, BaseFileOpenOperator):
     """Open new file"""
 
     bl_idname = "acon3d.file_open"
@@ -300,6 +293,8 @@ class FileOpenOperator(bpy.types.Operator, ImportHelper, BaseFileOpenOperator):
     filter_glob: bpy.props.StringProperty(default="*.blend", options={"HIDDEN"})
 
     def execute(self, context):
+        if AconImportHelper.execute(self, context) is not None:
+            return {"FINISHED"}
         self.open_file()
         return {"FINISHED"}
 

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -144,7 +144,7 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
 
     def execute(self, context):
         try:
-            if not AconImportHelper.check_path(self):
+            if not self.check_path():
                 return {"FINISHED"}
 
             for obj in bpy.data.objects:
@@ -290,7 +290,7 @@ class FileOpenOperator(bpy.types.Operator, AconImportHelper, BaseFileOpenOperato
     filter_glob: bpy.props.StringProperty(default="*.blend", options={"HIDDEN"})
 
     def execute(self, context):
-        if not AconImportHelper.check_path(self):
+        if not self.check_path():
             return {"FINISHED"}
         self.open_file()
         return {"FINISHED"}

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -266,9 +266,6 @@ class BaseFileOpenOperator:
         try:
             path = self.filepath
 
-            if path.endswith("/") or path.endswith("\\") or path.endswith("//"):
-                return
-
             bpy.ops.wm.open_mainfile(
                 "INVOKE_DEFAULT", filepath=path, display_file_selector=False
             )

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -144,7 +144,7 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
 
     def execute(self, context):
         try:
-            if AconImportHelper.execute(self, context) is not None:
+            if not AconImportHelper.check_path(self):
                 return {"FINISHED"}
 
             for obj in bpy.data.objects:
@@ -290,7 +290,7 @@ class FileOpenOperator(bpy.types.Operator, AconImportHelper, BaseFileOpenOperato
     filter_glob: bpy.props.StringProperty(default="*.blend", options={"HIDDEN"})
 
     def execute(self, context):
-        if AconImportHelper.execute(self, context) is not None:
+        if not AconImportHelper.check_path(self):
             return {"FINISHED"}
         self.open_file()
         return {"FINISHED"}

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -143,6 +143,17 @@ class ImportOperator(bpy.types.Operator, ImportHelper):
 
     def execute(self, context):
         try:
+            path = self.filepath
+            if path.endswith('/') or path.endswith('\\') or path.endswith('//'):
+                return {"FINISHED"}
+            elif not os.path.isfile(path):
+                bpy.ops.acon3d.alert(
+                    "INVOKE_DEFAULT",
+                    title="File not found",
+                    message_1="Selected file does not exist",
+                )
+                return {"FINISHED"}
+
             for obj in bpy.data.objects:
                 obj.select_set(False)
 

--- a/release/scripts/startup/abler/import_external_files.py
+++ b/release/scripts/startup/abler/import_external_files.py
@@ -49,7 +49,7 @@ class ImportFBXOperator(bpy.types.Operator, AconImportHelper):
     filter_glob: bpy.props.StringProperty(default="*.fbx", options={"HIDDEN"})
 
     def execute(self, context):
-        if not AconImportHelper.check_path(self):
+        if not self.check_path():
             return {"FINISHED"}
         try:
             for obj in bpy.data.objects:

--- a/release/scripts/startup/abler/import_external_files.py
+++ b/release/scripts/startup/abler/import_external_files.py
@@ -36,9 +36,10 @@ import bpy
 from bpy_extras.io_utils import ImportHelper
 from .lib.materials import materials_setup
 from .lib.tracker import tracker
+from .lib.import_file import AconImportHelper
 
 
-class ImportFBXOperator(bpy.types.Operator, ImportHelper):
+class ImportFBXOperator(bpy.types.Operator, AconImportHelper):
     """Import FBX file according to the current settings"""
 
     bl_idname = "acon3d.import_fbx"
@@ -48,6 +49,8 @@ class ImportFBXOperator(bpy.types.Operator, ImportHelper):
     filter_glob: bpy.props.StringProperty(default="*.fbx", options={"HIDDEN"})
 
     def execute(self, context):
+        if AconImportHelper.execute(self, context) is not None:
+            return {"FINISHED"}
         try:
             for obj in bpy.data.objects:
                 obj.select_set(False)

--- a/release/scripts/startup/abler/import_external_files.py
+++ b/release/scripts/startup/abler/import_external_files.py
@@ -49,7 +49,7 @@ class ImportFBXOperator(bpy.types.Operator, AconImportHelper):
     filter_glob: bpy.props.StringProperty(default="*.fbx", options={"HIDDEN"})
 
     def execute(self, context):
-        if AconImportHelper.execute(self, context) is not None:
+        if not AconImportHelper.check_path(self):
             return {"FINISHED"}
         try:
             for obj in bpy.data.objects:

--- a/release/scripts/startup/abler/lib/import_file.py
+++ b/release/scripts/startup/abler/lib/import_file.py
@@ -4,16 +4,19 @@ from bpy_extras.io_utils import ImportHelper
 
 
 class AconImportHelper(ImportHelper):
-    def execute(self, context):
+    def check_path(self) -> bool:
+        """
+        :return: 파일이 아니거나 파일이 없을 경우 False를 반환, 존재하고 파일일 경우 True를 반환
+        """
         path = self.filepath
         if path.endswith('/') or path.endswith('\\') or path.endswith('//'):
-            return {"FINISHED"}
+            return False
         elif not os.path.isfile(path):
             bpy.ops.acon3d.alert(
                 "INVOKE_DEFAULT",
                 title="File not found",
                 message_1="Selected file does not exist",
             )
-            return {"FINISHED"}
+            return False
         else:
-            return None
+            return True

--- a/release/scripts/startup/abler/lib/import_file.py
+++ b/release/scripts/startup/abler/lib/import_file.py
@@ -1,0 +1,19 @@
+import os
+import bpy
+from bpy_extras.io_utils import ImportHelper
+
+
+class AconImportHelper(ImportHelper):
+    def execute(self, context):
+        path = self.filepath
+        if path.endswith('/') or path.endswith('\\') or path.endswith('//'):
+            return {"FINISHED"}
+        elif not os.path.isfile(path):
+            bpy.ops.acon3d.alert(
+                "INVOKE_DEFAULT",
+                title="File not found",
+                message_1="Selected file does not exist",
+            )
+            return {"FINISHED"}
+        else:
+            return None


### PR DESCRIPTION
## 발제/내용

### **어떤 현상이 발생하고 있었나요? 가능하다면 스크린샷/영상을 첨부해주세요.**

- 빈 문자열을 받아 파일 열기를 했을 때 에러 발생

### **어떤 경로를 통해서 인지하게 되었나요? 내부인원 이용, CS인입 등**

- 센트리 오류
    
    [[Sign In | Sentry](https://sentry.io/organizations/carpenstreet/issues/2785438622/?environment=production&project=6046815&query=is%3Aunresolved)](https://sentry.io/organizations/carpenstreet/issues/2785438622/?environment=production&project=6046815&query=is%3Aunresolved)
    

### **해당 오류의 이해관계자는 어디까지인가요? (해당 인원에게 안내를 목적으로 합니다)**

- 알앤디 개발셀

## 대응

### **재현 방법이 어떻게 되나요?**

- 파일 창 열었을 때 빈 곳을 더블 클릭하면 발생

### 그래서 이 현상은 1)언제부터 2)어디에서 3)어떤 이유로 생겼나요?

- 빈 문자열일 때 suppress하는 코드가 없어서 발생
- 동일한 현상이 [Import FBX]에도 발생하므로 같이 달아주면 될거 같습니다.

[https://acontainer.slack.com/archives/C02K1NPTV42/p1657785061394089](https://acontainer.slack.com/archives/C02K1NPTV42/p1657785061394089)

### 어떤 조치를 취했나요?

- [x]  이전에 스듴님이 [File Open] 버튼에 넣은 코드가 있어서 [Import], [Import FBX] 에도 달아주면 됨
    
    [https://github.com/ACON3D/blender/pull/57](https://github.com/ACON3D/blender/pull/57)
    
- [x] ImportHelper를 오버라이딩하는 AconImportHelper 클래스를 만들어서 ImportHelper를 사용하는 Import, File Open, Import FBX에 모두 적용함.