### PR TITLE
obj.active_material이 있는지 확인

### DIFF
--- a/release/scripts/startup/abler/face_control.py
+++ b/release/scripts/startup/abler/face_control.py
@@ -110,8 +110,9 @@ class MaterialPanel(bpy.types.Panel):
             col.label(text=obj.name, icon="OBJECT_DATA")
             col = row.column()
             col.label(text="", icon="RIGHTARROW")
-            col = row.column()
-            col.label(text=obj.active_material.name, icon="MATERIAL")
+            if obj.active_material:
+                col = row.column()
+                col.label(text=obj.active_material.name, icon="MATERIAL")
             # MATERIAL_UL_List을 그려주는 부분
             row = layout.row()
             col = row.column()


### PR DESCRIPTION
0.2.4에 추가된 active_material 표시 기능 중 active_material이 없는 경우 에러가 발생합니다.
에이블러 상에서 에러 재현은 못했지만 if문으로 확인 후 없으면 서프레스하도록 코드 추가했습니다.

노션 문서 : https://www.notion.so/acon3d/active_material-None-type-4a22f53d3fca4276ad307a2d8d792738
