### PR TITLE
Acon3dImportPanel 이름 변경

### DIFF
--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -423,8 +423,8 @@ class SaveAsOperator(bpy.types.Operator, ExportHelper):
         return {"FINISHED"}
 
 
-class Acon3dImportPanel(bpy.types.Panel):
-    bl_idname = "ACON3D_PT_import"
+class Acon3dGeneralPanel(bpy.types.Panel):
+    bl_idname = "ACON3D_PT_general"
     bl_label = "General"
     bl_category = "ACON3D"
     bl_space_type = "VIEW_3D"
@@ -482,7 +482,7 @@ classes = (
     AconTutorialGuide1Operator,
     AconTutorialGuide2Operator,
     AconTutorialGuide3Operator,
-    Acon3dImportPanel,
+    Acon3dGeneralPanel,
     ToggleToolbarOperator,
     ImportOperator,
     ApplyToonStyleOperator,


### PR DESCRIPTION
실제 사용하는 부분의 내용과 맞지 않던
Acon3dImportPanel 의 이름과 idname 을 Import => General 로 변경하였습니다.

[노션 링크](https://www.notion.so/acon3d/Acon3dImportPanel-cad22d48952c4249bef31da9431a9a54)