### PR TITLE
Exposure, Gamma 토글 추가

### DIFF
--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -367,6 +367,28 @@ class AconSceneProperty(bpy.types.PropertyGroup):
         update=materials_handler.change_image_adjust_saturation,
     )
 
+    exposure: bpy.props.FloatProperty(
+        # name="Exposure",
+        name="",
+        description="Change exposure of the camera while looking at indoor objects",
+        subtype="FACTOR",
+        default=0.0,
+        min=0,
+        max=10,
+        update=materials_handler.change_exposure,
+    )
+
+    gamma: bpy.props.FloatProperty(
+        # name="Gamma",
+        name="",
+        description="Change the amount of the camera's gamma while looking at indoor objects",
+        subtype="FACTOR",
+        default=1.0,
+        min=0,
+        max=10,
+        update=materials_handler.change_gamma,
+    )
+
     selected_objects_str: bpy.props.StringProperty(name="Selected Objects")
 
     use_dof: bpy.props.BoolProperty(

--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -370,10 +370,10 @@ class AconSceneProperty(bpy.types.PropertyGroup):
     exposure: bpy.props.FloatProperty(
         # name="Exposure",
         name="",
-        description="Change exposure of the camera while looking at indoor objects",
+        description="Adjust the overall exposure and light up indoor space along with gamma (range: -10 ~ 10)",
         subtype="FACTOR",
         default=0.0,
-        min=0,
+        min=-10,
         max=10,
         update=materials_handler.change_exposure,
     )
@@ -381,11 +381,11 @@ class AconSceneProperty(bpy.types.PropertyGroup):
     gamma: bpy.props.FloatProperty(
         # name="Gamma",
         name="",
-        description="Change the amount of the camera's gamma while looking at indoor objects",
+        description="Adjust the overall gamma value and light up indoor space along with exposure (range: 0 ~ 5)",
         subtype="FACTOR",
         default=1.0,
         min=0,
-        max=10,
+        max=5,
         update=materials_handler.change_gamma,
     )
 

--- a/release/scripts/startup/abler/image_adjustment.py
+++ b/release/scripts/startup/abler/image_adjustment.py
@@ -117,11 +117,33 @@ class Acon3dHueSaturationPanel(bpy.types.Panel):
         layout.prop(prop, "image_adjust_saturation", text="Saturation", slider=True)
 
 
+class Acon3dExposurePanel(bpy.types.Panel):
+    bl_label = "Exposure"
+    bl_idname = "ACON3D_PT_image_sub_exposure"
+    bl_parent_id = "ACON3D_PT_image_adjustment"
+    bl_category = "ACON3D"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_options = {"DEFAULT_CLOSED"}
+    COMPAT_ENGINES = {"BLENDER_RENDER", "BLENDER_EEVEE", "BLENDER_WORKBENCH"}
+
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False  # No animation.
+
+        prop = context.scene.ACON_prop
+
+        layout.prop(prop, "exposure", text="Exposure", slider=True)
+        layout.prop(prop, "gamma", text="Gamma", slider=True)
+
+
 classes = (
     Acon3dImageAdjustmentPanel,
     Acon3dBrightnessContrastPanel,
     Acon3dColorBalancePanel,
     Acon3dHueSaturationPanel,
+    Acon3dExposurePanel,
 )
 
 

--- a/release/scripts/startup/abler/lib/materials/materials_handler.py
+++ b/release/scripts/startup/abler/lib/materials/materials_handler.py
@@ -396,6 +396,32 @@ def change_image_adjust_saturation(self, context: Context) -> None:
     inputs[1].default_value = value
 
 
+def change_exposure(self, context: Context) -> None:
+    if not context:
+        context = bpy.context
+
+    if not self:
+        self = context.scene.ACON_prop
+
+    prop: PropertyGroup = context.scene.ACON_prop
+    exposure: FloatProperty = prop.exposure
+
+    context.scene.view_settings.exposure = exposure
+
+
+def change_gamma(self, context: Context) -> None:
+    if not context:
+        context = bpy.context
+
+    if not self:
+        self = context.scene.ACON_prop
+
+    prop: PropertyGroup = context.scene.ACON_prop
+    gamma: FloatProperty = prop.gamma
+
+    context.scene.view_settings.gamma = gamma
+
+
 def change_line_props(self, context: Context) -> None:
     if not context:
         context = bpy.context


### PR DESCRIPTION
<img width="197" alt="스크린샷 2022-08-18 오후 7 57 58" src="https://user-images.githubusercontent.com/87409148/185379137-0f5b86e2-ace8-454a-9924-45f6b24fcfe3.png">

Color Management에 있던 Exposure, Gamma 토글을 custom_properties에 연결해 에이블러 Image Adjustment 패널 내 추가했습니다.

노션 문서 : https://www.notion.so/acon3d/Exposure-Gamma-6958b83530f04c22bb57558f32cb9343

