### PR TITLE
뷰포트 배경색 변경

### DIFF
--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -438,6 +438,16 @@ class AconSceneProperty(bpy.types.PropertyGroup):
         update=bloom.change_bloom_clamp,
     )
 
+    background_color: bpy.props.FloatVectorProperty(
+        name="",
+        description="Change background color",
+        subtype="COLOR",
+        default=(1.0, 1.0, 1.0),
+        min=0.0,
+        max=1.0,
+        update=scenes.change_background_color,
+    )
+
 
 class AconMaterialProperty(bpy.types.PropertyGroup):
     @classmethod

--- a/release/scripts/startup/abler/lib/post_open.py
+++ b/release/scripts/startup/abler/lib/post_open.py
@@ -1,5 +1,6 @@
 import bpy
 from ..custom_properties import AconSceneProperty
+import mathutils
 
 
 def change_and_reset_value() -> None:
@@ -13,6 +14,10 @@ def change_and_reset_value() -> None:
         if type(original_value) == float or type(original_value) == int:
             setattr(bpy.context.scene.ACON_prop, property, original_value)
         elif type(original_value) == bool:
+            setattr(bpy.context.scene.ACON_prop, property, original_value)
+
+        # background_color property 업데이트
+        elif type(original_value) == mathutils.Color:
             setattr(bpy.context.scene.ACON_prop, property, original_value)
 
         # string을 뺀 이유 : EnumProperty에 없는 값을 넣어주면 error가 뜸.

--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -77,6 +77,14 @@ def refresh_look_at_me() -> None:
     context.view_layer.objects.active = prev_active_object
 
 
+def change_background_color(self, context: Context) -> None:
+    background_color = context.scene.ACON_prop.background_color
+
+    ui = context.preferences.themes[0].user_interface
+    ui.transparent_checker_primary = background_color
+    ui.transparent_checker_secondary = background_color
+
+
 # scene_items should be a global variable due to a bug in EnumProperty
 scene_items: List[Tuple[str, str, str]] = []
 

--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -38,6 +38,7 @@ def init_setting(dummy):
     prefs_view.show_navigate_ui = False
     prefs_view.show_developer_ui = False
     prefs_view.show_tooltips_python = False
+    prefs_view.color_picker_type = "SQUARE_SV"
     prefs_paths.use_load_ui = False
     prefs_paths.save_version = 0
 

--- a/release/scripts/startup/abler/render_control.py
+++ b/release/scripts/startup/abler/render_control.py
@@ -602,6 +602,13 @@ class Acon3dRenderPanel(bpy.types.Panel):
             row.operator("acon3d.render_all", text="Render All Scenes")
             row.operator("acon3d.render_snip", text="Snip Render")
 
+            theme = context.preferences.themes[0]
+            ui = theme.user_interface
+            row = layout.row()
+            row.prop(ui, "transparent_checker_primary")
+            row = layout.row()
+            row.prop(ui, "transparent_checker_secondary")
+
 
 classes = (
     Acon3dCameraViewOperator,

--- a/release/scripts/startup/abler/render_control.py
+++ b/release/scripts/startup/abler/render_control.py
@@ -602,11 +602,9 @@ class Acon3dRenderPanel(bpy.types.Panel):
             row.operator("acon3d.render_all", text="Render All Scenes")
             row.operator("acon3d.render_snip", text="Snip Render")
 
-            ui = context.preferences.themes[0].user_interface
             row = layout.row()
-            row.prop(ui, "transparent_checker_primary", text="Background Color")
-
-            ui.transparent_checker_secondary = ui.transparent_checker_primary
+            prop = context.scene.ACON_prop
+            row.prop(prop, "background_color", text="background_color")
 
 
 classes = (

--- a/release/scripts/startup/abler/render_control.py
+++ b/release/scripts/startup/abler/render_control.py
@@ -602,12 +602,11 @@ class Acon3dRenderPanel(bpy.types.Panel):
             row.operator("acon3d.render_all", text="Render All Scenes")
             row.operator("acon3d.render_snip", text="Snip Render")
 
-            theme = context.preferences.themes[0]
-            ui = theme.user_interface
+            ui = context.preferences.themes[0].user_interface
             row = layout.row()
-            row.prop(ui, "transparent_checker_primary")
-            row = layout.row()
-            row.prop(ui, "transparent_checker_secondary")
+            row.prop(ui, "transparent_checker_primary", text="Background Color")
+
+            ui.transparent_checker_secondary = ui.transparent_checker_primary
 
 
 classes = (

--- a/release/scripts/startup/abler/render_control.py
+++ b/release/scripts/startup/abler/render_control.py
@@ -604,7 +604,7 @@ class Acon3dRenderPanel(bpy.types.Panel):
 
             row = layout.row()
             prop = context.scene.ACON_prop
-            row.prop(prop, "background_color", text="background_color")
+            row.prop(prop, "background_color", text="Background Color")
 
 
 classes = (


### PR DESCRIPTION
1. 렌더 토글에 `user_interface.transparent_checker_primary `프로퍼티를 그대로 가져와 row.prop으로 써서 배경색을 변경하도록 했습니다. 추가로 pref.py에 컬러 토글을 `"SQUARE_SV"`로 설정해주었습니다.

2. 그러나 프로퍼티를 직접 바꿔 배경색을 변경하면 다시 켰을 때 배경색이 저장되지 않는 문제가 발생했습니다.
그래서 배경색 값을 저장하는 ACON_prop의 커스텀 프로퍼티(`background_color`)를 만들어 row.prop으로 토글에 넣었습니다. 이렇게 되면 배경색을 기억해 껐다가 켜도 프로퍼티가 남아있습니다.
3. 하지만 껐다가 켰을 때 프로터티에 값은 남아있는데 에이블러를 켰을 때 바로 반영이 안되는 문제가 있었습니다. 
이는 이전에 겪었던 문제고 post_open의 커스텀 프로퍼티 값들을 받아와 업데이트 해주는 `change_and_reset_value()` 내에 Color 타입을 추가해주어 켤때마다 반영되도록 했습니다.

노션 문서 : https://www.notion.so/acon3d/0649a4860018414383d536f8e17cbf6f
