### PR TITLE
레이어 이름 변경 시, 앱이 강제종료되는 현상 수정

### DIFF
--- a/source/blender/editors/interface/interface_handlers.c
+++ b/source/blender/editors/interface/interface_handlers.c
@@ -939,13 +939,16 @@ static void ui_apply_but_undo(uiBut *but)
       str_len_clip = strlen(str);
     }
 
-    const char* rna_id = RNA_property_identifier(but->rnaprop);
-    for (int i = 0; i < sizeof(SkipIdentifierKeywords) / sizeof(SkipIdentifierKeywords[0]); i++) {
-      if (strcmp(rna_id, SkipIdentifierKeywords[i]) == 0) {
-        skip_undo = true;
-        break;
+    if (but->rnaprop) {
+      const char* rna_id = RNA_property_identifier(but->rnaprop);
+      for (int i = 0; i < sizeof(SkipIdentifierKeywords) / sizeof(SkipIdentifierKeywords[0]); i++) {
+        if (strcmp(rna_id, SkipIdentifierKeywords[i]) == 0) {
+          skip_undo = true;
+          break;
+        }
       }
     }
+
     /* Optionally override undo when undo system doesn't support storing properties. */
     if (but->rnapoin.owner_id) {
       /* Exception for renaming ID data, we always need undo pushes in this case,


### PR DESCRIPTION
## 관련 링크
[슬랙](https://acontainer.slack.com/archives/C02K1NPTV42/p1661766293657939)
[태스크 카드](https://www.notion.so/acon3d/705e63e117e04ab0a77647804b823abb)

## 발제/내용

- 아웃라이너에서 레이어 이름을 변경하면, 앱이 강제 종료됩니다.

## 대응

### 어떤 조치를 취했나요?

- but→rnaprop 이 NULL 일 때 위 이슈가 발생하는 것으로 판단되어 해당 부분에 NULL 이 아닐 때만 동작하도록 조건을 추가하였습니다.