### PR TITLE
최근 파일 목록 관련 엣지 케이스 대응

### DIFF
--- a/release/scripts/presets/keyconfig/keymap_data/abler_default.py
+++ b/release/scripts/presets/keyconfig/keymap_data/abler_default.py
@@ -437,7 +437,7 @@ def km_window(params):
     items.extend([
         # File operations
         op_menu("TOPBAR_MT_file_new", {"type": 'N', "value": 'PRESS', "ctrl": True}),
-        op_menu("TOPBAR_MT_ACON3D_open_recent_files", {"type": 'O', "value": 'PRESS', "shift": True, "ctrl": True}),
+        op_menu("TOPBAR_MT_file_open_recent", {"type": 'O', "value": 'PRESS', "shift": True, "ctrl": True}),
         ("acon3d.file_open", {"type": 'O', "value": 'PRESS', "ctrl": True}, None),
         ("acon3d.save", {"type": 'S', "value": 'PRESS', "ctrl": True}, None),
         ("acon3d.save_as", {"type": 'S', "value": 'PRESS', "shift": True, "ctrl": True}, None),

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -285,7 +285,7 @@ class SaveOperator(bpy.types.Operator, ExportHelper):
                 dirname, basename = split_filepath(self.filepath)
 
                 bpy.ops.wm.save_mainfile(
-                    {"dict": "override"}, filepath=self.filepath, need_update=True
+                    {"dict": "override"}, filepath=self.filepath, update_history=True
                 )
 
                 self.report({"INFO"}, f'Saved "{basename}{self.filename_ext}"')
@@ -298,7 +298,7 @@ class SaveOperator(bpy.types.Operator, ExportHelper):
                 self.filepath = f"{numbered_filepath}{self.filename_ext}"
 
                 bpy.ops.wm.save_mainfile(
-                    {"dict": "override"}, filepath=self.filepath, need_update=True
+                    {"dict": "override"}, filepath=self.filepath, update_history=True
                 )
 
                 self.report({"INFO"}, f'Saved "{numbered_filename}{self.filename_ext}"')
@@ -330,7 +330,7 @@ class SaveAsOperator(bpy.types.Operator, ExportHelper):
             self.filepath = f"{numbered_filepath}{self.filename_ext}"
 
             bpy.ops.wm.save_as_mainfile(
-                {"dict": "override"}, filepath=self.filepath, need_update=True
+                {"dict": "override"}, filepath=self.filepath, update_history=True
             )
 
             self.report({"INFO"}, f'Saved "{numbered_filename}{self.filename_ext}"')

--- a/release/scripts/startup/abler/tracker_functions.py
+++ b/release/scripts/startup/abler/tracker_functions.py
@@ -1,0 +1,9 @@
+from lib.tracker import tracker
+
+# function for tracking in c
+def tracker_file_open_fail():
+    tracker.file_open_fail()
+
+
+def tracker_file_open():
+    tracker.file_open()

--- a/release/scripts/startup/bl_ui/space_topbar.py
+++ b/release/scripts/startup/bl_ui/space_topbar.py
@@ -289,7 +289,7 @@ class TOPBAR_MT_file(Menu):
         layout.operator_context = 'INVOKE_AREA'
         layout.menu("TOPBAR_MT_file_new", text="New", icon='FILE_NEW')
         layout.operator("acon3d.file_open", text="Open...", icon='FILE_FOLDER')
-        layout.menu("TOPBAR_MT_ACON3D_open_recent_files")
+        layout.menu("TOPBAR_MT_file_open_recent")
         layout.operator("wm.revert_mainfile")
         layout.menu("TOPBAR_MT_file_recover")
 
@@ -395,29 +395,6 @@ class TOPBAR_MT_file_new(Menu):
 
     def draw(self, context):
         TOPBAR_MT_file_new.draw_ex(self.layout, context)
-
-class TOPBAR_MT_ACON3D_open_recent_files(Menu):
-    bl_label = "Open Recent"
-
-    def draw(self, _context):
-        layout = self.layout
-
-        history_path = bpy.utils.user_resource("CONFIG") + "/recent-files.txt"
-
-        try:
-            with open(history_path, "r") as f:
-                recent_filepaths = f.read().splitlines()
-
-            if len(recent_filepaths) == 0:
-                raise
-        except:
-            layout.label(text='No Recent Files')
-            return
-
-        for filepath in recent_filepaths:
-            filename = os.path.basename(filepath)
-            sublayout = layout.operator("acon3d.recent_file_open", text=filename, icon='FILE_BLEND')
-            sublayout.filepath = filepath
 
 
 class TOPBAR_MT_file_recover(Menu):
@@ -893,7 +870,6 @@ classes = (
     TOPBAR_MT_blender_system,
     TOPBAR_MT_file,
     TOPBAR_MT_file_new,
-    TOPBAR_MT_ACON3D_open_recent_files,
     TOPBAR_MT_file_recover,
     TOPBAR_MT_file_defaults,
     TOPBAR_MT_templates_more,

--- a/source/blender/makesrna/intern/rna_access.c
+++ b/source/blender/makesrna/intern/rna_access.c
@@ -2153,6 +2153,8 @@ static void rna_property_update(
       WM_msg_publish_rna(mbus, ptr, prop);
     }
     if (ptr->owner_id != NULL && ((prop->flag & PROP_NO_DEG_UPDATE) == 0)) {
+      printf("Update %s: insert %s\n", ptr->owner_id->name, prop->identifier);
+
       const short id_type = GS(ptr->owner_id->name);
       if (ID_TYPE_IS_COW(id_type)) {
         DEG_id_tag_update(ptr->owner_id, ID_RECALC_COPY_ON_WRITE);

--- a/source/blender/python/intern/ABLER_py.c
+++ b/source/blender/python/intern/ABLER_py.c
@@ -3,7 +3,12 @@
 //
 #include <Python.h>
 #include "ABLER_py.h"
-#include <unistd.h>
+
+#ifdef WIN32
+#   include <direct.h>
+#else
+#   include <unistd.h>
+#endif
 
 #define FILE_MAX 1024
 
@@ -12,12 +17,18 @@ static void call_abler_function(char* file_path, char* file_name, char* function
     const PyGILState_STATE gilstate = PyGILState_Ensure();
 
     char cwd[FILE_MAX];
+
+#if defined(WIN32)
+    wchar_t wText[MAX_PATH];
+    _wgetcwd(path, MAX_PATH);
+#else
     getcwd(cwd, sizeof(cwd));
     strcat(cwd, file_path);
 
     const size_t size = strlen(cwd) + 1;
     wchar_t wText[size];
     mbstowcs(wText, cwd, size);
+#endif
 
     PySys_SetPath(wText);
 

--- a/source/blender/python/intern/ABLER_py.c
+++ b/source/blender/python/intern/ABLER_py.c
@@ -1,0 +1,44 @@
+//
+// Created by 장종원 on 2022/08/30.
+//
+#include <Python.h>
+#include "ABLER_py.h"
+#include <unistd.h>
+
+#define FILE_MAX 1024
+
+// file_path root - blender
+static void call_abler_function(char* file_path, char* file_name, char* function_name) {
+    const PyGILState_STATE gilstate = PyGILState_Ensure();
+
+    char cwd[FILE_MAX];
+    getcwd(cwd, sizeof(cwd));
+    strcat(cwd, file_path);
+
+    const size_t size = strlen(cwd) + 1;
+    wchar_t wText[size];
+    mbstowcs(wText, cwd, size);
+
+    PySys_SetPath(wText);
+
+    PyObject *module = NULL, *result = NULL;
+    module = PyImport_ImportModule(file_name);
+    if (module) {
+        result = PyObject_CallMethod(module, function_name, NULL);
+    }
+
+    PyErr_Print();
+
+    Py_DECREF(result);
+    Py_DECREF(module);
+
+    PyGILState_Release(gilstate);
+}
+
+void tracker_open_fail(void) {
+    call_abler_function("/release/scripts/startup/abler", "tracker_functions", "tracker_file_open_fail");
+}
+
+void tracker_open(void) {
+    call_abler_function("/release/scripts/startup/abler", "tracker_functions", "tracker_file_open");
+}

--- a/source/blender/python/intern/ABLER_py.c
+++ b/source/blender/python/intern/ABLER_py.c
@@ -12,7 +12,12 @@
 static void call_abler_function(wchar_t *w_cwd, char* file_name, char* function_name) {
   PyGILState_STATE gilstate = PyGILState_Ensure();
 
+//  PyObject *sys_path = PySys_GetObject("path");
+//  PyList_Append(sys_path, PyUnicode_FromWideChar(w_cwd, -1));
+//  Py_DECREF(sys_path);
+
   PySys_SetPath(w_cwd);
+
   PyObject *module = NULL, *result = NULL;
 
   module = PyImport_ImportModule(file_name);

--- a/source/blender/python/intern/ABLER_py.h
+++ b/source/blender/python/intern/ABLER_py.h
@@ -1,0 +1,19 @@
+//
+// Created by 장종원 on 2022/08/30.
+//
+/** \file
+ * \ingroup pythonintern
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void tracker_open_fail(void);
+void tracker_open(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/source/blender/python/intern/CMakeLists.txt
+++ b/source/blender/python/intern/CMakeLists.txt
@@ -129,6 +129,9 @@ set(SRC
   ../BPY_extern_clog.h
   ../BPY_extern_python.h
   ../BPY_extern_run.h
+
+  ABLER_py.h
+  ABLER_py.c
 )
 
 set(LIB

--- a/source/blender/windowmanager/intern/wm.c
+++ b/source/blender/windowmanager/intern/wm.c
@@ -636,6 +636,7 @@ void WM_main(bContext *C)
 {
   /* Single refresh before handling events.
    * This ensures we don't run operators before the depsgraph has been evaluated. */
+  printf("WM_MAIN!\n");
   wm_event_do_refresh_wm_and_depsgraph(C);
 
   while (1) {

--- a/source/blender/windowmanager/intern/wm_files.c
+++ b/source/blender/windowmanager/intern/wm_files.c
@@ -2671,6 +2671,7 @@ static int wm_open_mainfile__select_file_path(bContext *C, wmOperator *op)
 
 static int wm_open_mainfile__open(bContext *C, wmOperator *op)
 {
+  printf("File Open!\n");
   char filepath[FILE_MAX];
   bool success;
 

--- a/source/blender/windowmanager/intern/wm_files.c
+++ b/source/blender/windowmanager/intern/wm_files.c
@@ -1749,7 +1749,7 @@ static bool wm_file_write(bContext *C,
                           eBLO_WritePathRemap remap_mode,
                           bool use_save_as_copy,
                           ReportList *reports,
-                          bool need_update)
+                          bool update_history)
 {
   Main *bmain = CTX_data_main(C);
   int len;
@@ -1871,7 +1871,7 @@ static bool wm_file_write(bContext *C,
                          .thumb = thumb,
                      },
                      reports)) {
-    const bool do_history_file_update = need_update || ((G.background == false) &&
+    const bool do_history_file_update = update_history || ((G.background == false) &&
                                         (CTX_wm_manager(C)->op_undo_depth == 0));
 
     if (use_save_as_copy == false) {
@@ -3127,9 +3127,9 @@ static int wm_save_as_mainfile_exec(bContext *C, wmOperator *op)
   /* set compression flag */
   SET_FLAG_FROM_TEST(fileflags, RNA_boolean_get(op->ptr, "compress"), G_FILE_COMPRESS);
 
-  const bool need_update = RNA_boolean_get(op->ptr, "need_update");
+  const bool update_history = RNA_boolean_get(op->ptr, "update_history");
 
-  const bool ok = wm_file_write(C, path, fileflags, remap_mode, use_save_as_copy, op->reports, need_update);
+  const bool ok = wm_file_write(C, path, fileflags, remap_mode, use_save_as_copy, op->reports, update_history);
 
   if ((op->flag & OP_IS_INVOKE) == 0) {
     /* OP_IS_INVOKE is set when the operator is called from the GUI.
@@ -3224,7 +3224,7 @@ void WM_OT_save_as_mainfile(wmOperatorType *ot)
   // ABLER Custom Property
   RNA_def_boolean(
       ot->srna,
-      "need_update",
+      "update_history",
       false,
       "Need Update",
       "Update recent files if true");
@@ -3298,7 +3298,7 @@ void WM_OT_save_mainfile(wmOperatorType *ot)
   // ABLER Custom Property
   RNA_def_boolean(
       ot->srna,
-      "need_update",
+      "update_history",
       false,
       "Need Update",
       "Update recent files if true");


### PR DESCRIPTION
## 관련 링크
[노션 태스트 카드](https://www.notion.so/acon3d/8844c8fe7032428da1e9f61cedc41c04)

## 발제/내용

- Save Remind 팝업이 띄워지는 시점 변경
- Save Cancel 시 최근 파일에 기록이 되는 버그 수정

## 대응

### 어떤 조치를 취했나요?

- `call_abler_function` 이라는 함수를 만들어, 에이블러의 python 코드를 C 에서 사용할 수 있게 만들었습니다.
    - 현재 `tracker_open_fail` , `tracker_open` 두 가지 함수가 사용되고 있습니다.
- 위에서 python 함수를 C 로 변환하는 과정에 트래킹하는 함수만 넣으면 기본 오퍼레이터가 사용 가능해서 기존에 사용하던 최근파일열기 Operator 를 제거하였습니다.
- 위 과정에서 최근 파일이 저장 시에 갱신 안되는 오류가 있어서, save (as) 오퍼레이터에 need_update 라는 커스텀 파라미터를 넣어서 에이블러의 커스텀 오퍼레이터를 사용할 떄는 항상 최근 파일 리스트를 갱신하도록 하였습니다.
- 위 변경 과정에 따라 필요 없어진 최근 파일을 작성하는 함수 `update_recent_files` 를 제거하였습니다.