### PR TITLE
아웃라이너에서 카메라를 지워서 없을 때, 새로운 카메라를 만들어서 카메라뷰로 켜주는 로직 추가

### DIFF
--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -150,6 +150,7 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
     else:
         cam = bpy.data.cameras.new("View Camera")
         cam.lens = 30
+        cam.show_passepartout = False
         obj = bpy.data.objects.new("View Camera", cam)
         obj.location = (4.7063, 7.6888, 1.9738)
         obj.rotation_euler = (radians(90), radians(0), radians(-212))

--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -146,6 +146,7 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
 
     else:
         cam2 = bpy.data.cameras.new("View Camera")
+        cam2.lens = 30
         obj2 = bpy.data.objects.new("View Camera", cam2)
         obj2.location = (4.7063, 7.6888, 1.9738)
         obj2.rotation_euler = (radians(90), radians(0), radians(-212))

--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -145,19 +145,20 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
             print("Failed to unlink camera from old scene.")
 
     else:
-        cam2 = bpy.data.cameras.new("View Camera")
-        cam2.lens = 30
-        obj2 = bpy.data.objects.new("View Camera", cam2)
-        obj2.location = (4.7063, 7.6888, 1.9738)
-        obj2.rotation_euler = (radians(90), radians(0), radians(-212))
-        new_scene.collection.objects.link(obj2)
-        new_scene.camera = obj2
+        cam = bpy.data.cameras.new("View Camera")
+        cam.lens = 30
+        obj = bpy.data.objects.new("View Camera", cam)
+        obj.location = (4.7063, 7.6888, 1.9738)
+        obj.rotation_euler = (radians(90), radians(0), radians(-212))
+        new_scene.collection.objects.link(obj)
+        new_scene.camera = obj
         cameras.switch_to_rendered_view()
         cameras.turn_on_camera_view(False)
 
     prop = new_scene.ACON_prop
 
     if type == "Indoor Daytime":
+
         prop.toggle_toon_edge = True
         prop.edge_min_line_width = 1
         prop.edge_max_line_width = 1
@@ -191,6 +192,7 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
         new_scene.render.resolution_y = 2700
 
     if type == "Indoor Sunset":
+
         prop.toggle_toon_edge = True
         prop.edge_min_line_width = 1
         prop.edge_max_line_width = 1
@@ -224,6 +226,7 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
         new_scene.render.resolution_y = 2700
 
     if type == "Indoor Nighttime":
+
         prop.toggle_toon_edge = True
         prop.edge_min_line_width = 1
         prop.edge_max_line_width = 1
@@ -257,6 +260,7 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
         new_scene.render.resolution_y = 2700
 
     if type == "Outdoor Daytime":
+
         prop.toggle_toon_edge = True
         prop.edge_min_line_width = 1
         prop.edge_max_line_width = 1
@@ -290,6 +294,7 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
         new_scene.render.resolution_y = 2700
 
     if type == "Outdoor Sunset":
+
         prop.toggle_toon_edge = True
         prop.edge_min_line_width = 1
         prop.edge_max_line_width = 1
@@ -323,6 +328,7 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
         new_scene.render.resolution_y = 2700
 
     if type == "Outdoor Nighttime":
+
         prop.toggle_toon_edge = True
         prop.edge_min_line_width = 1
         prop.edge_max_line_width = 1

--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -24,6 +24,7 @@ from . import shadow, layers, objects
 from .materials import materials_handler
 from math import radians
 from .tracker import tracker
+from . import cameras
 
 
 def change_dof(self, context: Context) -> None:
@@ -62,7 +63,6 @@ def gen_scene_name(name: str, i: int = 1) -> str:
 
 
 def refresh_look_at_me() -> None:
-
     context = bpy.context
     prev_active_object = context.active_object
 
@@ -98,7 +98,6 @@ def add_scene_items(self, context: Context) -> List[Tuple[str, str, str]]:
 
 
 def load_scene(self, context: Context) -> None:
-
     if not context:
         context = bpy.context
 
@@ -134,23 +133,30 @@ def load_scene(self, context: Context) -> None:
 
 
 def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
-
     new_scene = old_scene.copy()
     new_scene.name = name
+    if old_scene.camera:
+        new_scene.camera = old_scene.camera.copy()
+        new_scene.camera.data = old_scene.camera.data.copy()
+        new_scene.collection.objects.link(new_scene.camera)
+        try:
+            new_scene.collection.objects.unlink(old_scene.camera)
+        except:
+            print("Failed to unlink camera from old scene.")
 
-    new_scene.camera = old_scene.camera.copy()
-    new_scene.camera.data = old_scene.camera.data.copy()
-    new_scene.collection.objects.link(new_scene.camera)
-
-    try:
-        new_scene.collection.objects.unlink(old_scene.camera)
-    except:
-        print("Failed to unlink camera from old scene.")
+    else:
+        cam2 = bpy.data.cameras.new("View Camera")
+        obj2 = bpy.data.objects.new("View Camera", cam2)
+        obj2.location = (4.7063, 7.6888, 1.9738)
+        obj2.rotation_euler = (radians(90), radians(0), radians(-212))
+        new_scene.collection.objects.link(obj2)
+        new_scene.camera = obj2
+        cameras.switch_to_rendered_view()
+        cameras.turn_on_camera_view(False)
 
     prop = new_scene.ACON_prop
 
     if type == "Indoor Daytime":
-
         prop.toggle_toon_edge = True
         prop.edge_min_line_width = 1
         prop.edge_max_line_width = 1
@@ -184,7 +190,6 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
         new_scene.render.resolution_y = 2700
 
     if type == "Indoor Sunset":
-
         prop.toggle_toon_edge = True
         prop.edge_min_line_width = 1
         prop.edge_max_line_width = 1
@@ -218,7 +223,6 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
         new_scene.render.resolution_y = 2700
 
     if type == "Indoor Nighttime":
-
         prop.toggle_toon_edge = True
         prop.edge_min_line_width = 1
         prop.edge_max_line_width = 1
@@ -252,7 +256,6 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
         new_scene.render.resolution_y = 2700
 
     if type == "Outdoor Daytime":
-
         prop.toggle_toon_edge = True
         prop.edge_min_line_width = 1
         prop.edge_max_line_width = 1
@@ -286,7 +289,6 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
         new_scene.render.resolution_y = 2700
 
     if type == "Outdoor Sunset":
-
         prop.toggle_toon_edge = True
         prop.edge_min_line_width = 1
         prop.edge_max_line_width = 1
@@ -320,7 +322,6 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
         new_scene.render.resolution_y = 2700
 
     if type == "Outdoor Nighttime":
-
         prop.toggle_toon_edge = True
         prop.edge_min_line_width = 1
         prop.edge_max_line_width = 1

--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -63,6 +63,7 @@ def gen_scene_name(name: str, i: int = 1) -> str:
 
 
 def refresh_look_at_me() -> None:
+
     context = bpy.context
     prev_active_object = context.active_object
 
@@ -98,6 +99,7 @@ def add_scene_items(self, context: Context) -> List[Tuple[str, str, str]]:
 
 
 def load_scene(self, context: Context) -> None:
+
     if not context:
         context = bpy.context
 
@@ -133,6 +135,7 @@ def load_scene(self, context: Context) -> None:
 
 
 def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
+
     new_scene = old_scene.copy()
     new_scene.name = name
     if old_scene.camera:


### PR DESCRIPTION
## 관련 링크
[노션 링크](https://www.notion.so/acon3d/Nonetype-a25d1c51174d4b11a9597f9f041b3ce4)

## 발제/내용

- 아웃라이너에서 View Camera를 지우고 씬을 추가하는 경우에 old_scene의 씬 카메라 정보가 없어서 Nonetype 에러가 나고 있었음
![image](https://user-images.githubusercontent.com/43770096/188572858-e5f4be21-10de-44ed-aefd-77dc57beaee5.png)


## 대응

### 어떤 조치를 취했나요?

- [x]  old_scene의 카메라 정보가 없을 경우, 새로 카메라를 추가함
- [x]  해당 카메라를 scene에 추가함
- [x]  그 카메라를 중심으로 camera view를 켜줌