### PR TITLE
ImportOperator에서 사용되지 않는 부분 삭제

### DIFF
--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -161,19 +161,12 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
                 data_to.collections = data_from.collections
                 data_to.objects = list(data_from.objects)
 
-            children_names = {}
-
-            for coll in data_to.collections:
-                for child in coll.children.keys():
-                    children_names[child] = True
-
             for coll in data_to.collections:
 
                 if "ACON_col" in coll.name:
                     data_to.collections.remove(coll)
                     break
 
-                found = any(coll.name == child for child in children_names)
                 if coll.name == "Layers" or (
                     "Layers." in coll.name and len(coll.name) == 10
                 ):


### PR DESCRIPTION
## 관련 링크
[Notion](https://www.notion.so/acon3d/Import-1460fc44d04d4b6aad69e179fb3b84b6)
[Slack](https://acontainer.slack.com/archives/C02K1NPTV42/p1662536717842939) 논의 내용

## 발제/내용

- Import 관련 에러를 처리하는 중, 사용되지 않는 코드가 있어 삭제하였습니다.

## 대응

### 어떤 조치를 취했나요?

- `general.py`에서 사용되지 않는 변수 `children_names`, `found` 관련 코드를 삭제했습니다.