### PR TITLE
파일 오픈 후, .blend 파일 import 에러 처리

### DIFF
--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -143,6 +143,16 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
     filter_glob: bpy.props.StringProperty(default="*.blend", options={"HIDDEN"})
 
     def execute(self, context):
+        # TODO: 현재 상태의 콜렉션 받아오기
+        layers = []
+        layers_same = []
+
+        print("\n기존 파일의 콜렉션 출력")
+        for coll in bpy.data.collections:
+            layers.append(coll.name)
+        print(layers)
+
+
         try:
             if not self.check_path():
                 return {"FINISHED"}
@@ -163,9 +173,12 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
                 data_to.collections = data_from.collections
                 data_to.objects = list(data_from.objects)
 
-                print("\ncoll (0)")
+                print("\ncoll (1)")
                 for coll in data_to.collections:
                     print(coll)
+
+                    if coll in layers:
+                        layers_same.append(coll)
 
             print("\ncoll (2)")
             for coll in data_to.collections:

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -175,6 +175,14 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
                 data_to.collections = data_from.collections
                 data_to.objects = list(data_from.objects)
 
+            # Note: data_to에서 object.name을 확인해서 중복 처리 전후로 오브젝트 목록 비교해보기
+            print("")
+            for obj in data_from.objects:
+                print(f"from: {obj}")
+            for obj in data_to.objects:
+                print(f"to: {obj.name}")
+
+
             for coll in data_to.collections:
                 if "ACON_col" in coll.name:
                     data_to.collections.remove(coll)
@@ -216,10 +224,22 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
 
             self.duplicate_layer.clear()
 
+            # Note: bpy.context.view_layer의 데이터 가져오기
+            view_layer = []
+            for obj in context.view_layer.objects:
+                view_layer.append(obj.name)
+            print(view_layer)
+
             for obj in data_to.objects:
                 if obj.type == "MESH":
-                    obj.select_set(True)
+                    print(f"obj.type == 'MESH': {obj.name}")
+                    if obj.name in view_layer:
+                        obj.select_set(True)
+                    # obj.select_set(True)
+                    else:
+                        data_to.objects.remove(obj)
                 else:
+                    print(f"else: {obj.name}")
                     data_to.objects.remove(obj)
 
             materials_setup.apply_ACON_toon_style()

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -141,7 +141,6 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
     bl_translation_context = "*"
 
     filter_glob: bpy.props.StringProperty(default="*.blend", options={"HIDDEN"})
-    duplicate_layer = []
 
     class SameFileImportError(Exception):
         def __init__(self):
@@ -190,7 +189,6 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
                                     coll_obj
                                 )
                                 bpy.data.collections["Layer0"].objects.link(coll_obj)
-                            self.duplicate_layer.append(coll_2.name)
 
                         else:
                             added_l_exclude = context.scene.l_exclude.add()
@@ -199,14 +197,13 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
                             col_layers.children.link(coll_2)
 
             # 레이어 이름에 Layer0.이 포함된 중복 레이어 제거
-            for coll_name in self.duplicate_layer:
-                coll = bpy.data.collections.get(coll_name)
-                bpy.data.collections.remove(coll)
-            self.duplicate_layer.clear()
+            for coll in data_to.collections:
+                if "Layer0." in coll.name:
+                    bpy.data.collections.remove(coll)
 
+            # View Layer에 없는 Mesh Object들의 select_set(True) 에러가 나고 있었음
+            # 이런 오브젝트들은 선택되지 않아도 무방하여 해당 작업을 제거함
             for obj in data_to.objects:
-                # View Layer에 없는 Mesh Object들의 select_set(True) 에러가 나고 있었음
-                # 이런 오브젝트들은 선택되지 않아도 무방하여 해당 작업을 제거함
                 if obj.type != "MESH":
                     data_to.objects.remove(obj)
 

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -143,6 +143,7 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
     filter_glob: bpy.props.StringProperty(default="*.blend", options={"HIDDEN"})
     duplicate_layer = []
     view_layer_obj = []
+    ImportError = False
 
     def execute(self, context):
         try:
@@ -155,12 +156,8 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
             filepath = self.filepath
 
             if filepath_curr == filepath:
-                bpy.ops.acon3d.alert(
-                    "INVOKE_DEFAULT",
-                    title="Import Failure",
-                    message_1="Cannot import exact same file from same directory.",
-                )
-                return {"FINISHED"}
+                self.ImportError = True
+                raise
 
             for obj in bpy.data.objects:
                 obj.select_set(False)
@@ -228,7 +225,14 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
         # TODO: 에러 세분화 필요
         except Exception as e:
             tracker.import_blend_fail()
-            self.report({"ERROR"}, f"Fail to import blend file. Check filepath.")
+            if self.ImportError:
+                bpy.ops.acon3d.alert(
+                    "INVOKE_DEFAULT",
+                    title="Import Failure",
+                    message_1="Cannot import exact same file from same directory.",
+                )
+            else:
+                self.report({"ERROR"}, f"Fail to import blend file. Check filepath.")
         else:
             tracker.import_blend()
 

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -208,6 +208,7 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
             # View Layer에 포함된 오브젝트 가져오기
             for obj in context.view_layer.objects:
                 self.view_layer_obj.append(obj.name)
+            self.view_layer_obj.clear()
 
             for obj in data_to.objects:
                 if (obj.type == "MESH") and (obj.name in self.view_layer_obj):

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -162,7 +162,16 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
                 data_to.objects = list(data_from.objects)
 
             print("")
+            print("data_to.collections 출력")
             for coll in data_to.collections:
+                # print(f"0) coll.name: {coll.name}")
+                pass
+
+            print("")
+            remove_list = []
+            for coll in data_to.collections:
+                # print(f"1) coll: {coll}")
+
                 if "ACON_col" in coll.name:
                     data_to.collections.remove(coll)
                     break
@@ -170,29 +179,31 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
                 if coll.name == "Layers" or (
                     "Layers." in coll.name and len(coll.name) == 10
                 ):
-                    print(f"coll.name: {coll.name}")
+                    print(f"2) coll.name: {coll.name}")
                     for coll_2 in coll.children:
-                        print(f"coll_2.name: {coll_2.name}")
+                        print(f"3) coll_2.name: {coll_2.name}")
                         # 중복된 Collection Layer명에는 ".001"부터 넘버링됨
                         # ".001"이 추가될 때마다 처리를 해주면, ".001" 넘버링만으로도 중복 체크 가능
                         if ".001" in coll_2.name:
-                            print(f"coll_2.name.001: {coll_2.name}")
+                            print(f"4) 중복 처리")
                             for obj in bpy.data.collections[coll_2.name].objects:
-                                print(obj.name)
+                                # print(obj.name)
                                 bpy.data.collections[coll_2.name].objects.unlink(obj)
                                 bpy.data.collections[coll_2.name[:-4]].objects.link(obj)
-                            coll_3 = bpy.data.collections[coll_2.name[:-4]]
-                            bpy.data.collections.remove(coll_2)
-
-                            # added_l_exclude = context.scene.l_exclude.add()
-                            # added_l_exclude.name = coll_3.name
-                            # added_l_exclude.value = True
+                            # bpy.data.collections.remove(coll_2)
+                            print("콜렉션 지울 예정")
+                            remove_list.append(coll_2.name)
 
                         else:
+                            print("5) 중복 처리 아님")
                             added_l_exclude = context.scene.l_exclude.add()
                             added_l_exclude.name = coll_2.name
                             added_l_exclude.value = True
                             col_layers.children.link(coll_2)
+
+            for name in remove_list:
+                coll = bpy.data.collections.get(name)
+                bpy.data.collections.remove(coll)
 
 
             for obj in data_to.objects:

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -157,8 +157,8 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
             if filepath_curr == filepath:
                 bpy.ops.acon3d.alert(
                     "INVOKE_DEFAULT",
-                    title="Import 예외",
-                    message_1="Import 예외가 발생함.",
+                    title="Import Failure",
+                    message_1="Cannot import exact same file from same directory.",
                 )
                 return {"FINISHED"}
 

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -174,6 +174,9 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
                         # file open과 다른 파일을 import 할 때는 layer 이름이 중복되면 ".001"부터 넘버링됨
                         # Layer0.001를 아웃라이너에서 삭제하기 위해 Layer0.001에 있는 오브젝트를 Layer0로 이동
                         if "Layer0" in coll_2.name:
+                            print("")
+                            print(f"coll_2.name: {coll_2.name}")
+                            print(f"coll_2.name[coll_2.name[:-4]]: {coll_2.name[:-4]}")
                             for coll_obj in bpy.data.collections[coll_2.name].objects:
                                 bpy.data.collections[coll_2.name].objects.unlink(
                                     coll_obj
@@ -194,9 +197,15 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
                             col_layers.children.link(coll_2)
 
             # 레이어 이름에 Layer0.이 포함된 중복 레이어 제거
+            print("")
+            print(f"self.duplicate_layer: {self.duplicate_layer}")
             for coll_name in self.duplicate_layer:
+                print(f"coll_name in self.duplicate_layer: {coll_name}")
                 coll = bpy.data.collections.get(coll_name)
                 bpy.data.collections.remove(coll)
+            print("")
+
+            self.duplicate_layer.clear()
 
             for obj in data_to.objects:
                 if obj.type == "MESH":
@@ -216,7 +225,8 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
         # TODO: 에러 세분화 필요
         except Exception as e:
             tracker.import_blend_fail()
-            self.report({"ERROR"}, f"Fail to import blend file. Check filepath.")
+            # self.report({"ERROR"}, f"Fail to import blend file. Check filepath.")
+            raise e
         else:
             tracker.import_blend()
 

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -162,11 +162,6 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
                 data_to.collections = data_from.collections
                 data_to.objects = list(data_from.objects)
 
-            print("")
-            print("Import ops.로 파일 데이터 load 후, 불러온 파일의 collection 출력")
-            for coll in data_to.collections:
-                print(f"1) coll.name - import: {coll.name}")
-
             for coll in data_to.collections:
                 if "ACON_col" in coll.name:
                     data_to.collections.remove(coll)
@@ -176,9 +171,6 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
                     "Layers." in coll.name and len(coll.name) == 10
                 ):
                     for coll_2 in coll.children:
-                        print("")
-                        print(f"2) coll.name - Layers.children: {coll_2.name}")
-
                         # file open과 다른 파일을 import 할 때는 layer 이름이 중복되면 ".001"부터 넘버링됨
                         # Layer0.001를 아웃라이너에서 삭제하기 위해 Layer0.001에 있는 오브젝트를 Layer0로 이동
                         if "Layer0" in coll_2.name:

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -183,8 +183,12 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
                         # Layer0.001를 아웃라이너에서 삭제하기 위해 Layer0.001에 있는 오브젝트를 Layer0로 이동
                         if "Layer0" in coll_2.name:
                             for coll_obj in bpy.data.collections[coll_2.name].objects:
-                                bpy.data.collections[coll_2.name].objects.unlink(coll_obj)
-                                bpy.data.collections[coll_2.name[:-4]].objects.link(coll_obj)
+                                bpy.data.collections[coll_2.name].objects.unlink(
+                                    coll_obj
+                                )
+                                bpy.data.collections[coll_2.name[:-4]].objects.link(
+                                    coll_obj
+                                )
                             self.duplicate_layer.append(coll_2.name)
 
                         # TODO: 같은 파일 import 처리
@@ -217,10 +221,10 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
                     ctx["region"] = area.regions[-1]
                     bpy.ops.view3d.view_selected(ctx)
 
+        # TODO: 에러 세분화 필요
         except Exception as e:
             tracker.import_blend_fail()
-            # self.report({"ERROR"}, f"Fail to import blend file. Check filepath.")
-            raise e
+            self.report({"ERROR"}, f"Fail to import blend file. Check filepath.")
         else:
             tracker.import_blend()
 

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -150,7 +150,7 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
             if not self.check_path():
                 return {"FINISHED"}
 
-            # Blender에서 File Open과 같은 파일을 import 하면 Layer와 Object 이름에 ".001"이 넘버링 하지 않음
+            # Blender에서 File Open과 같은 파일을 import하면 Collection과 Mesh Object 이름에 ".001"이 넘버링 하지 않음
             # 그래서 중복 처리를 하지 않고 있어, 예외 경우로 구분하고 메세지 알림 띄워주기
             filepath_curr = bpy.data.filepath
             filepath = self.filepath
@@ -180,7 +180,7 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
                     "Layers." in coll.name and len(coll.name) == 10
                 ):
                     for coll_child in coll.children:
-                        # File Open과 다른 파일을 import 할 때, Layer와 Object 이름이 중복되면 ".001"부터 넘버링됨
+                        # File Open과 다른 파일을 import 할 때, Collection과 Mesh Object 이름이 중복되면 ".001"부터 넘버링됨
                         # Layer0.001의 오브젝트를 Layer0으로 이동하고 Layer0.001을 Outliner에서 제거
                         if "Layer0." in coll_child.name:
                             for coll_obj in bpy.data.collections[coll_child.name].objects:
@@ -202,7 +202,7 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
                 bpy.data.collections.remove(coll)
             self.duplicate_layer.clear()
 
-            # View Layer에 포함된 오브젝트 가져오기
+            # View Layer에 포함된 오브젝트만 가져오기
             for obj in context.view_layer.objects:
                 self.view_layer_obj.append(obj.name)
             self.view_layer_obj.clear()

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -221,7 +221,7 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
 
         # TODO: 에러 세분화 필요
         except self.SameFileImportError:
-            tracker.import_blend_fail()
+            tracker.import_same_blend_fail()
             bpy.ops.acon3d.alert(
                 "INVOKE_DEFAULT",
                 title="Import Failure",

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -151,14 +151,17 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
             # TODO: 같은 파일 import 처리
             # file open과 같은 파일을 import 할 때는 layer 이름에 ".001" 넘버링이 되지 않음
             # 그래서 같은 레이어끼리 오브젝트 처리를 해야함
-
             print(f"bpy.data.filepath로 잡히는 file: {bpy.data.filepath}")
             print(f"self.filepath로 잡히는 file: {self.filepath}")
             file_current = bpy.data.filepath
             file_open = self.filepath
-            if (not file_current) or (file_current == file_open):
-                print("Import 예외")
-                print("같은 파일로 처리 안함")
+
+            if file_current == file_open:
+                bpy.ops.acon3d.alert(
+                    "INVOKE_DEFAULT",
+                    title="Import 예외",
+                    message_1="Import 예외가 발생함.",
+                )
                 return {"FINISHED"}
 
             for obj in bpy.data.objects:
@@ -182,7 +185,6 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
             for obj in data_to.objects:
                 print(f"to: {obj.name}")
 
-
             for coll in data_to.collections:
                 if "ACON_col" in coll.name:
                     data_to.collections.remove(coll)
@@ -194,7 +196,7 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
                     for coll_2 in coll.children:
                         # file open과 다른 파일을 import 할 때는 layer 이름이 중복되면 ".001"부터 넘버링됨
                         # Layer0.001를 아웃라이너에서 삭제하기 위해 Layer0.001에 있는 오브젝트를 Layer0로 이동
-                        if "Layer0" in coll_2.name:
+                        if "Layer0." in coll_2.name:
                             print("")
                             print(f"coll_2.name: {coll_2.name}")
                             print(f"coll_2.name[coll_2.name[:-4]]: {coll_2.name[:-4]}")
@@ -202,9 +204,7 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
                                 bpy.data.collections[coll_2.name].objects.unlink(
                                     coll_obj
                                 )
-                                bpy.data.collections[coll_2.name[:-4]].objects.link(
-                                    coll_obj
-                                )
+                                bpy.data.collections["Layer0"].objects.link(coll_obj)
                             self.duplicate_layer.append(coll_2.name)
 
                         else:

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -148,6 +148,19 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
             if not self.check_path():
                 return {"FINISHED"}
 
+            # TODO: 같은 파일 import 처리
+            # file open과 같은 파일을 import 할 때는 layer 이름에 ".001" 넘버링이 되지 않음
+            # 그래서 같은 레이어끼리 오브젝트 처리를 해야함
+
+            print(f"bpy.data.filepath로 잡히는 file: {bpy.data.filepath}")
+            print(f"self.filepath로 잡히는 file: {self.filepath}")
+            file_current = bpy.data.filepath
+            file_open = self.filepath
+            if (not file_current) or (file_current == file_open):
+                print("Import 예외")
+                print("같은 파일로 처리 안함")
+                return {"FINISHED"}
+
             for obj in bpy.data.objects:
                 obj.select_set(False)
 
@@ -185,10 +198,6 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
                                     coll_obj
                                 )
                             self.duplicate_layer.append(coll_2.name)
-
-                        # TODO: 같은 파일 import 처리
-                        # file open과 같은 파일을 import 할 때는 layer 이름에 ".001" 넘버링이 되지 않음
-                        # 그래서 같은 레이어끼리 오브젝트 처리를 해야함
 
                         else:
                             added_l_exclude = context.scene.l_exclude.add()

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -161,6 +161,7 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
                 data_to.collections = data_from.collections
                 data_to.objects = list(data_from.objects)
 
+            print("")
             for coll in data_to.collections:
                 if "ACON_col" in coll.name:
                     data_to.collections.remove(coll)
@@ -169,18 +170,30 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
                 if coll.name == "Layers" or (
                     "Layers." in coll.name and len(coll.name) == 10
                 ):
+                    print(f"coll.name: {coll.name}")
                     for coll_2 in coll.children:
+                        print(f"coll_2.name: {coll_2.name}")
                         # 중복된 Collection Layer명에는 ".001"부터 넘버링됨
                         # ".001"이 추가될 때마다 처리를 해주면, ".001" 넘버링만으로도 중복 체크 가능
                         if ".001" in coll_2.name:
-                            for obj in bpy.data.collections[coll_2.name].all_objects:
+                            print(f"coll_2.name.001: {coll_2.name}")
+                            for obj in bpy.data.collections[coll_2.name].objects:
+                                print(obj.name)
                                 bpy.data.collections[coll_2.name].objects.unlink(obj)
                                 bpy.data.collections[coll_2.name[:-4]].objects.link(obj)
+                            coll_3 = bpy.data.collections[coll_2.name[:-4]]
+                            bpy.data.collections.remove(coll_2)
 
-                        added_l_exclude = context.scene.l_exclude.add()
-                        added_l_exclude.name = coll_2.name
-                        added_l_exclude.value = True
-                        col_layers.children.link(coll_2)
+                            # added_l_exclude = context.scene.l_exclude.add()
+                            # added_l_exclude.name = coll_3.name
+                            # added_l_exclude.value = True
+
+                        else:
+                            added_l_exclude = context.scene.l_exclude.add()
+                            added_l_exclude.name = coll_2.name
+                            added_l_exclude.value = True
+                            col_layers.children.link(coll_2)
+
 
             for obj in data_to.objects:
                 if obj.type == "MESH":

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -157,12 +157,19 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
                 col_layers = bpy.data.collections.new("Layers")
                 context.scene.collection.children.link(col_layers)
 
+            print("\nFILEPATH")
+            print(FILEPATH)
             with bpy.data.libraries.load(FILEPATH) as (data_from, data_to):
                 data_to.collections = data_from.collections
                 data_to.objects = list(data_from.objects)
 
-            for coll in data_to.collections:
+                print("\ncoll (0)")
+                for coll in data_to.collections:
+                    print(coll)
 
+            print("\ncoll (2)")
+            for coll in data_to.collections:
+                print(coll.name)
                 if "ACON_col" in coll.name:
                     data_to.collections.remove(coll)
                     break
@@ -170,13 +177,15 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
                 if coll.name == "Layers" or (
                     "Layers." in coll.name and len(coll.name) == 10
                 ):
+                    print("\ncoll (3)")
                     for coll_2 in coll.children:
+                        print(coll_2.name)
                         added_l_exclude = context.scene.l_exclude.add()
                         added_l_exclude.name = coll_2.name
                         added_l_exclude.value = True
                         col_layers.children.link(coll_2)
-                        print(coll_2)
 
+            print("\nhere")
             for obj in data_to.objects:
                 if obj.type == "MESH":
                     obj.select_set(True)

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -175,6 +175,7 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
                         added_l_exclude.name = coll_2.name
                         added_l_exclude.value = True
                         col_layers.children.link(coll_2)
+                        print(coll_2)
 
             for obj in data_to.objects:
                 if obj.type == "MESH":
@@ -193,7 +194,8 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
 
         except Exception as e:
             tracker.import_blend_fail()
-            self.report({"ERROR"}, f"Fail to import blend file. Check filepath.")
+            # self.report({"ERROR"}, f"Fail to import blend file. Check filepath.")
+            raise e
         else:
             tracker.import_blend()
 

--- a/release/scripts/startup/abler/lib/tracker/_tracker.py
+++ b/release/scripts/startup/abler/lib/tracker/_tracker.py
@@ -23,6 +23,7 @@ class EventKind(enum.Enum):
     render_snip = "Render Snip"
     import_blend = "Import *.blend"
     import_blend_fail = "Import *.blend Fail"
+    import_same_blend_fail = "Import Same *.blend Fail"
     import_fbx = "Import FBX"
     import_fbx_fail = "Import FBX Fail"
     toggle_toolbar = "Toggle Toolbar"
@@ -181,6 +182,9 @@ class Tracker(metaclass=ABCMeta):
 
     def import_blend_fail(self):
         self._track(EventKind.import_blend_fail.value)
+
+    def import_same_blend_fail(self):
+        self._track(EventKind.import_same_blend_fail)
 
     def import_fbx(self):
         self._track(EventKind.import_fbx.value)


### PR DESCRIPTION
## 관련 링크

- [[Import] 파일 오픈 후, 같은 파일 Import 하면 Layer 오류 발생](https://www.notion.so/acon3d/Import-Import-Layer-cb39914724cc410e9a5e83d50a0a0055)
- [[Import] 파일 오픈 후, 다른 파일 Import 하면 Layer0.001 레이어가 생기는 문제](https://www.notion.so/acon3d/Import-Import-Layer0-001-aa80454dc11c4321bfdad23d6b617227)
- [파일 오픈 후, 같은 .blend 파일을 import 했을 때 노출되는 에러 알림 번역 #20](https://github.com/ACON3D/blender-translations/pull/20)


## 발제/내용

- 에이블러에서 `.blend` 파일을 오픈하고, 경로와 이름이 같은 (`filepath`가 같은) 파일을 import 하면 중복 레이어와 오브젝트에 대해서 에러가 발생하고 있었습니다. 그래서, 같은 파일에 대해서는 에러 알림을 노출하는 것으로 수정하였습니다.
- 에이블러에서 `.blend` 파일을 오픈하고, 다른 파일을 import 하면 중복 레이어 (이름이 같은) 에 대해서 `.001` 과 같은 Blender 넘버링이 추가되고, 노출하지 않는 `Layer0.xxx` 이 레이어 패널에 노출됩니다. 그래서, 레이어 중복 처리를 해주었습니다.


## 대응

### 어떤 조치를 취했나요?

분량이 많아서 Notion 문서로 확인하는 것이 좋습니다.

### 파일 오픈 후, 같은 파일 import

- 현재 열려 있는 파일의 `filepath` 와 import 에 사용되는 `filepath`를 비교함
- 현재 열려 있는 파일이 New > General 이면 filepath가 없을 수 있음
- 만약, filepath가 없거나, 열린 filepath와 import filepath가 같다면 → 같은 파일 import 처리 `alert`를 띄우고 import 종료
- 기획된 에러 메세지 반영

### 파일 오픈 후, 다른 파일 import

- Import 실행하고 `Layers` 콜렉션을 탐색할 때, child 레이어의 이름에 Layer0 문자열이 포함되어 있으면 별도 처리를 함
- `Outliner` > `Blender File` 에는 있는 Meshes 혹은 Objects 데이터가 View Layer 에 없는 상태에서 View Layer의 기능을 수행할 때 `RuntimeError` 에러가 나타남. 그래서 별도 처리를 함


### 번역 작업 Merge 되면 해당 PR Merge 할 예정입니다.