### PR TITLE
selected object가 있을 시에, 축 + 대지가 보이도록 하는 기능을 추가함.

### DIFF
--- a/release/datafiles/userdef/userdef_default_theme.c
+++ b/release/datafiles/userdef/userdef_default_theme.c
@@ -311,7 +311,7 @@ const bTheme U_theme_default = {
       .back = RGBA(0xffffffff),
       .sub_back = RGBA(0x00000007),
     },
-    .grid = RGBA(0xffffffb3),
+    .grid = RGBA(0x8f8f8fb3),
     .wire = RGBA(0x313131ff),
     .wire_edit = RGBA(0x575757ff),
     .select = RGBA(0xed5700ff),

--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -99,8 +99,10 @@ def save_post_handler(dummy):
 
 def grid_on_when_selected(dummy):
     show_grid = len(bpy.context.selected_objects) > 0
-    bpy.data.screens["ACON3D"].areas[0].spaces[0].overlay.show_ortho_grid = show_grid
-    bpy.data.screens["ACON3D"].areas[0].spaces[0].overlay.show_floor = show_grid
+    if "ACON3D" in bpy.data.screens.keys() and len(bpy.data.screens["ACON3D"].areas) > 0 and len(bpy.data.screens["ACON3D"].areas[0].spaces) > 0:
+        viewport_overlay = bpy.data.screens["ACON3D"].areas[0].spaces[0].overlay
+        viewport_overlay.show_ortho_grid = show_grid
+        viewport_overlay.show_floor = show_grid
 
 
 def register():

--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -97,7 +97,6 @@ def save_post_handler(dummy):
         scene.view_settings.view_transform = "Standard"
 
 
-@persistent
 def grid_on_when_selected(dummy):
     show_grid = len(bpy.context.selected_objects) > 0
     bpy.data.screens["ACON3D"].areas[0].spaces[0].overlay.show_ortho_grid = show_grid

--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -97,14 +97,23 @@ def save_post_handler(dummy):
         scene.view_settings.view_transform = "Standard"
 
 
+@persistent
+def grid_on_when_selected(dummy):
+    show_grid = len(bpy.context.selected_objects) > 0
+    bpy.data.screens["ACON3D"].areas[0].spaces[0].overlay.show_ortho_grid = show_grid
+    bpy.data.screens["ACON3D"].areas[0].spaces[0].overlay.show_floor = show_grid
+
+
 def register():
     bpy.app.handlers.load_factory_startup_post.append(init_setting)
     bpy.app.handlers.load_post.append(load_handler)
     bpy.app.handlers.save_pre.append(save_pre_handler)
     bpy.app.handlers.save_post.append(save_post_handler)
+    bpy.app.handlers.depsgraph_update_post.append(grid_on_when_selected)
 
 
 def unregister():
+    bpy.app.handlers.depsgraph_update_post.remove(grid_on_when_selected)
     bpy.app.handlers.save_post.remove(save_post_handler)
     bpy.app.handlers.save_pre.remove(save_pre_handler)
     bpy.app.handlers.load_post.remove(load_handler)


### PR DESCRIPTION
## 관련 링크
[기획 티켓 링크](https://www.notion.so/acon3d/Object-Control-f619ee9458c345ad9785f792c02567ad)

## 발제/내용
- 오브젝트 이동을 할 때 상대적 위치와 거리감을 확인할 수 있는 플레인과 그리드를 열어주는 것이 사용상에 편리함
    - 참고 : [220812, 220817 3D툴 리서치 결과 ](https://www.notion.so/220812-220817-3D-31a12a043d174dce83c8235254fd5c5c)
- 가능 여부 판단이 우선

## 대응

### 어떤 조치를 취했나요?

- depsgraph_update_post 핸들러에 floor과 grid를 켜고 끄는 기능을 붙여서 원하는 기능이 구현될 수 있도록 함.
- grid의 기본 컬러를 #8f8f8f로 바꿈 (기획 내용에 있음)


https://user-images.githubusercontent.com/43770096/190949391-ea6ef4d1-4639-4e8e-b4fd-e343045a41b1.mov

