### PR TITLE
outliner을 panel에 추가할 수 있도록 기술검증 및 개발

### DIFF
--- a/release/scripts/startup/abler/__init__.py
+++ b/release/scripts/startup/abler/__init__.py
@@ -50,6 +50,7 @@ from . import render_control
 from . import import_external_files
 from . import pref
 from . import operators
+from . import outliner_control
 from .lib.tracker import tracker
 
 # =========================================================================
@@ -71,6 +72,7 @@ importedLibrary = [
     import_external_files,
     pref,
     operators,
+    outliner_control,
 ]
 if "--background" not in sys.argv and "-b" not in sys.argv:
     from . import credential_modal

--- a/release/scripts/startup/abler/outliner_control.py
+++ b/release/scripts/startup/abler/outliner_control.py
@@ -1,0 +1,83 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+
+import contextlib
+bl_info = {
+    "name": "Outliner Panel",
+    "description": "",
+    "author": "sdk@acon3d.com",
+    "version": (0, 0, 1),
+    "blender": (3, 00, 0),
+    "location": "",
+    "warning": "",  # used for warning icon and text in addons panel
+    "wiki_url": "",
+    "tracker_url": "",
+    "category": "ACON3D",
+}
+import bpy
+
+
+class Acon3dOutlinerPanel(bpy.types.Panel):
+    bl_idname = "ACON3D_PT_outliner"
+    bl_label = "Outliner"
+    bl_category = "ACON3D"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+
+    def recursive_collection(self, layout, collection, indent=0):
+        indent_basis = "   "
+        for child in collection.children:
+            row = layout.row()
+            row.alignment = "LEFT"
+            row.label(text=indent_basis * indent + child.name, icon="GROUP")
+            self.recursive_collection(layout, child, indent=indent + 1)
+        with contextlib.suppress(AttributeError):
+            for child in collection.objects:
+                row = layout.row()
+                row.alignment = "LEFT"
+                row.label(text=indent_basis * indent + child.name, icon="OBJECT_DATA")
+                self.recursive_collection(layout, child, indent=indent + 1)
+
+    def draw_header(self, context):
+        layout = self.layout
+        layout.label(icon="OUTLINER")
+
+    def draw(self, context):
+        layout = self.layout
+        box = layout.box()
+        self.recursive_collection(box, bpy.context.scene.collection)
+
+
+classes = (
+    Acon3dOutlinerPanel,
+)
+
+
+def register():
+    from bpy.utils import register_class
+
+    for cls in classes:
+        register_class(cls)
+
+
+def unregister():
+    from bpy.utils import unregister_class
+
+    for cls in reversed(classes):
+        unregister_class(cls)


### PR DESCRIPTION
## 관련 링크
[기획 티켓 링크](https://www.notion.so/acon3d/Hide-7a411ff2dcd84539b7966a153396294b)

## 발제/내용

- 그룹내비게이션 기능은 전체 그룹 구조를 조망하는데 어려움이 존재함.
- 그러나 사용자들에게는 그룹 구조를 파악하고 이를 최소한으로 조정하는 니즈가 존재함.
- 레이어 기능이 존재하지만 해당 기능은 수정 및 생성, 삭제가 불가능해 제한적임.
- 블렌더 고유의 기능인 아웃라이너를 활용하여 이러한 니즈를 해결하고자 함.

## 대응

### 어떤 작업을 하고 있나요?
- Enum 느낌으로 짜야 List 형태로, 그리고 각 row  별로 선택이 가능할 것 같음. 각 row 별로 hide_render 스러운 기능을 끝에 버튼으로 넣는건 어려운일이 아닐 것 같음.
    - 근데 Enum으로 짜면 toggle down triangle 버튼 같이 트리구조는 구현이 가능하려나? 이거는 좀더 찾아봐야함
- 삭제는 context_menu로 구현해야 할 것 같은데, 아직 이부분은 확실하지 않음. (아니면 hide_render 있는 쪽에 버튼으로 구현할 수는 있을듯?)
- 해당 row를 select 할 시에 뷰포트에 object가 선택되는건 가능할 것 같음.
- outliner panel을 만들어봄
![image](https://user-images.githubusercontent.com/43770096/191013931-f0d00e63-13f6-4e57-baf2-8eefa775af42.png)
