### PR TITLE
config.ini의 버전정보를 splash screen에서 보이도록 만들기

### DIFF
--- a/release/scripts/startup/abler/lib/version.py
+++ b/release/scripts/startup/abler/lib/version.py
@@ -6,7 +6,6 @@ import bpy
 import configparser
 from distutils.version import StrictVersion
 
-
 # GitHub Repo의 URL 세팅
 url = "https://api.github.com/repos/ACON3D/blender/releases/latest"
 
@@ -33,11 +32,14 @@ def get_launcher():
 
 def get_local_version():
     config = configparser.ConfigParser()
-    config.read(os.path.join(set_updater(), "config.ini"))
-    abler_ver = config["main"]["installed"]
+    if os.path.isfile(os.path.join(set_updater(), "config.ini")):
+        config.read(os.path.join(set_updater(), "config.ini"))
+        abler_ver = config["main"]["installed"]
+    else:
+        abler_ver = "0.0.0"
 
     # config.ini에 installed 정보가 없을 때 버전 처리
-    if abler_ver is (None or ""):
+    if abler_ver == (None or ""):
         abler_ver = "0.0.0"
 
     return abler_ver

--- a/release/scripts/startup/bl_operators/wm.py
+++ b/release/scripts/startup/bl_operators/wm.py
@@ -3127,7 +3127,19 @@ class WM_MT_splash(Menu):
                     but.link = ""
                     but.link_name = ""
             layout.separator()
-        layout.label(text=abler_version())
+
+        split = layout.split()
+        col1 = split.column()
+        col1.label(text=abler_version())
+
+        col2 = split.column()
+        col2.label(text="config.ini 정보 들어갈 예정")
+
+        from abler.lib.version import get_local_version
+        config_ver = get_local_version()
+        col2.label(text=config_ver)
+
+        # layout.label(text=abler_version())
         layout.separator()
 
 

--- a/release/scripts/startup/bl_operators/wm.py
+++ b/release/scripts/startup/bl_operators/wm.py
@@ -3134,7 +3134,6 @@ class WM_MT_splash(Menu):
         split = layout.split()
         col1 = split.column()
         # col1.label(text=abler_version()) # 원래 쓰던 코드 아카이빙을 위해서 주석으로 만듬
-        # config.ini가 없을 경우 0.0.0으로 표시
         col1.label(text=f"release/v{config_ver}")  # 현재 사용중인 코드
 
         layout.separator()

--- a/release/scripts/startup/bl_operators/wm.py
+++ b/release/scripts/startup/bl_operators/wm.py
@@ -3128,18 +3128,15 @@ class WM_MT_splash(Menu):
                     but.link_name = ""
             layout.separator()
 
-        split = layout.split()
-        col1 = split.column()
-        col1.label(text=abler_version())
-
-        col2 = split.column()
-        col2.label(text="config.ini 정보 들어갈 예정")
-
         from abler.lib.version import get_local_version
         config_ver = get_local_version()
-        col2.label(text=config_ver)
 
-        # layout.label(text=abler_version())
+        split = layout.split()
+        col1 = split.column()
+        # col1.label(text=abler_version()) # 원래 쓰던 코드 아카이빙을 위해서 주석으로 만듬
+        # config.ini가 없을 경우 0.0.0으로 표시
+        col1.label(text=f"release/v{config_ver}")  # 현재 사용중인 코드
+
         layout.separator()
 
 

--- a/release/scripts/startup/bl_operators/wm.py
+++ b/release/scripts/startup/bl_operators/wm.py
@@ -3131,10 +3131,8 @@ class WM_MT_splash(Menu):
         from abler.lib.version import get_local_version
         config_ver = get_local_version()
 
-        split = layout.split()
-        col1 = split.column()
-        # col1.label(text=abler_version()) # 원래 쓰던 코드 아카이빙을 위해서 주석으로 만듬
-        col1.label(text=f"release/v{config_ver}")  # 현재 사용중인 코드
+        # layout.label(text=abler_version()) # 원래 쓰던 코드 아카이빙을 위해서 주석으로 만듬
+        layout.label(text=f"release/v{config_ver}")  # 현재 사용중인 코드
 
         layout.separator()
 


### PR DESCRIPTION
## 관련 링크
[노션 카드](https://www.notion.so/acon3d/config-ini-splash-screen-8dc1947124294134b7d8333dc594de9d)

## 발제/내용

- config.ini와 splash screen의 버전정보가 일치하지 않을 수 있는 케이스가 있어서 테스트에 어려움이 있음

## 대응

### 어떤 조치를 취했나요?

- [x]  config.ini의 version 정보를 splash screen의 버전정보에서 보여줌
- [x]  config.ini 파일이 없을 경우 0.0.0으로 표시하도록 함.

![image](https://user-images.githubusercontent.com/43770096/191195347-15ba5087-a12c-42f3-a7fa-095faf24ccd6.png)
