### PR TITLE
과거 파일 Open 시에, Update Button이 출력되어서 정책서에 맞게 해당 버튼을 없앰.

### DIFF
--- a/release/scripts/startup/abler/startup_flow.py
+++ b/release/scripts/startup/abler/startup_flow.py
@@ -566,7 +566,6 @@ class Acon3dLowFileVersionWarning(BlockingModalOperator):
         )
         row.label(text="Don’t show this message again.")
 
-        col.operator("acon3d.update_abler", text="Update ABLER")
         col.operator("acon3d.close_blocking_modal", text="Close")
         row.label(text="")
 


### PR DESCRIPTION
## 관련 링크
[이슈 링크](https://www.notion.so/acon3d/Issue-34_-Open-652d1e4ed5354107b831e01708186dac)

## 발제/내용

- 과거 버전 파일 Open 시, 팝업 내에 에이블러 업데이트 버튼이 출력됨

## 대응

### 어떤 조치를 취했나요?

- [정책서](https://www.notion.so/acon3d/AB01_01_-d3ce15797ddf45af8b7e95d58b67fd2f)에 따르면 과거파일 Open 시에 뜨는 팝업에서는 에이블러 업데이트 버튼이 출력되면 안되므로, 해당 내용에 맞도록 Update 버튼을 없앰