### PR TITLE
Full/Line/Shadow Render 시에 원래의 Scene으로 변경

### DIFF
--- a/release/scripts/startup/abler/render_control.py
+++ b/release/scripts/startup/abler/render_control.py
@@ -187,28 +187,26 @@ class Acon3dRenderFileOperator(Acon3dRenderOperator, ExportHelper):
 
             elif self.rendering is False:
 
-                qitem = self.render_queue[0]
-
-                # Update filename
-                if qitem.name != self.basename:
-                    qitem.name = self.basename
-
-                base_filepath = os.path.join(self.dirname, qitem.name)
-                file_format = qitem.render.image_settings.file_format
+                base_filepath = os.path.join(self.dirname, self.basename)
+                file_format = self.filename_ext
                 numbered_filepath = base_filepath
                 number = 2
 
-                while os.path.isfile(f"{numbered_filepath}.{file_format}"):
+                while os.path.isfile(f"{numbered_filepath}{file_format}"):
                     numbered_filepath = f"{base_filepath} ({number})"
                     number += 1
 
-                qitem.render.filepath = numbered_filepath
-                self.filepath = f"{numbered_filepath}{self.filename_ext}"
-                context.window_manager.ACON_prop.scene = qitem.name
+                context.scene.render.filepath = numbered_filepath
+                self.filepath = f"{numbered_filepath}{file_format}"
+
+                for obj in context.selected_objects:
+                    obj.select_set(False)
 
                 self.prepare_render()
 
                 bpy.ops.render.render("INVOKE_DEFAULT", write_still=self.write_still)
+
+                # bpy.data.scenes.remove(qitem, do_unlink=True)
 
         return {"PASS_THROUGH"}
 

--- a/release/scripts/startup/abler/render_control.py
+++ b/release/scripts/startup/abler/render_control.py
@@ -350,9 +350,7 @@ class Acon3dRenderTempSceneFileOperator(Acon3dRenderFileOperator):
 
         self.temp_scenes.clear()
 
-        # set initial_scene
-        bpy.data.window_managers["WinMan"].ACON_prop.scene = self.initial_scene.name
-
+        super().on_render_finish(context)
         return {"FINISHED"}
 
 
@@ -392,9 +390,7 @@ class Acon3dRenderTempSceneDirOperator(Acon3dRenderDirOperator):
 
         self.temp_scenes.clear()
 
-        # set initial_scene
-        bpy.data.window_managers["WinMan"].ACON_prop.scene = self.initial_scene.name
-
+        super().on_render_finish(context)
         return {"FINISHED"}
 
 

--- a/release/scripts/startup/abler/render_control.py
+++ b/release/scripts/startup/abler/render_control.py
@@ -58,6 +58,20 @@ def open_directory(path):
         print("Linux")
 
 
+def check_file_numbering(self, context):
+    base_filepath = os.path.join(self.dirname, self.basename)
+    file_format = self.filename_ext
+    numbered_filepath = base_filepath
+    number = 2
+
+    while os.path.isfile(f"{numbered_filepath}{file_format}"):
+        numbered_filepath = f"{base_filepath} ({number})"
+        number += 1
+
+    context.scene.render.filepath = numbered_filepath
+    self.filepath = f"{numbered_filepath}{file_format}"
+
+
 class Acon3dCameraViewOperator(bpy.types.Operator):
     """Fit render region to viewport"""
 
@@ -187,26 +201,11 @@ class Acon3dRenderFileOperator(Acon3dRenderOperator, ExportHelper):
 
             elif self.rendering is False:
 
-                base_filepath = os.path.join(self.dirname, self.basename)
-                file_format = self.filename_ext
-                numbered_filepath = base_filepath
-                number = 2
-
-                while os.path.isfile(f"{numbered_filepath}{file_format}"):
-                    numbered_filepath = f"{base_filepath} ({number})"
-                    number += 1
-
-                context.scene.render.filepath = numbered_filepath
-                self.filepath = f"{numbered_filepath}{file_format}"
-
-                for obj in context.selected_objects:
-                    obj.select_set(False)
+                check_file_numbering(self, context)
 
                 self.prepare_render()
 
                 bpy.ops.render.render("INVOKE_DEFAULT", write_still=self.write_still)
-
-                # bpy.data.scenes.remove(qitem, do_unlink=True)
 
         return {"PASS_THROUGH"}
 
@@ -542,17 +541,7 @@ class Acon3dRenderQuickOperator(Acon3dRenderFileOperator):
     def prepare_queue(self, context):
         # File name duplicate check
 
-        base_filepath = os.path.join(self.dirname, self.basename)
-        file_format = self.filename_ext
-        numbered_filepath = base_filepath
-        number = 2
-
-        while os.path.isfile(f"{numbered_filepath}{file_format}"):
-            numbered_filepath = f"{base_filepath} ({number})"
-            number += 1
-
-        context.scene.render.filepath = numbered_filepath
-        self.filepath = f"{numbered_filepath}{file_format}"
+        check_file_numbering(self, context)
 
         for obj in context.selected_objects:
             obj.select_set(False)

--- a/release/scripts/startup/abler/render_control.py
+++ b/release/scripts/startup/abler/render_control.py
@@ -321,6 +321,10 @@ class Acon3dRenderTempSceneFileOperator(Acon3dRenderFileOperator):
     def prepare_queue(self, context):
 
         scene = context.scene.copy()
+
+        # 현재 씬을 복사한 씬으로 적용
+        bpy.data.window_managers["WinMan"].ACON_prop.scene = scene.name
+
         self.render_queue.append(scene)
         self.temp_scenes.append(scene)
 


### PR DESCRIPTION
## 관련 링크
[노션](https://www.notion.so/acon3d/Full-Line-Shadow-Render-Scene-56ef0a185af44bc9befd132810781685)

## 발제/내용

- Full/Line/Shadow Render 시에 Scene의 명칭이 변경되고 있습니다.
- 파일 넘버링 과정에서 qitem과 self.initial_scene이 바라보고 있는게 같은 context.scene임. → qitem이 업데이트 되면서 context.scene과 self.initial_scene이 같이 업데이트됨

## 대응

### 어떤 조치를 취했나요?

- 퀵렌더에선 발생하지 않아 비교해보니 퀵렌더에선 qitem을 쓰지 않고 self.filepath로 바로 업데이트 하고 있음 → 퀵렌더 코드의 파일 넘버링을 대신 넣었더니 에러 없이 풀렌더 후 이름이 잘 나옴 → 중복되는 해당 코드 `check_file_numbering()` 함수로 묶기
- 쉐도우 렌더, 라인 렌더에선 scene.copy() 후 적용이 안돼서 현재 씬을 복사한 씬으로 돌려둠
- 추가로 on_render_finish에 `bpy.data.window_managers["WinMan"].ACON_prop.scene` 코드가 상속 후에도 중복되고 있어서 super().on_render_finish로 바꿔줌