### PR TITLE
뷰포트 색 변경 UI 숨기기

### DIFF
--- a/release/scripts/startup/abler/render_control.py
+++ b/release/scripts/startup/abler/render_control.py
@@ -589,9 +589,12 @@ class Acon3dRenderPanel(bpy.types.Panel):
             row.operator("acon3d.render_all", text="Render All Scenes")
             row.operator("acon3d.render_snip", text="Snip Render")
 
-            row = layout.row()
-            prop = context.scene.ACON_prop
-            row.prop(prop, "background_color", text="Background Color")
+            # 변경한 뷰포트 색이 같이 렌더되는 기능과 함께 들어가기로 논의되었습니다.
+            # 그 전까지 주석처리 해두겠습니다.
+            # 해당 이슈 링크: https://www.notion.so/acon3d/Issue-37_-af9ca441b3c44e858097418fb6dc811c
+            # row = layout.row()
+            # prop = context.scene.ACON_prop
+            # row.prop(prop, "background_color", text="Background Color")
 
 
 classes = (


### PR DESCRIPTION
## 관련 링크
[링크](https://www.notion.so/acon3d/Hide-778d73982d184dfdb82751a38a161070)

## 발제/내용

- 뷰포트 색 함께 렌더하기 기능과 함께 오픈하도록 논의되어 해당 기능은 숨기기로 했습니다.

## 대응

### 어떤 조치를 취했나요?

- render_control의 UI 코드 주석처리