### PR TITLE
업데이트 팝업에서 런처를 실행할 때 에이블러가 종료되지 않는 문제 수정

### DIFF
--- a/release/scripts/startup/abler/startup_flow.py
+++ b/release/scripts/startup/abler/startup_flow.py
@@ -24,6 +24,7 @@ import platform
 import sys
 import textwrap
 import webbrowser
+import psutil
 from json import JSONDecodeError
 
 import bpy
@@ -519,10 +520,10 @@ class Acon3dUpdateAblerOperator(bpy.types.Operator):
 
     def execute(self, context):
         launcher = get_launcher()
-        bpy.ops.wm.quit_blender()
 
         # 관리자 권한이 필요한 프로그램을 실행하는 옵션
-        subprocess.call(launcher, shell=True)
+        subprocess.Popen(launcher, shell=True)
+        bpy.ops.wm.quit_blender()
 
         return {"FINISHED"}
 

--- a/release/scripts/startup/abler/startup_flow.py
+++ b/release/scripts/startup/abler/startup_flow.py
@@ -24,7 +24,6 @@ import platform
 import sys
 import textwrap
 import webbrowser
-import psutil
 from json import JSONDecodeError
 
 import bpy


### PR DESCRIPTION
## 관련 링크

[추가 예정](URL) 


## 발제/내용

- 에이블러 버전이 낮을 때 발생하는 업데이트 팝업에서 Update ABLER를 실행하면 관리자 권한으로 런처가 실행됨
- 이 때, 에이블러가 정상적으로 종료되지 않는 문제가 있음.
- 에이블러 업데이트를 위해서 에이블러 종료가 필수기 때문에 이 문제를 수정함


## 대응

### 어떤 조치를 취했나요?

- `subprocess.call(launcher, shell=True)` 을 `subprocess.Popen(launcher, shell=True)` 로 수정함
- `call()` 은 런처를 `blender.exe` 의 child process 로 실행하고 있어서 `bpy.ops.wm.quit_blend()` 를 실행하지 못하는 문제가 있었음.
- 그래서 `Popen()` 으로 런처를 실행해 독립적인 프로세스로 분리하고 정상적으로 에이블러가 종료되게 수정함.