### PR TITLE
op_node에서 Nullptr인데 접근을 해서 exception 발생 후 프로그램 종료되는 이슈

### DIFF
--- a/source/blender/depsgraph/intern/node/deg_node_component.cc
+++ b/source/blender/depsgraph/intern/node/deg_node_component.cc
@@ -223,7 +223,9 @@ void ComponentNode::clear_operations()
     operations_map->clear();
   }
   for (OperationNode *op_node : operations) {
-    delete op_node;
+    if (op_node != nullptr){
+      delete op_node;
+    }
   }
   operations.clear();
 }


### PR DESCRIPTION


## 관련 링크
[노션 링크](https://www.notion.so/acon3d/crash-efa5bbfc45cc4833b0a2046cb6325716)

## 발제/내용

### 재현 환경

- ABLER v0.2.6
- Window 11
- Alienware 에서 발생 (~~나머지 환경에서 재현 안됨~~, 2022-09-22 18:17 하비님 컴퓨터 재현 추가)

### 재현 경로

- .blend 파일을 더블클릭하여 에이블러 실행
- 컨트롤 패널 > General > File Open, Menu > File > Open 시에도 동일하게 간헐적으로 발생

### 현재 상태

- 간헐적으로, 에이블러 클라이언트가 종료됩니다.

## 대응

### 어떤 조치를 취했나요?

- op_node가 nullptr인 상황에서 EXCEPTION_ACCESS_VIOLATION이 나는것 같아서 op_node가 nullptr인지 아닌지 검사하는 로직을 추가함.
- 하지만 이 형태가 진짜 해당 이슈를 제거하는지는 테스트를 해보아야 알 수 있음.