### PR TITLE
첫 실행 이후에 File Open 하면 Show Tutorial Guide가 작동하지 않는 현상

### DIFF
--- a/release/scripts/startup/abler/startup_flow.py
+++ b/release/scripts/startup/abler/startup_flow.py
@@ -106,7 +106,7 @@ def start_check_file_version():
     elif is_first_run:
         start_check_server_version()
     else:
-        open_credential_modal()
+        start_authentication()
 
 
 def start_check_server_version():
@@ -115,7 +115,7 @@ def start_check_server_version():
     if has_server_update():
         bpy.ops.acon3d.update_alert("INVOKE_DEFAULT")
     else:
-        open_credential_modal()
+        start_authentication()
 
 
 class Acon3dAlertOperator(bpy.types.Operator):
@@ -438,7 +438,7 @@ class Acon3dAnchorOperator(bpy.types.Operator):
 
 
 @persistent
-def open_credential_modal():
+def start_authentication():
     prefs = bpy.context.preferences
     prefs.view.show_splash = True
 
@@ -509,7 +509,7 @@ class Acon3dUpdateAlertOperator(BlockingModalOperator):
         main.label(text="")
 
     def after_close(self, context, event):
-        open_credential_modal()
+        start_authentication()
 
 
 class Acon3dUpdateAblerOperator(bpy.types.Operator):

--- a/release/scripts/startup/abler/startup_flow.py
+++ b/release/scripts/startup/abler/startup_flow.py
@@ -105,6 +105,8 @@ def start_check_file_version():
         bpy.ops.acon3d.low_file_version_warning("INVOKE_DEFAULT")
     elif is_first_run:
         start_check_server_version()
+    else:
+        open_credential_modal()
 
 
 def start_check_server_version():
@@ -472,12 +474,11 @@ def open_credential_modal():
     except:
         print("Failed to load cookies")
 
-    # 자동로그인 시 modal이 실행 안되고 있어서
-    # 자동로그인인 경우에도 modal 실행하도록 if문 제거
-    bpy.ops.acon3d.modal_operator("INVOKE_DEFAULT")
-
     if prop.remember_username:
         prop.username = read_remembered_username()
+
+    if is_first_run:
+        bpy.ops.acon3d.modal_operator("INVOKE_DEFAULT")
 
 
 class Acon3dUpdateAlertOperator(BlockingModalOperator):


### PR DESCRIPTION
## 관련 링크

[태스트 카드 링크](https://www.notion.so/acon3d/File-Open-Show-Tutorial-Guide-cfbbfdde81264801b5e42b9d15e10e07)

## 내용

이번에 수정된 시작 흐름때문에, 첫 실행 이후 다른 파일을 열었을 때 ACON_userInfo 메시가 생성되지 않았고, 그것을 참조하는 튜토리얼 가이드 측 코드에서 ACON_userInfo 를 찾지 못해 생긴 문제였습니다.

따라서, 첫 실행이든 그 이후에 열린 파일에서든 ACON_userInfo 메시가 생성되도록 만들어서 문제를 해결했습니다.
