### PR TITLE
과거 버전의 에이블러 파일 실행 시, 팝업 문구가 잘못 입력되어있음

### DIFF
--- a/release/scripts/startup/abler/startup_flow.py
+++ b/release/scripts/startup/abler/startup_flow.py
@@ -535,6 +535,7 @@ class Acon3dLowFileVersionWarning(BlockingModalOperator):
     def draw_modal(self, layout):
         tr = bpy.app.translations.pgettext
         file_version = get_file_version() or "< 0.2.6"
+        client_version = get_local_version()
 
         padding_size = 0.01
         content_size = 1.0 - 2 * padding_size
@@ -553,7 +554,9 @@ class Acon3dLowFileVersionWarning(BlockingModalOperator):
             ).replace("$(fileVer)", file_version)
         )
         col.label(
-            text="When using an older version of ABLER, some features may not work properly."
+            text=tr(
+                "If you save in the current version ($(clientVer)), you will not be able to load this file from older version of ABLER."
+            ).replace("$(clientVer)", client_version)
         )
 
         row = col.row()


### PR DESCRIPTION
## 관련 링크
[이슈 링크](https://www.notion.so/acon3d/Issue-0051_-af0482022f7f4044855203a88ca2334d)

## 발제/내용

- 버전 없는 / 과거 버전의 에이블러(.blend)파일 실행
- 팝업 문구 확인

## 대응

### 어떤 조치를 취했나요?

- 아래 문구로 수정했습니다
![image](https://user-images.githubusercontent.com/43770096/191911206-514c7492-b529-49ff-8df5-82120795f8fa.png)
