### PR TITLE
REMOVE "release" from splash screen version

### DIFF
--- a/release/scripts/startup/bl_operators/wm.py
+++ b/release/scripts/startup/bl_operators/wm.py
@@ -3132,7 +3132,7 @@ class WM_MT_splash(Menu):
         config_ver = get_local_version()
 
         # layout.label(text=abler_version()) # 원래 쓰던 코드 아카이빙을 위해서 주석으로 만듬
-        layout.label(text=f"release/v{config_ver}")  # 현재 사용중인 코드
+        layout.label(text=f"v{config_ver}")  # 현재 사용중인 코드
 
         layout.separator()
 


### PR DESCRIPTION
## 관련 링크
[개발 태스크](URL)
[관련 이전 PR 링크](https://github.com/ACON3D/blender/pull/146)

## 발제/내용
- Splash 화면의 버전명에서 보이는 release 를 없애야 함.