### PR TITLE
AblerLauncher에서 ABLER (및 Blender) 안전하게 종료하기

### DIFF
--- a/launcher_abler/AblerLauncher.py
+++ b/launcher_abler/AblerLauncher.py
@@ -356,9 +356,10 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
             # TODO: 유저 flow는 알림이 떴을 때, 배경은 흐리게 (blur) 하는 것이 좋음
             QtWidgets.QMessageBox.information(
                 self,
-                "테스트",
-                "내용",
+                "title",
+                "Currently ABLER is running.\nPlease close all ABLER before update.",
             )
+            # QtWidgets.QMessageBox.close(self, "A", "B")
 
     def updatepb(self, percent: int) -> None:
         """다운로드 진행상황 바 표시"""

--- a/launcher_abler/AblerLauncher.py
+++ b/launcher_abler/AblerLauncher.py
@@ -296,6 +296,18 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
             lambda throwaway=0, entry=self.entry: self.download(entry, dir_name=dir_)
         )
 
+    def setup_test_ui(self) -> None:
+        """Update Launcher 버튼 활성화 UI"""
+        print("111")
+        self.btn_update_launcher.hide()
+        print("222")
+        self.btn_update.show()
+        print("333")
+        self.btn_execute.hide()
+        print("444")
+        self.btn_update.setDisabled(False)
+        print("555")
+
     def setup_execute_ui(self) -> None:
         """Run ABLER 버튼 활성화 UI"""
 
@@ -312,6 +324,9 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
 
     def download(self, entry: dict, dir_name: str) -> None:
         """ABLER/Launcher 최신 릴리즈 다운로드"""
+
+        print("")
+        print("download 함수 들어옴")
 
         temp_name = "./blendertemp" if dir_name == dir_ else "./launchertemp"
 
@@ -330,23 +345,41 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
 
         logger.info(f"Starting download thread for {url}{version}")
 
-        self.setup_download_ui(entry, dir_name)
+        proc = count_process("blender")
 
-        self.exec_dir_name = os.path.join(dir_name, "")
-        filename = temp_name + entry["filename"]
+        if proc == 0:
+            print("실제 다운로드 하는 곳. 여기 들어오면 안됨.")
+            self.setup_download_ui(entry, dir_name)
 
-        thread = WorkerThread(url, filename, self.exec_dir_name, temp_name)
-        thread.update.connect(self.updatepb)
-        thread.finishedDL.connect(self.extraction)
-        thread.finishedEX.connect(self.finalcopy)
-        thread.finishedCP.connect(self.cleanup)
+            self.exec_dir_name = os.path.join(dir_name, "")
+            filename = temp_name + entry["filename"]
 
-        if dir_name == dir_:
-            thread.finishedCL.connect(self.done_abler)
+            thread = WorkerThread(url, filename, self.exec_dir_name, temp_name)
+            thread.update.connect(self.updatepb)
+            thread.finishedDL.connect(self.extraction)
+            thread.finishedEX.connect(self.finalcopy)
+            thread.finishedCP.connect(self.cleanup)
+
+            if dir_name == dir_:
+                thread.finishedCL.connect(self.done_abler)
+            else:
+                thread.finishedCL.connect(self.done_launcher)
+
+            thread.start()
         else:
-            thread.finishedCL.connect(self.done_launcher)
-
-        thread.start()
+            self.btn_update.setDisabled(True)
+            # print(f"counter_process: {count_process('blender')}")
+            print(f"proc: {proc}")
+            QtWidgets.QMessageBox.information(
+                self,
+                "테스트",
+                "내용",
+            )
+            self.setup_test_ui()
+            if os.path.isdir(temp_name):
+                shutil.rmtree(temp_name)
+            print("DDDDDDDDDDDD")
+            return
 
     def updatepb(self, percent: int) -> None:
         """다운로드 진행상황 바 표시"""

--- a/launcher_abler/AblerLauncher.py
+++ b/launcher_abler/AblerLauncher.py
@@ -296,18 +296,6 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
             lambda throwaway=0, entry=self.entry: self.download(entry, dir_name=dir_)
         )
 
-    def setup_test_ui(self) -> None:
-        """Update Launcher 버튼 활성화 UI"""
-        print("111")
-        self.btn_update_launcher.hide()
-        print("222")
-        self.btn_update.show()
-        print("333")
-        self.btn_execute.hide()
-        print("444")
-        self.btn_update.setDisabled(False)
-        print("555")
-
     def setup_execute_ui(self) -> None:
         """Run ABLER 버튼 활성화 UI"""
 
@@ -324,9 +312,6 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
 
     def download(self, entry: dict, dir_name: str) -> None:
         """ABLER/Launcher 최신 릴리즈 다운로드"""
-
-        print("")
-        print("download 함수 들어옴")
 
         temp_name = "./blendertemp" if dir_name == dir_ else "./launchertemp"
 
@@ -345,10 +330,7 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
 
         logger.info(f"Starting download thread for {url}{version}")
 
-        proc = count_process("blender")
-
-        if proc == 0:
-            print("실제 다운로드 하는 곳. 여기 들어오면 안됨.")
+        if count_process("blender") == 0:
             self.setup_download_ui(entry, dir_name)
 
             self.exec_dir_name = os.path.join(dir_name, "")
@@ -366,20 +348,17 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
                 thread.finishedCL.connect(self.done_launcher)
 
             thread.start()
+
         else:
-            self.btn_update.setDisabled(True)
-            # print(f"counter_process: {count_process('blender')}")
-            print(f"proc: {proc}")
+            if os.path.isdir(temp_name):
+                shutil.rmtree(temp_name)
+
+            # TODO: 유저 flow는 알림이 떴을 때, 배경은 흐리게 (blur) 하는 것이 좋음
             QtWidgets.QMessageBox.information(
                 self,
                 "테스트",
                 "내용",
             )
-            self.setup_test_ui()
-            if os.path.isdir(temp_name):
-                shutil.rmtree(temp_name)
-            print("DDDDDDDDDDDD")
-            return
 
     def updatepb(self, percent: int) -> None:
         """다운로드 진행상황 바 표시"""

--- a/launcher_abler/AblerLauncher.py
+++ b/launcher_abler/AblerLauncher.py
@@ -356,8 +356,8 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
             # TODO: 유저 flow는 알림이 떴을 때, 배경은 흐리게 (blur) 하는 것이 좋음
             QtWidgets.QMessageBox.information(
                 self,
-                "title",
-                "Currently ABLER is running.\nPlease close all ABLER before update.",
+                "ABLER Updater",
+                "Currently ABLER(or Blender) is running.\nPlease close all ABLER and Blender before update.",
                 QtWidgets.QMessageBox.Close,
             )
 

--- a/launcher_abler/AblerLauncher.py
+++ b/launcher_abler/AblerLauncher.py
@@ -330,7 +330,7 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
 
         logger.info(f"Starting download thread for {url}{version}")
 
-        if count_process("blender") == 0:
+        if process_count("blender") == 0:
             self.setup_download_ui(entry, dir_name)
 
             self.exec_dir_name = os.path.join(dir_name, "")
@@ -358,8 +358,8 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
                 self,
                 "title",
                 "Currently ABLER is running.\nPlease close all ABLER before update.",
+                QtWidgets.QMessageBox.Close,
             )
-            # QtWidgets.QMessageBox.close(self, "A", "B")
 
     def updatepb(self, percent: int) -> None:
         """다운로드 진행상황 바 표시"""

--- a/launcher_abler/AblerLauncherUtils.py
+++ b/launcher_abler/AblerLauncherUtils.py
@@ -68,7 +68,7 @@ def hbytes(num) -> str:
     return "%3.1f%s" % (num, " TB")
 
 
-def count_process(proc) -> int:
+def process_count(proc) -> int:
     """현재 실행되고 있는 프로세스의 개수를 세기"""
 
     proc_list = [p.name() for p in psutil.process_iter()]

--- a/launcher_abler/AblerLauncherUtils.py
+++ b/launcher_abler/AblerLauncherUtils.py
@@ -22,7 +22,8 @@ if len(sys.argv) > 1:
 
 def set_url() -> str:
     """GitHub Repo의 URL 세팅"""
-    url = "https://api.github.com/repos/ACON3D/blender/releases/latest"
+    # url = "https://api.github.com/repos/ACON3D/blender/releases/latest"
+    url = "https://cms.abler3d.biz/abler_update_info"
 
     if pre_rel:
         url = "https://api.github.com/repos/ACON3D/blender/releases"

--- a/launcher_abler/AblerLauncherUtils.py
+++ b/launcher_abler/AblerLauncherUtils.py
@@ -1,5 +1,6 @@
 import pathlib
 import sys
+import psutil
 from enum import Enum, auto
 
 
@@ -62,6 +63,12 @@ def hbytes(num) -> str:
             return "%3.1f%s" % (num, x)
         num /= 1024.0
     return "%3.1f%s" % (num, " TB")
+
+
+def count_process(proc) -> int:
+    proc_list = [p.name() for p in psutil.process_iter()]
+    proc_count = sum(i.startswith(proc) for i in proc_list)
+    return proc_count
 
 
 class StateUI(Enum):

--- a/launcher_abler/AblerLauncherUtils.py
+++ b/launcher_abler/AblerLauncherUtils.py
@@ -23,9 +23,12 @@ if len(sys.argv) > 1:
 
 def set_url() -> str:
     """GitHub Repo의 URL 세팅"""
+
+    # GitHub API에는 접근 횟수 60회가 있어, 캐시를 받아오는 URL로 대체
     # url = "https://api.github.com/repos/ACON3D/blender/releases/latest"
     url = "https://cms.abler3d.biz/abler_update_info"
 
+    # TODO: Pre-Release, Test Repository Release API 등에 대해서도 교체 필요
     if pre_rel:
         url = "https://api.github.com/repos/ACON3D/blender/releases"
     elif new_repo_rel:
@@ -66,6 +69,8 @@ def hbytes(num) -> str:
 
 
 def count_process(proc) -> int:
+    """현재 실행되고 있는 프로세스의 개수를 세기"""
+
     proc_list = [p.name() for p in psutil.process_iter()]
     proc_count = sum(i.startswith(proc) for i in proc_list)
     return proc_count

--- a/launcher_abler/requirements.txt
+++ b/launcher_abler/requirements.txt
@@ -13,3 +13,4 @@ QtPy==2.0.1
 requests==2.27.1
 shiboken2==5.15.2.1
 urllib3==1.26.9
+psutil==5.9.2


### PR DESCRIPTION
## 관련 링크

Notion: [AblerLauncher에서 ABLER (및 Blender) 안전하게 종료하기](https://www.notion.so/acon3d/AblerLauncher-ABLER-Blender-bcfe9a25391445aa9c6585f5a15b7385)


## 발제/내용

- 파일 or 프로그램 버전 알림 팝업에서 Update ABLER 클릭하면, 해당 에이블러는 종료되고 런처는 정상적으로 실행됨
- 그러나, 다른 에이블러 클라이언트가 실행되어 있으면, Windows 에서는 켜져있는 프로그램에 접근할 수 없어 런처로 업데이트를 해도 정상적으로 업데이트가 되지 않는 문제가 있음
- 에이블러 런처에서 Update ABLER 클릭 시, 켜져있는 모든 에이블러 클라이언트들이 종료되어 정상적으로 업데이트가 진행되어야함


## 대응

- 런처의 GitHub API URL을 CMS 주소로 변경
    - [GitHub API URL](https://api.github.com/repos/ACON3D/blender/releases/latest) → [ABLER CMS API URL](https://cms.abler3d.biz/abler_update_info)
- 런처 유틸리티 모듈 (`AblerLauncherUtils.py`) 에 프로세스 개수를 세는 함수 `process_count()` 추가
- 실행되고 있는 프로세스 개수에 따라, 동작 분리
    ```python
    # AblerLauncher.py
    def download() -> None:
        ...
        if process_count("blender") == 0:
            "Download ABLER"
        else:
            "프로그램 종료 QMessageBox"
    ```
- 메세지 박스 (`QMessageBox`) 업데이트
    ```python
    QtWidgets.QMessageBox.information(
        self,
        "ABLER Updater",
        "Currently ABLER(or Blender) is running.\nPlease close all ABLER and Blender before update.",
        QtWidgets.QMessageBox.Close,
    )
    ```
- 런처를 `.exe` 로 추출하여 테스트
    ```bash
    $ pyinstaller --icon=icon.ico --onefile --uac-admin --windowed AblerLauncher.py
    ```

- 결과

![image](https://user-images.githubusercontent.com/52474700/192199261-95b5910a-c9c8-40de-a013-e054dc9eb8dd.png)
