### PR TITLE
스플래시 스크린이 출력 된 상태에서 창전환 시 튜토리얼 팝업이 스플래시 스크린 위로 올라오는 오류

### DIFF
--- a/release/scripts/startup/abler/startup_flow.py
+++ b/release/scripts/startup/abler/startup_flow.py
@@ -252,6 +252,8 @@ class Acon3dModalOperator(BlockingModalOperator):
             "ESC",
             "RET",
         )
+        if event.type == "WINDOW_DEACTIVATE":
+            return False
 
         if (
             userInfo


### PR DESCRIPTION

## 관련 링크
[이슈 링크](https://www.notion.so/acon3d/Issue-0052-09e13d23596148b78fec11112aca775f)

## 발제/내용

- 스플래시 스크린 상태에서 창 전환을 하면 튜토리얼 팝업이 스플래시 위로 올라옴
- 튜토리얼 팝업을 종료 시에 스플래시 화면이 남아있음

## 대응

### 어떤 조치를 취했나요?

- 윈도우에서 Window deactivate 이벤트 발생할 시, 스플래시의 순서가 꼬이는 경우가 있어서 해당 경우에 False를 반환하도록 함.
