### PR TITLE
카메라 삭제 후 렌더 및 씬 추가 에러

### DIFF
--- a/release/scripts/startup/abler/lib/cameras.py
+++ b/release/scripts/startup/abler/lib/cameras.py
@@ -66,7 +66,6 @@ def go_to_custom_camera(self, context) -> None:
     turn_on_camera_view()
 
 
-# ACON 카메라 유무와 관계없이 View_Camera 가 존재하는지 체크, 없으면 만듦
 def make_sure_camera_exists() -> None:
     # early out if scene camera exists
     if bpy.context.scene.camera:

--- a/release/scripts/startup/abler/lib/cameras.py
+++ b/release/scripts/startup/abler/lib/cameras.py
@@ -66,27 +66,24 @@ def go_to_custom_camera(self, context) -> None:
     turn_on_camera_view()
 
 
+# ACON 카메라 유무와 관계없이 View_Camera 가 존재하는지 체크, 없으면 만듦
 def make_sure_camera_exists() -> None:
     # early out if scene camera exists
     if bpy.context.scene.camera:
         bpy.context.scene.camera.data.show_passepartout = False
         return
 
-    # get camera to set to context
-    camera_object: Optional[Object] = bpy.data.objects.get("View_Camera")
-
     # create camera if View_Camera does not exist
-    if not camera_object or camera_object.type != "CAMERA":
-        camera_data: Camera = bpy.data.cameras.new("View_Camera")
-        camera_object: Object = bpy.data.objects.new("View_Camera", camera_data)
-        camera_object.location[0] = 7.35889
-        camera_object.location[1] = -6.92579
-        camera_object.location[2] = 4.9583
-        camera_object.rotation_mode = "XYZ"
-        camera_object.rotation_euler[0] = 1.109319
-        camera_object.rotation_euler[1] = 0
-        camera_object.rotation_euler[2] = 0.814928
-        bpy.context.scene.collection.objects.link(camera_object)
+    camera_data: Camera = bpy.data.cameras.new("View_Camera")
+    camera_object: Object = bpy.data.objects.new("View_Camera", camera_data)
+    camera_object.location[0] = 7.35889
+    camera_object.location[1] = -6.92579
+    camera_object.location[2] = 4.9583
+    camera_object.rotation_mode = "XYZ"
+    camera_object.rotation_euler[0] = 1.109319
+    camera_object.rotation_euler[1] = 0
+    camera_object.rotation_euler[2] = 0.814928
+    bpy.context.scene.collection.objects.link(camera_object)
 
     camera_object.data.show_passepartout = False
 

--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -148,10 +148,10 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
             print("Failed to unlink camera from old scene.")
 
     else:
-        cam = bpy.data.cameras.new("View Camera")
+        cam = bpy.data.cameras.new("View_Camera")
         cam.lens = 30
         cam.show_passepartout = False
-        obj = bpy.data.objects.new("View Camera", cam)
+        obj = bpy.data.objects.new("View_Camera", cam)
         obj.location = (4.7063, 7.6888, 1.9738)
         obj.rotation_euler = (radians(90), radians(0), radians(-212))
         new_scene.collection.objects.link(obj)

--- a/release/scripts/startup/abler/render_control.py
+++ b/release/scripts/startup/abler/render_control.py
@@ -580,7 +580,7 @@ class Acon3dRenderPanel(bpy.types.Panel):
         row = layout.row()
         row.operator("acon3d.render_quick", text="Quick Render", text_ctxt="*")
 
-        if any(obj.type == "CAMERA" for obj in bpy.data.objects):
+        if bpy.context.scene.camera:
             row.operator("acon3d.render_full", text="Full Render")
             row = layout.row()
             row.operator("acon3d.render_line", text="Line Render")


### PR DESCRIPTION
## 관련 링크
[개발 태스크 카드](https://www.notion.so/acon3d/2bb1ce82a5f34bb1a5c7a419098365f4)
[QA 이슈 카드 1](https://www.notion.so/acon3d/Issue-0040_-Full-Render-ee40c3eb2c1c4d699f1862d4dd8c91e8)
[QA 이슈 카드 2](https://www.notion.so/acon3d/Issue-0041_-977320d0405848d589230cb47aea3911)

## 발제/내용
프로젝트에 Scene 이 두 개 이상일 때, 현재 Scene 에 카메라가 없고, 다른 Scene 에 카메라가 한 개 이상 있는 상태에서
-  현재 Scene의 카메라를 지우고 render 를 호출하면 에러 발생

- create_scene 을 호출했을 떄 발생

## 대응

### 어떤 조치를 취했나요?

1. 기본적으로 `View_Camera` 라는 이름으로 카메라를 만들도록 되어있으나, create_scene 에서 camera 가 없는 경우 `View Camera` 라는 이름으로 카메라를 만들고 있음
View Camera => View_Camera 로 수정하였습니다.

2. create_scene 의

`camera_object: Optional[Object] = bpy.data.objects.get("View_Camera")`

구문에서

-  다른 씬에 있는 카메라를 가져와서, 현재 씬의 View_Layer 에서 찾을 수 없어서 에러 발생

- View_Camera 라는 이름이 여러개 생기면 .001, .002 가 붙어서 제대로 가져오지 못하는 경우가 발생

위 두가지 오류가 있어서,
`bpy.context.scene.camera` 가 없으면 현재 씬에 카메라가 없다고 가정하고 위 구문을 삭제했습니다.

3. Acon3dRenderPanel 의
`if any(obj.type == "CAMERA" for obj in bpy.data.objects):`
구문에서 ACON_col_cameras 의 카메라와 다른 씬의 메인 카메라까지 감지해서 에러가 발생하고 있었습니다.
현재 씬에 카메라가 있는지 체크하는 것으로 조건을 변경하였습니다.