### PR TITLE
에이블러 파일 더블클릭으로 오픈시, 간헐적으로 에이블러 클라이언트가 종료됨

### DIFF
--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -66,8 +66,16 @@ def refresh_look_at_me() -> None:
 
     context = bpy.context
     prev_active_object = context.active_object
-
-    bpy.ops.object.select_all(action="DESELECT")
+    # 기존에 있는 bpy.ops.object.select_all(action='DESELECT')를 사용하면 가끔 크래시가 나는 경우가 있음
+    # 일단 GPU와 RAM의 사용량이 많아서 뭔가 delay가 생기는 경우에 해당 크래시가 나는 것으로 보임
+    # 그래서 일단 deselect를 확보된 자원들을 이용해서 사용하도록 아래와 같이 안전하게 처리함.
+    try:
+        if context.selected_objects and len(context.selected_objects) >0:
+            for obj in context.selected_objects:
+                obj.select_set(False)
+    except Exception as e:
+        # raise RuntimeError("Error while deselecting objects: " + str(e)) # TODO: 아직 어떻게 관리되어야 할지 모르겠어서 raise는 일단 주석처리
+        pass
     for obj in bpy.data.objects:
         if obj.ACON_prop.constraint_to_camera_rotation_z:
             obj.select_set(True)

--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -70,7 +70,7 @@ def refresh_look_at_me() -> None:
     # 일단 GPU와 RAM의 사용량이 많아서 뭔가 delay가 생기는 경우에 해당 크래시가 나는 것으로 보임
     # 그래서 일단 deselect를 확보된 자원들을 이용해서 사용하도록 아래와 같이 안전하게 처리함.
     try:
-        if context.selected_objects and len(context.selected_objects) >0:
+        if context.selected_objects and len(context.selected_objects) > 0:
             for obj in context.selected_objects:
                 obj.select_set(False)
     except Exception as e:

--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -70,7 +70,7 @@ def refresh_look_at_me() -> None:
     # 일단 GPU와 RAM의 사용량이 많아서 뭔가 delay가 생기는 경우에 해당 크래시가 나는 것으로 보임
     # 그래서 일단 deselect를 확보된 자원들을 이용해서 사용하도록 아래와 같이 안전하게 처리함.
     try:
-        if context.selected_objects and len(context.selected_objects) > 0:
+        if context.selected_objects:
             for obj in context.selected_objects:
                 obj.select_set(False)
     except Exception as e:


### PR DESCRIPTION
## 관련 링크
[이슈 링크](https://www.notion.so/acon3d/Issue-0039_-244e83d84c21436a87f84cb38ef1173b)

## 발제/내용

- File open시에 간헐적으로, 에이블러 클라이언트가 종료됨
## 대응

### 어떤 조치를 취했나요?

- 에이블러로 실행 시에 scene을 로드 하면서 가끔 GPU 연산이나 RAM이 꽉차서 뭔가 연산이 꼬일 경우가 있고, bpy.ops.object.Select_all()이 작동 하다가 크래시 나는 경우가 있는데 경우가 있음. 
- 해당 케이스에서 자료에 접근가능함이 그나마 보장 되어있도록 안전하게 케이스를 수정함.