### PR TITLE
메타데이터 저장용 text block 를 일반 UI 에서 보이지 않게 숨기기

### DIFF
--- a/release/scripts/startup/abler/lib/version.py
+++ b/release/scripts/startup/abler/lib/version.py
@@ -12,6 +12,7 @@ from enum import Enum
 url = "https://cms.abler3d.biz/abler_update_info"
 user_path = bpy.utils.resource_path("USER")
 low_version_warning_hidden_path = os.path.join(user_path, "lvwh")
+METADATA_NAME = ".metadata"
 
 
 def set_updater() -> str:
@@ -97,7 +98,7 @@ def get_file_version() -> Optional[str]:
 
     0.2.6 이전 버전에서는 이 기능이 없었으므로, None 반환됨
     """
-    if text_data := bpy.data.texts.get("ACON_metadata"):
+    if text_data := bpy.data.texts.get(METADATA_NAME):
         return text_data.ACON_metadata.file_version
     else:
         return None
@@ -127,9 +128,9 @@ def check_file_version() -> FileVersionCheckResult:
 
 
 def update_file_version():
-    text_data = bpy.data.texts.get("ACON_metadata")
+    text_data = bpy.data.texts.get(METADATA_NAME)
     if text_data is None:
-        text_data = bpy.data.texts.new("ACON_metadata")
+        text_data = bpy.data.texts.new(METADATA_NAME)
     metadata = text_data.ACON_metadata
     metadata.file_version = get_local_version()
 


### PR DESCRIPTION
## 관련 링크

[슬랙 스레드 링크](https://acontainer.slack.com/archives/C02K1NPTV42/p1663814652493189)

## 발제/내용

- 기존에는 `ACON_metadata` 라는 이름의 text block 를 사용했기 때문에, Blender 내장 텍스트 에디터 (Shift+F11 로 접근) 에서 해당 항목이 보이고, 지울 수도 있는 상태였습니다.
- 여기에 기록되는 내용은 (많은 것들이 그렇긴 하지만) 미래에 출시될 에이블러에서 항상 안정적으로 접근할 수 있어야 하는 정보이기 때문에, 사용자가 실수로 지워버린다거나 하는 일이 가급적 발생하지 않는 구조이면 좋습니다.
- text block 이름이 `.` 으로 시작하면 텍스트 에디터 UI 에서는 보이지 않는다는 사실을 @JJong84 님이 알려주셔서, 사용자가 쉽게 접근하지 못하도록 해당 내용을 반영했습니다. (Outliner -> Data API 로 접근하면 여전히 보이긴 합니다만, 텍스트 에디터보다는 접근성이 훨씬 떨어집니다.)
