### PR TITLE
과거 파일을 열었을 때 튜토리얼 가이드가 뜨지 않는 문제

### DIFF
--- a/release/scripts/startup/abler/startup_flow.py
+++ b/release/scripts/startup/abler/startup_flow.py
@@ -110,9 +110,7 @@ def start_check_file_version():
 
 
 def start_check_server_version():
-    if not is_first_run:
-        return
-    if has_server_update():
+    if is_first_run and has_server_update():
         bpy.ops.acon3d.update_alert("INVOKE_DEFAULT")
     else:
         start_authentication()


### PR DESCRIPTION
## 관련 링크

[Reopen 된 QA 이슈 링크](https://www.notion.so/acon3d/Issue-0032_File-Open-Show-Tutorial-Guide-c150b50a210e4230aaedeafd29a4a69f)

## 발제/내용

- 튜토리얼 가이드를 띄울 때 ACON_userInfo 메시에 접근하는데, ACON_userInfo 는 start_authentication 에서 생성합니다.
- 그런데 "과거 파일" 을 여는 경우에, 실수로 start_authentication 을 실행하지 못해서 ACON_userInfo 메시가 생성되지 않습니다.
- 해당 경우에도 start_authentication 을 실행되도록 수정해서 해결했습니다.