### PR TITLE
네트워크 없이 런처를 실행할 때, 메세지 박스 출력

### DIFF
--- a/launcher_abler/AblerLauncher.py
+++ b/launcher_abler/AblerLauncher.py
@@ -145,6 +145,7 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
         self.launcher_installed = ""
         self.lastcheck = ""
         self.entry = {}
+        self.network_check = get_network_connection()
         global dir_
         global launcherdir_
 
@@ -156,7 +157,7 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
             import UpdateLauncher
             import UpdateAbler
 
-            if get_network_connection():
+            if self.network_check:
                 state_ui, finallist = UpdateLauncher.check_launcher(
                     dir_, self.launcher_installed
                 )
@@ -307,7 +308,7 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
         self.btn_execute.show()
 
         if sys.platform == "win32":
-            if get_network_connection():
+            if self.network_check:
                 self.btn_execute.clicked.connect(self.exec_windows)
             else:
                 self.btn_execute.clicked.connect(self.exec_no_network)

--- a/launcher_abler/AblerLauncher.py
+++ b/launcher_abler/AblerLauncher.py
@@ -545,7 +545,7 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
         QtWidgets.QMessageBox.information(
             self,
             "ABLER Launcher",
-            "ABLER requires internet connectivity. Please check internet connection and try again.",
+            "ABLER requires internet connection. Please check internet connection and try again.",
             QtWidgets.QMessageBox.Close,
         )
 

--- a/launcher_abler/AblerLauncher.py
+++ b/launcher_abler/AblerLauncher.py
@@ -66,6 +66,15 @@ logging.basicConfig(
 logger = logging.getLogger()
 
 
+import requests
+
+try:
+    request = requests.get("https://google.com", timeout=5)
+    print("Connected to the Internet")
+except (requests.ConnectionError, requests.Timeout) as exception:
+    print("No Internet connection.")
+
+
 class WorkerThread(QtCore.QThread):
     """Does all the actual work in the background, informs GUI about status"""
 

--- a/launcher_abler/AblerLauncher.py
+++ b/launcher_abler/AblerLauncher.py
@@ -29,6 +29,7 @@ import sys
 import urllib.parse
 import urllib.request
 import time
+import requests
 from distutils.dir_util import copy_tree
 from AblerLauncherUtils import *
 from enum import Enum
@@ -66,13 +67,12 @@ logging.basicConfig(
 logger = logging.getLogger()
 
 
-import requests
 
-try:
-    request = requests.get("https://google.com", timeout=5)
-    print("Connected to the Internet")
-except (requests.ConnectionError, requests.Timeout) as exception:
-    print("No Internet connection.")
+# try:
+#     request = requests.get(set_url(), timeout=5)
+#     print("Connected to the Internet")
+# except (requests.ConnectionError, requests.Timeout) as exception:
+#     print("No Internet connection.")
 
 
 class WorkerThread(QtCore.QThread):
@@ -161,13 +161,28 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
         self.setup_config()
         self.setup_init_ui()
 
+        # if network_connection():
+        #     print("network connection")
+        # else:
+        #     QtWidgets.QMessageBox.information(
+        #         self,
+        #         "Title",
+        #         "Contents",
+        #     )
+        #     return
+
         try:
             import UpdateLauncher
             import UpdateAbler
 
+            # request = requests.get(set_url(), timeout=5)
+
+
             state_ui, finallist = UpdateLauncher.check_launcher(
                 dir_, self.launcher_installed
             )
+            print("aaaa")
+            print(state_ui)
 
             if finallist:
                 self.entry = finallist[0]
@@ -175,6 +190,7 @@ class BlenderUpdater(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
 
             # Launcher에서 릴리즈가 없는 빈 저장소임을 확인하면 ABLER에서 확인할 필요 없음
             state_ui = None if state_ui == StateUI.empty_repo else state_ui
+            print(state_ui)
 
             if not state_ui:
                 state_ui, finallist = UpdateAbler.check_abler(

--- a/launcher_abler/AblerLauncherUtils.py
+++ b/launcher_abler/AblerLauncherUtils.py
@@ -77,13 +77,14 @@ def process_count(proc) -> int:
     return proc_count
 
 
-# def network_connection():
-#     try:
-#         request = requests.get(set_url(), timeout=5)
-#         return True
-#     except (requests.ConnectionError, requests.Timeout) as exception:
-#         QtWidgets.
-#         return False
+def get_network_connection() -> bool:
+    """네트워크 연결 상태를 bool 타입으로 return"""
+
+    try:
+        request = requests.get(set_url(), timeout=5)
+        return True
+    except (requests.ConnectionError, requests.Timeout) as exception:
+        return False
 
 
 class StateUI(Enum):

--- a/launcher_abler/AblerLauncherUtils.py
+++ b/launcher_abler/AblerLauncherUtils.py
@@ -83,7 +83,7 @@ def get_network_connection() -> bool:
     try:
         request = requests.get(set_url(), timeout=5)
         return True
-    except (requests.ConnectionError, requests.Timeout) as exception:
+    except (requests.ConnectionError, requests.ConnectTimeout) as exception:
         return False
 
 

--- a/launcher_abler/AblerLauncherUtils.py
+++ b/launcher_abler/AblerLauncherUtils.py
@@ -1,6 +1,7 @@
 import pathlib
 import sys
 import psutil
+import requests
 from enum import Enum, auto
 
 
@@ -74,6 +75,15 @@ def process_count(proc) -> int:
     proc_list = [p.name() for p in psutil.process_iter()]
     proc_count = sum(i.startswith(proc) for i in proc_list)
     return proc_count
+
+
+# def network_connection():
+#     try:
+#         request = requests.get(set_url(), timeout=5)
+#         return True
+#     except (requests.ConnectionError, requests.Timeout) as exception:
+#         QtWidgets.
+#         return False
 
 
 class StateUI(Enum):

--- a/launcher_abler/UpdateLauncher.py
+++ b/launcher_abler/UpdateLauncher.py
@@ -7,7 +7,6 @@ from typing import Tuple, Optional
 from distutils.version import StrictVersion
 import configparser
 from AblerLauncherUtils import *
-from PySide2 import QtWidgets, QtCore, QtGui
 
 
 if sys.platform == "win32":
@@ -40,15 +39,12 @@ def check_launcher(dir_: str, launcher_installed: str) -> Tuple[Enum, Optional[l
     # URL settings
     # Pre-Release 테스트 시에는 req = req[0]으로 pre-release 데이터 받아오기
     url = set_url()
-    # print(f"> url : {url}")
 
     is_release, req, state_ui, launcher_installed = get_req_from_url(
         url, state_ui, launcher_installed, dir_
     )
-    print(f"get_req_from_url 이후 확인하는 state_ui: {state_ui}")
 
     if state_ui == StateUI.error:
-        print("check state_ui")
         return state_ui, finallist
 
     if not is_release:
@@ -92,25 +88,15 @@ def get_req_from_url(
 
     try:
         req = requests.get(url).json()
-
     except Exception as e:
-        print(f"bool(req): {bool(req)}")
-        # print(e)
         # self.statusBar().showMessage(
         #     "Error reaching server - check your internet connection"
         # )
         # logger.error(e)
         # self.frm_start.show()
-        print("메세지 박스 직전")
-        # self.statusBar().showMessage(
-        #     "qwer"
-        # )
-        print("메세지 박스 직후")
+        logger.error(e)
         state_ui = StateUI.error
-        print(f"exception에서 state_ui: {state_ui}")
-        # return state_ui, finallist
 
-    print("exception 이후 실행되는 부분")
     is_release = True
 
     # Pre-Release에서는 req[0]이 pre-release 정보를 가지고 있음
@@ -121,19 +107,11 @@ def get_req_from_url(
         # 따라서 len(req) == 0 이고, is_release를 False로 업데이트
         is_release = False if len(req) == 0 else is_release
 
-    print("여기까지 도달하는지 확인")
     try:
         is_release = req["message"] != "Not Found"
-        print("Part A")
     except Exception as e:
         logger.debug("Release found")
-        print("Part B")
 
-    print("check_launcher 끝날때 변수 체크")
-    print(f"is_release: {is_release}")
-    print(f"req: {req}")
-    print(f"state_ui: {state_ui}")
-    print(f"launcher_installed: {launcher_installed}")
     return is_release, req, state_ui, launcher_installed
 
 

--- a/launcher_abler/UpdateLauncher.py
+++ b/launcher_abler/UpdateLauncher.py
@@ -7,6 +7,7 @@ from typing import Tuple, Optional
 from distutils.version import StrictVersion
 import configparser
 from AblerLauncherUtils import *
+from PySide2 import QtWidgets, QtCore, QtGui
 
 
 if sys.platform == "win32":
@@ -39,13 +40,14 @@ def check_launcher(dir_: str, launcher_installed: str) -> Tuple[Enum, Optional[l
     # URL settings
     # Pre-Release 테스트 시에는 req = req[0]으로 pre-release 데이터 받아오기
     url = set_url()
-    print(f"> url : {url}")
+    # print(f"> url : {url}")
 
     is_release, req, state_ui, launcher_installed = get_req_from_url(
         url, state_ui, launcher_installed, dir_
     )
 
     if state_ui == StateUI.error:
+        print("check state_ui")
         return state_ui, finallist
 
     if not is_release:
@@ -89,14 +91,16 @@ def get_req_from_url(
 
     try:
         req = requests.get(url).json()
+        print(bool(req))
     except Exception as e:
+        print(e)
         # self.statusBar().showMessage(
         #     "Error reaching server - check your internet connection"
         # )
         # logger.error(e)
         # self.frm_start.show()
-        logger.error(e)
         state_ui = StateUI.error
+        print(state_ui)
 
     is_release = True
 

--- a/launcher_abler/UpdateLauncher.py
+++ b/launcher_abler/UpdateLauncher.py
@@ -45,6 +45,7 @@ def check_launcher(dir_: str, launcher_installed: str) -> Tuple[Enum, Optional[l
     is_release, req, state_ui, launcher_installed = get_req_from_url(
         url, state_ui, launcher_installed, dir_
     )
+    print(f"get_req_from_url 이후 확인하는 state_ui: {state_ui}")
 
     if state_ui == StateUI.error:
         print("check state_ui")
@@ -91,17 +92,25 @@ def get_req_from_url(
 
     try:
         req = requests.get(url).json()
-        print(bool(req))
+
     except Exception as e:
-        print(e)
+        print(f"bool(req): {bool(req)}")
+        # print(e)
         # self.statusBar().showMessage(
         #     "Error reaching server - check your internet connection"
         # )
         # logger.error(e)
         # self.frm_start.show()
+        print("메세지 박스 직전")
+        # self.statusBar().showMessage(
+        #     "qwer"
+        # )
+        print("메세지 박스 직후")
         state_ui = StateUI.error
-        print(state_ui)
+        print(f"exception에서 state_ui: {state_ui}")
+        # return state_ui, finallist
 
+    print("exception 이후 실행되는 부분")
     is_release = True
 
     # Pre-Release에서는 req[0]이 pre-release 정보를 가지고 있음
@@ -112,11 +121,19 @@ def get_req_from_url(
         # 따라서 len(req) == 0 이고, is_release를 False로 업데이트
         is_release = False if len(req) == 0 else is_release
 
+    print("여기까지 도달하는지 확인")
     try:
         is_release = req["message"] != "Not Found"
+        print("Part A")
     except Exception as e:
         logger.debug("Release found")
+        print("Part B")
 
+    print("check_launcher 끝날때 변수 체크")
+    print(f"is_release: {is_release}")
+    print(f"req: {req}")
+    print(f"state_ui: {state_ui}")
+    print(f"launcher_installed: {launcher_installed}")
     return is_release, req, state_ui, launcher_installed
 
 


### PR DESCRIPTION
## 관련 링크

- [Issue #0053](https://www.notion.so/acon3d/Issue-0053-launch-abler-run-abler-launch-updater-89848080cbb24c11bf4b6761bcfd9f24)
- [네트워크 연결이 없으면 에이블러 런처에서 관련 메세지 띄워주기](https://www.notion.so/acon3d/e7f056db20af49a38bb84e9b11e04a6f)


## 발제/내용

- 네트워크가 연결되어 있지 않는 환경에서 에이블러 런처를 실행하면, Update Launcher 가 노출되며, 버튼 클릭 시에도 아무 반응이 없음.
- 따라서, 기획 요구 사항으로 해결 필요


## 대응

### 어떤 조치를 취했나요?

- 네트워크 통신 테스트를 `bool` 타입 함수로 만듬
    
    ```python
    # AblerLauncherUtils.py
    def get_network_connection() -> bool:
        """네트워크 연결 상태를 bool 타입으로 return"""
    
        try:
            request = requests.get(set_url(), timeout=5)
            return True
        except (requests.ConnectionError, requests.Timeout) as exception:
            return False
    ```
    
- 네트워크 통신이 `True` 이면 런처 정상 실행, `False` 이면 런처 네트워크 메세지 띄워주기
    
    ```python
    # AblerLauncher.py
    class BlenderUpdater():
        ...
        try:
            if get_network_connection():
                # 네트워크가 연결된 상태
                "런처 정상 실행"
            else:
                # Run ABLER 버튼으로 업데이트
                self.setup_execute_ui()
        ...
    
        def setup_execute_ui():
            ...
            if "Windows":
                if "네트워크 연결됨":
                    "Run ABLER"
                else:
                    self.btn_execute.clicked.connect(self.exec_no_network)
    
        def exec_no_network():
            "네트워크에 연결되어 있지 않을 때, QMessageBox만 띄워주기"
    ```