### PR TITLE
check_path시 extension 추가

### DIFF
--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -148,7 +148,7 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
 
     def execute(self, context):
         try:
-            if not self.check_path():
+            if not self.check_path(extension=".blend"):
                 return {"FINISHED"}
 
             # Blender에서 File Open과 같은 파일을 import하면 Collection과 Mesh Object 이름에 ".001"이 넘버링 하지 않음
@@ -316,7 +316,7 @@ class FileOpenOperator(bpy.types.Operator, AconImportHelper, BaseFileOpenOperato
     filter_glob: bpy.props.StringProperty(default="*.blend", options={"HIDDEN"})
 
     def execute(self, context):
-        if not self.check_path():
+        if not self.check_path(extension=".blend"):
             return {"FINISHED"}
         self.open_file()
         return {"FINISHED"}

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -148,7 +148,7 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
 
     def execute(self, context):
         try:
-            if not self.check_path(extension=".blend"):
+            if not self.check_path(extension="blend"):
                 return {"FINISHED"}
 
             # Blender에서 File Open과 같은 파일을 import하면 Collection과 Mesh Object 이름에 ".001"이 넘버링 하지 않음
@@ -316,7 +316,7 @@ class FileOpenOperator(bpy.types.Operator, AconImportHelper, BaseFileOpenOperato
     filter_glob: bpy.props.StringProperty(default="*.blend", options={"HIDDEN"})
 
     def execute(self, context):
-        if not self.check_path(extension=".blend"):
+        if not self.check_path(extension="blend"):
             return {"FINISHED"}
         self.open_file()
         return {"FINISHED"}

--- a/release/scripts/startup/abler/import_external_files.py
+++ b/release/scripts/startup/abler/import_external_files.py
@@ -49,7 +49,8 @@ class ImportFBXOperator(bpy.types.Operator, AconImportHelper):
     filter_glob: bpy.props.StringProperty(default="*.fbx", options={"HIDDEN"})
 
     def execute(self, context):
-        if not self.check_path():
+        if not self.check_path(extension=".fbx"):
+            print("A")
             return {"FINISHED"}
         try:
             for obj in bpy.data.objects:

--- a/release/scripts/startup/abler/import_external_files.py
+++ b/release/scripts/startup/abler/import_external_files.py
@@ -50,7 +50,6 @@ class ImportFBXOperator(bpy.types.Operator, AconImportHelper):
 
     def execute(self, context):
         if not self.check_path(extension="fbx"):
-            print("A")
             return {"FINISHED"}
         try:
             for obj in bpy.data.objects:

--- a/release/scripts/startup/abler/import_external_files.py
+++ b/release/scripts/startup/abler/import_external_files.py
@@ -49,7 +49,7 @@ class ImportFBXOperator(bpy.types.Operator, AconImportHelper):
     filter_glob: bpy.props.StringProperty(default="*.fbx", options={"HIDDEN"})
 
     def execute(self, context):
-        if not self.check_path(extension=".fbx"):
+        if not self.check_path(extension="fbx"):
             print("A")
             return {"FINISHED"}
         try:

--- a/release/scripts/startup/abler/lib/import_file.py
+++ b/release/scripts/startup/abler/lib/import_file.py
@@ -9,7 +9,7 @@ class AconImportHelper(ImportHelper):
         :return: 파일이 아니거나 파일이 없을 경우 False를 반환, 존재하고 파일일 경우 True를 반환
         """
         basename = self.filepath.rsplit(".")[0]
-        path = basename + extension
+        path = basename + "." + extension
         if not os.path.isfile(path):
             bpy.ops.acon3d.alert(
                 "INVOKE_DEFAULT",

--- a/release/scripts/startup/abler/lib/import_file.py
+++ b/release/scripts/startup/abler/lib/import_file.py
@@ -8,9 +8,10 @@ class AconImportHelper(ImportHelper):
         """
         :return: 파일이 아니거나 파일이 없을 경우 False를 반환, 존재하고 파일일 경우 True를 반환
         """
-        basename = self.filepath.rsplit(".")[0]
-        path = basename + "." + extension
-        if not os.path.isfile(path):
+        path = self.filepath
+        path_ext = path.rsplit(".")[-1]
+
+        if path_ext != extension or not os.path.isfile(path):
             bpy.ops.acon3d.alert(
                 "INVOKE_DEFAULT",
                 title="File Select Error",

--- a/release/scripts/startup/abler/lib/import_file.py
+++ b/release/scripts/startup/abler/lib/import_file.py
@@ -4,11 +4,12 @@ from bpy_extras.io_utils import ImportHelper
 
 
 class AconImportHelper(ImportHelper):
-    def check_path(self) -> bool:
+    def check_path(self, extension: str) -> bool:
         """
         :return: 파일이 아니거나 파일이 없을 경우 False를 반환, 존재하고 파일일 경우 True를 반환
         """
-        path = self.filepath
+        basename = self.filepath.rsplit(".")[0]
+        path = basename + extension
         if not os.path.isfile(path):
             bpy.ops.acon3d.alert(
                 "INVOKE_DEFAULT",


### PR DESCRIPTION
## 관련 링크
[링크](https://www.notion.so/acon3d/importFBX-filepath-9f2e0fc5488a44879d227b086c134678)

## 발제/내용

- check_path 함수가 importFBX시에는 fbx 파일만 확인해야 합니다.

## 대응

### 어떤 조치를 취했나요?

- check_path에 extension 파라미터를 추가해 .blend와 .fbx 다르게 확인하도록 변경했습니다.
- 추후 importSKP가 들어갈 때도 extension=".skp"로 구분해주면 될거 같습니다.