### PR TITLE
에이블러에서 런처 프로세스를 확인하고 에이블러 종료하기

### DIFF
--- a/release/scripts/startup/abler/lib/version.py
+++ b/release/scripts/startup/abler/lib/version.py
@@ -4,6 +4,7 @@ import sys
 import requests
 import bpy
 import configparser
+import psutil
 from distutils.version import StrictVersion
 from typing import Optional
 from enum import Enum
@@ -35,6 +36,14 @@ def set_updater() -> str:
 def get_launcher() -> str:
     launcher = os.path.join(set_updater(), "AblerLauncher.exe")
     return launcher
+
+
+def get_launcher_process(proc) -> int:
+    """현재 실행되고 있는 프로세스의 개수를 세기"""
+
+    proc_list = [p.name() for p in psutil.process_iter()]
+    proc_count = sum(i.startswith(proc) for i in proc_list)
+    return proc_count
 
 
 def get_local_version() -> str:

--- a/release/scripts/startup/abler/lib/version.py
+++ b/release/scripts/startup/abler/lib/version.py
@@ -38,7 +38,7 @@ def get_launcher() -> str:
     return launcher
 
 
-def get_launcher_process(proc) -> int:
+def get_launcher_process_count(proc) -> int:
     """현재 실행되고 있는 프로세스의 개수를 세기"""
 
     proc_list = [p.name() for p in psutil.process_iter()]

--- a/release/scripts/startup/abler/startup_flow.py
+++ b/release/scripts/startup/abler/startup_flow.py
@@ -47,6 +47,7 @@ from .lib.version import (
     get_file_version,
     get_local_version,
     read_low_version_warning_hidden,
+    get_launcher_process,
 )
 
 
@@ -524,12 +525,14 @@ class Acon3dUpdateAblerOperator(bpy.types.Operator):
         # 관리자 권한이 필요한 프로그램을 실행하는 옵션
         subprocess.Popen(launcher, shell=True)
 
-        import psutil
-        proc_list = [p.name() for p in psutil.process_iter()]
-        proc_count = sum(i.startswith("AblerLauncher") for i in proc_list)
-        while not proc_count >= 1:
-            proc_list = [p.name() for p in psutil.process_iter()]
-            proc_count = sum(i.startswith("AblerLauncher") for i in proc_list)
+        # AblerLauncer.exe가 실행되면 ABLER 종료
+        if sys.platform == "win32":
+            while not (proc_count := get_launcher_process("AblerLauncher")) >= 1:
+                proc_count = get_launcher_process("AblerLauncher")
+        elif sys.platform == "darwin":
+            pass
+        else:
+            raise Exception("Unsupported platform")
 
         bpy.ops.wm.quit_blender()
 

--- a/release/scripts/startup/abler/startup_flow.py
+++ b/release/scripts/startup/abler/startup_flow.py
@@ -523,6 +523,14 @@ class Acon3dUpdateAblerOperator(bpy.types.Operator):
 
         # 관리자 권한이 필요한 프로그램을 실행하는 옵션
         subprocess.Popen(launcher, shell=True)
+
+        import psutil
+        proc_list = [p.name() for p in psutil.process_iter()]
+        proc_count = sum(i.startswith("AblerLauncher") for i in proc_list)
+        while not proc_count >= 1:
+            proc_list = [p.name() for p in psutil.process_iter()]
+            proc_count = sum(i.startswith("AblerLauncher") for i in proc_list)
+
         bpy.ops.wm.quit_blender()
 
         return {"FINISHED"}

--- a/release/scripts/startup/abler/startup_flow.py
+++ b/release/scripts/startup/abler/startup_flow.py
@@ -23,6 +23,7 @@ import pickle
 import platform
 import sys
 import textwrap
+import time
 import webbrowser
 from json import JSONDecodeError
 
@@ -47,7 +48,7 @@ from .lib.version import (
     get_file_version,
     get_local_version,
     read_low_version_warning_hidden,
-    get_launcher_process,
+    get_launcher_process_count,
 )
 
 
@@ -527,10 +528,10 @@ class Acon3dUpdateAblerOperator(bpy.types.Operator):
 
         # AblerLauncer.exe가 실행되면 ABLER 종료
         if sys.platform == "win32":
-            while not (proc_count := get_launcher_process("AblerLauncher")) >= 1:
-                proc_count = get_launcher_process("AblerLauncher")
+            while get_launcher_process_count("AblerLauncher") < 1:
+                time.sleep(1)
         elif sys.platform == "darwin":
-            pass
+            raise NotImplementedError("Not implemented yet for %s." % sys.platform)
         else:
             raise Exception("Unsupported platform")
 


### PR DESCRIPTION
## 관련 링크

- [Issue #0055](https://www.notion.so/acon3d/Issue-0055_-Launcher-ABLER-f4fc30e5b7c44d52ae32a80bbede6e94)
- [에이블러 팝업으로 런처를 실행하면, 관리자 권한만 뜨고 런처가 실행되지 않는 문제](https://www.notion.so/acon3d/354fb0d62c304f8999943f36fc5881a1)


## 발제/내용

- 에이블러가 최신 버전보다 낮은 상태에서 과거 버전의 파일을 더블 클릭으로 실행하고, 업데이트 팝업에서 `ABLER 업데이트` 를 하면 다음 문제가 발생함.
    - 에이블러 클라이언트는 정상적으로 종료됨.
    - 에이블러 런처 실행을 위한 관리자 권한이 정상적으로 실행됨.
    - 그러나, 권리자 권한에서 런처를 실행해도 런처 실행이 안됨.


## 대응

### 어떤 조치를 취했나요?

- 에이블러에서 `subprocess.Popen` 으로 런처를 실행해주지만, 관리자 권한 팝업이 중간에 끼어 있어 런처 실행을 위한 작업 중에 에이블러가 종료되어 런처를 실행하지 못하는 것으로 추정됨.
- `subprocess.Popen` 으로 런처를 실행하고 에이블러를 바로 종료하지 말고, 런처 프로세스인 `AblerLauncher.exe` 를 확인할 때까지 에이블러 종료를 기다리기
    
    ```python
    # startup_flow.py
    class Acon3dUpdateAblerOperator(bpy.types.Operator):
        ...
        def execute(self, context):
            subprocess.Popen("런처 경로", shell=True)
    
            # Windows에서 AblerLauncher.exe 확인하기
            if "Windows":
                while not (proc_count := get_launcher_process("AblerLauncher")) >= 1:
                    proc_count = get_launcher_process("AblerLauncher")
            ...
    
            bpy.ops.wm.quit_blender()
    
    # version.py
    def get_launcher_process(proc) -> int:
        proc_list = "현재 실행되고 있는 Windows 프로세스"
        proc_count = "프로세스 리스트에서 'proc'이 포함된 프로세스 개수의 합"
        return proc_count
    ```