### PR TITLE
파일 오픈 시 때때로 크래시 나는 문제 회피

### DIFF
--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -52,6 +52,16 @@ def hide_header(dummy):
 
 @persistent
 def load_handler(dummy):
+    """
+    Scene 초기화 시 발생하는 크래시를 회피하기 위한 부분
+    관련 이슈:
+    https://www.notion.so/acon3d/Issue-0039_-244e83d84c21436a87f84cb38ef1173b
+    https://www.notion.so/acon3d/Issue-0058-fd84882296d24fd7b46808e37679dc47
+    """
+    bpy.app.timers.register(delayed_load_handler)
+
+
+def delayed_load_handler():
     tracker.turn_off()
     hide_header(None)
     try:


### PR DESCRIPTION
## 관련 링크
- [Issue 0039](https://www.notion.so/acon3d/Issue-0039_-244e83d84c21436a87f84cb38ef1173b)
- [Issue 0058](https://www.notion.so/acon3d/Issue-0058-fd84882296d24fd7b46808e37679dc47)

## 발제/내용

- 파일 오픈 시 load_post 핸들러에서 Scene 데이터에 접근하다가 크래시 나는 문제를 회피하는 수정사항을 적용했습니다.
- 시간 인자를 생략한 bpy.app.timers.register 를 호출하면 이벤트 핸들러 바로 다음 틱에 실행되어 지연을 최소화하면서도, 필요한 초기화 이후에 실행되기를 기대하고 작성했습니다.
- 경고: 이 변경사항이 어떤 부작용을 일으킬 수 있는지 검증되지 않았습니다.
