### PR TITLE
배경이미지 선택 시 에러 발생

### DIFF
--- a/release/scripts/startup/abler/camera_control.py
+++ b/release/scripts/startup/abler/camera_control.py
@@ -220,20 +220,6 @@ class RemoveBackgroundOperator(bpy.types.Operator):
         return {"FINISHED"}
 
 
-def is_valid_extension(target_path, accepted):
-    _, ext = os.path.splitext(target_path)
-
-    if ext.lower() not in accepted:
-        bpy.ops.acon3d.alert(
-            "INVOKE_DEFAULT",
-            title="Check Background Image File",
-            message_1="Failed to load background image file:",
-            message_2=f"{target_path}",
-        )
-        return False
-    return True
-
-
 class OpenDefaultBackgroundOperator(bpy.types.Operator, AconImportHelper):
     """Open Default Background Image"""
 
@@ -247,7 +233,7 @@ class OpenDefaultBackgroundOperator(bpy.types.Operator, AconImportHelper):
     filepath: bpy.props.StringProperty()
 
     def execute(self, context):
-        if not self.check_path() or not is_valid_extension(self.filepath, [".png", ".jpg"]):
+        if not self.check_path(accepted=["png", "jpg"]):
             return {"FINISHED"}
 
         new_image = bpy.data.images.load(self.filepath)
@@ -288,7 +274,7 @@ class OpenCustomBackgroundOperator(bpy.types.Operator, AconImportHelper):
     filter_glob: bpy.props.StringProperty(default=image_extension, options={"HIDDEN"})
 
     def execute(self, context):
-        if not self.check_path() or not is_valid_extension(self.filepath, [".png", ".jpg"]):
+        if not self.check_path(accepted=["png", "jpg"]):
             return {"FINISHED"}
 
         new_image = bpy.data.images.load(self.filepath)

--- a/release/scripts/startup/abler/general.py
+++ b/release/scripts/startup/abler/general.py
@@ -148,7 +148,7 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
 
     def execute(self, context):
         try:
-            if not self.check_path(extension="blend"):
+            if not self.check_path(accepted=["blend"]):
                 return {"FINISHED"}
 
             # Blender에서 File Open과 같은 파일을 import하면 Collection과 Mesh Object 이름에 ".001"이 넘버링 하지 않음
@@ -316,7 +316,7 @@ class FileOpenOperator(bpy.types.Operator, AconImportHelper, BaseFileOpenOperato
     filter_glob: bpy.props.StringProperty(default="*.blend", options={"HIDDEN"})
 
     def execute(self, context):
-        if not self.check_path(extension="blend"):
+        if not self.check_path(accepted=["blend"]):
             return {"FINISHED"}
         self.open_file()
         return {"FINISHED"}

--- a/release/scripts/startup/abler/import_external_files.py
+++ b/release/scripts/startup/abler/import_external_files.py
@@ -49,7 +49,7 @@ class ImportFBXOperator(bpy.types.Operator, AconImportHelper):
     filter_glob: bpy.props.StringProperty(default="*.fbx", options={"HIDDEN"})
 
     def execute(self, context):
-        if not self.check_path(extension="fbx"):
+        if not self.check_path(accepted=["fbx"]):
             return {"FINISHED"}
         try:
             for obj in bpy.data.objects:

--- a/release/scripts/startup/abler/lib/import_file.py
+++ b/release/scripts/startup/abler/lib/import_file.py
@@ -4,14 +4,14 @@ from bpy_extras.io_utils import ImportHelper
 
 
 class AconImportHelper(ImportHelper):
-    def check_path(self, extension: str) -> bool:
+    def check_path(self, accepted: list[str]) -> bool:
         """
         :return: 파일이 아니거나 파일이 없을 경우 False를 반환, 존재하고 파일일 경우 True를 반환
         """
         path = self.filepath
         path_ext = path.rsplit(".")[-1]
 
-        if path_ext != extension or not os.path.isfile(path):
+        if path_ext not in accepted or not os.path.isfile(path):
             bpy.ops.acon3d.alert(
                 "INVOKE_DEFAULT",
                 title="File Select Error",

--- a/release/scripts/startup/abler/lib/import_file.py
+++ b/release/scripts/startup/abler/lib/import_file.py
@@ -6,7 +6,7 @@ from bpy_extras.io_utils import ImportHelper
 class AconImportHelper(ImportHelper):
     def check_path(self, accepted: list[str]) -> bool:
         """
-        :param accepted: 하용할 extension 리스트
+        :param accepted: 허용할 extension 리스트
 
         :return: accepted 에 파일의 확장자가 없는 경우,
             파일 형식이 아닌 경우, 파일이 없는 경우 False 반환,

--- a/release/scripts/startup/abler/lib/import_file.py
+++ b/release/scripts/startup/abler/lib/import_file.py
@@ -6,7 +6,11 @@ from bpy_extras.io_utils import ImportHelper
 class AconImportHelper(ImportHelper):
     def check_path(self, accepted: list[str]) -> bool:
         """
-        :return: 파일이 아니거나 파일이 없을 경우 False를 반환, 존재하고 파일일 경우 True를 반환
+        :param accepted: 하용할 extension 리스트
+
+        :return: accepted 에 파일의 확장자가 없는 경우,
+            파일 형식이 아닌 경우, 파일이 없는 경우 False 반환,
+            그 외의 경우 True 반환
         """
         path = self.filepath
         path_ext = path.rsplit(".")[-1]


### PR DESCRIPTION
## 관련 링크
[개발 태스크](https://www.notion.so/acon3d/04e4f4455a3d4b1aa0bd7c15cc0b6098)

## 발제/내용

- 배경 이미지 선택 시 check_path의 파라미터가 없어서 에러가 발생하고 있습니다.

## 대응

### 어떤 조치를 취했나요?

- check_path 와 동일한 역할을 하던 is_valid_extension 함수를 지우고, check_path 가 여러개의 extension 을 처리할 수 있도록 변경하였습니다.
-  이에 맞게 파라미터명도 accepted 로 변경하였습니다.