### PR TITLE
툴바를 기본으로 표시하고 사용하지 않는 기능 정리하기

### DIFF
--- a/release/scripts/presets/keyconfig/keymap_data/abler_default.py
+++ b/release/scripts/presets/keyconfig/keymap_data/abler_default.py
@@ -1021,7 +1021,7 @@ def km_view3d_generic(_params):
 
     items.extend([
         *_template_space_region_type_toggle(
-            toolbar_key={"type": 'T', "value": 'PRESS'},
+            # toolbar_key={"type": 'T', "value": 'PRESS'},
             sidebar_key={"type": 'N', "value": 'PRESS'},
         )
     ])

--- a/release/scripts/startup/abler/general_tab/general.py
+++ b/release/scripts/startup/abler/general_tab/general.py
@@ -233,6 +233,34 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
         return {"FINISHED"}
 
 
+class ToggleToolbarOperator(bpy.types.Operator):
+    """
+    Toggle toolbar visibility
+
+    Toogle Toolbar를 General 패널에서 삭제하기로 기획됨.
+    그러나, 관련 내용을 다른 위치 혹은 다른 기능으로 재사용 할 수 있어 코드를 삭제하지 않음.
+    관련 Notion 문서:
+    https://www.notion.so/acon3d/DEFAULT-Show-78cd7fd6d13742ed9f36d9ae423e15cf
+    """
+
+    bl_idname = "acon3d.context_toggle"
+    bl_label = "Toggle Toolbar"
+    bl_translation_context = "*"
+
+    def execute(self, context):
+        tracker.toggle_toolbar()
+
+        context.scene.render.engine = "BLENDER_EEVEE"
+        for area in context.screen.areas:
+            if area.type == "VIEW_3D":
+                for space in area.spaces:
+                    if space.type == "VIEW_3D":
+                        value = space.show_region_toolbar
+                        space.show_region_toolbar = not value
+
+        return {"FINISHED"}
+
+
 def update_recent_files(target_path, is_add=False):
     """
     Update Recent Files in User Resources
@@ -551,6 +579,7 @@ classes = (
     AconTutorialGuide2Operator,
     AconTutorialGuide3Operator,
     Acon3dGeneralPanel,
+    ToggleToolbarOperator,
     ImportOperator,
     ApplyToonStyleOperator,
     FileOpenOperator,

--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -24,6 +24,7 @@ def init_setting(dummy):
             init_screen.shading.type = "RENDERED"
             init_screen.show_region_header = True
             init_screen.show_region_tool_header = False
+            init_screen.show_region_toolbar = True
             init_screen.show_gizmo = True
             init_screen.show_gizmo_object_translate = True
             init_screen.show_gizmo_object_rotate = True

--- a/release/scripts/startup/bl_ui/space_toolsystem_toolbar.py
+++ b/release/scripts/startup/bl_ui/space_toolsystem_toolbar.py
@@ -2788,12 +2788,12 @@ class VIEW3D_PT_tools_active(ToolSelectPanelHelper, Panel):
 
     _tools_default = (
         *_tools_select,
-        _defs_view3d_generic.cursor,
+        # _defs_view3d_generic.cursor,
         None,
         *_tools_transform,
         None,
-        *_tools_annotate,
-        _defs_view3d_generic.ruler,
+        # *_tools_annotate,
+        # _defs_view3d_generic.ruler,
     )
 
     # Private tools dictionary, store data to implement `tools_all` & `tools_from_context`.

--- a/release/scripts/startup/bl_ui/space_toolsystem_toolbar.py
+++ b/release/scripts/startup/bl_ui/space_toolsystem_toolbar.py
@@ -2788,12 +2788,9 @@ class VIEW3D_PT_tools_active(ToolSelectPanelHelper, Panel):
 
     _tools_default = (
         *_tools_select,
-        # _defs_view3d_generic.cursor,
         None,
         *_tools_transform,
         None,
-        # *_tools_annotate,
-        # _defs_view3d_generic.ruler,
     )
 
     # Private tools dictionary, store data to implement `tools_all` & `tools_from_context`.
@@ -2808,7 +2805,6 @@ class VIEW3D_PT_tools_active(ToolSelectPanelHelper, Panel):
         'OBJECT': [
             *_tools_default,
             None,
-            # _tools_view3d_add,
         ],
         'POSE': [
             *_tools_default,

--- a/release/scripts/startup/bl_ui/space_toolsystem_toolbar.py
+++ b/release/scripts/startup/bl_ui/space_toolsystem_toolbar.py
@@ -2808,7 +2808,7 @@ class VIEW3D_PT_tools_active(ToolSelectPanelHelper, Panel):
         'OBJECT': [
             *_tools_default,
             None,
-            _tools_view3d_add,
+            # _tools_view3d_add,
         ],
         'POSE': [
             *_tools_default,


### PR DESCRIPTION
## 관련 링크

[툴바를 기본으로 표시하고 사용하지 않는 기능 정리하기](https://www.notion.so/acon3d/78532cb7a0eb458ebcafdad50a2291ff)


## 발제/내용

- 많은 디자인 툴에서 기본 Toolbar가 보여지는 상태로 제공되는 경우가 많고, 사용자들에게도 사용성이 더 좋을 것으로 예상됨
- 하지만, 툴바 기능 중에서 필요 없는 기능이나 제대로 작동하지 않는 기능이 있어서 관련 기능을 툴바에서 제외함.


## 대응

### 어떤 조치를 취했나요?

- Toolbar가 보이는 것을 기본값으로 설정
- Toolbar에서 사용하지 않는 기능 제거
    - [x] Cursor
    - [x] Annotate
    - [x] Measure
    - [x] Add Cube
- `General` > `Toggle Toolbar` 삭제
    - ABLER 사이드바 UI 에서만 삭제하고 관련 기능은 일단 남겨둠
- Toggle Toolbar 단축기 `T` 키 삭제

### 추가로 발생한 문제

Toolbar가 보여지면 기존의 카메라 영역 (빨간 라인) 의 비율이 살짝 달라지면서 카메라 영역 바깥으로 여백이 생김


## 결과

![image](https://user-images.githubusercontent.com/52474700/193980756-87b489ed-9ac0-4300-a11b-cf0f4a748be1.png)
