### PR TITLE
에이블러 업데이트 팝업 결과에 따라 에이블러 멈추는 문제 수정

### DIFF
--- a/release/scripts/startup/abler/startup_flow.py
+++ b/release/scripts/startup/abler/startup_flow.py
@@ -527,7 +527,7 @@ class Acon3dUpdateAblerOperator(bpy.types.Operator):
         launcher_process = subprocess.Popen(launcher, shell=True)
         is_launcher_open = True
 
-        # AblerLauncer.exe가 실행되면 ABLER 종료
+        # AblerLauncher.exe가 실행되면 ABLER 종료
         if sys.platform == "win32":
             while get_launcher_process_count("AblerLauncher") < 1:
                 time.sleep(1)

--- a/release/scripts/startup/abler/startup_flow.py
+++ b/release/scripts/startup/abler/startup_flow.py
@@ -524,18 +524,26 @@ class Acon3dUpdateAblerOperator(bpy.types.Operator):
         launcher = get_launcher()
 
         # 관리자 권한이 필요한 프로그램을 실행하는 옵션
-        subprocess.Popen(launcher, shell=True)
+        launcher_process = subprocess.Popen(launcher, shell=True)
+        is_launcher_open = True
 
         # AblerLauncer.exe가 실행되면 ABLER 종료
         if sys.platform == "win32":
             while get_launcher_process_count("AblerLauncher") < 1:
                 time.sleep(1)
+
+                # Popen.poll()이 런처 (child process) 가 실행 되었는지 확인함.
+                # 실행되면 None이 아닌 값을 return
+                if launcher_process.poll() is not None:
+                    is_launcher_open = False
+                    break
         elif sys.platform == "darwin":
             raise NotImplementedError("Not implemented yet for %s." % sys.platform)
         else:
             raise Exception("Unsupported platform")
 
-        bpy.ops.wm.quit_blender()
+        if is_launcher_open:
+            bpy.ops.wm.quit_blender()
 
         return {"FINISHED"}
 


### PR DESCRIPTION
## 관련 링크

[링크](URL)
작성 예정


## 발제/내용

- 에이블러 팝업 업데이트에서 `Update ABLER`를 하면 런처 실행을 위한 관리자 권한 팝업이 실행됨
- 관리자 권한 팝업에서 "아니오" 선택하면 프로세스를 계속 `while`로 탐색하고 있어 에이블러가 멈춤


## 대응

### 어떤 조치를 취했나요?

- 런처 실행 여부를 `bool` 타입으로 정의하고, 에이블러에서 런처의 실행을 `Popen.poll()`로 탐색함