### PR TITLE
[re-PR] EDIT_Mode에서 씬 전환시 런타임에러 발생하는 문제

### DIFF
--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -71,6 +71,7 @@ def refresh_look_at_me() -> None:
     # 그래서 일단 deselect를 확보된 자원들을 이용해서 사용하도록 아래와 같이 안전하게 처리함.
     try:
         if context.selected_objects:
+            bpy.ops.object.mode_set(mode="OBJECT")
             for obj in context.selected_objects:
                 obj.select_set(False)
     except Exception as e:


### PR DESCRIPTION
## 관련 링크
[링크](https://github.com/ACON3D/blender/pull/176)

## 발제/내용

- 선택된 오브젝트가 없을 때 Object 모드로 설정하면 에러가 발생했습니다.
- 이전 브랜치에서 deselect_mode 를 
```
try:
        if context.selected_objects:
            for obj in context.selected_objects:
                obj.select_set(False)
```
로 변경해 Object 모드 설정을 조건문 안에 넣기 위해 Revert 하고 다시 PR을 올렸습니다.

## 대응

### 어떤 조치를 취했나요?

- 조건문 안에 object 모드로 설정하는 코드 추가했습니다.