### PR TITLE
Import 기능 사용 시 현재 씬에만 레이어가 추가되고, 다른 씬에는 추가되지 않는 에러

### DIFF
--- a/release/scripts/startup/abler/general_tab/general.py
+++ b/release/scripts/startup/abler/general_tab/general.py
@@ -473,7 +473,6 @@ class ImportFBXOperator(bpy.types.Operator, AconImportHelper):
             # 모든 씬의 l_exclude에 col_imported를 추가
             col_layers.children.link(col_imported)
             for scene in bpy.data.scenes:
-                print(scene)
                 added_l_exclude = scene.l_exclude.add()
                 added_l_exclude.name = col_imported.name
                 added_l_exclude.value = True

--- a/release/scripts/startup/abler/general_tab/general.py
+++ b/release/scripts/startup/abler/general_tab/general.py
@@ -191,9 +191,11 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
                                 bpy.data.collections["Layer0"].objects.link(coll_obj)
 
                         else:
-                            added_l_exclude = context.scene.l_exclude.add()
-                            added_l_exclude.name = coll_2.name
-                            added_l_exclude.value = True
+                            # 모든 씬의 l_exclude에 col_imported를 추가
+                            for scene in bpy.data.scenes:
+                                added_l_exclude = scene.l_exclude.add()
+                                added_l_exclude.name = coll_2.name
+                                added_l_exclude.value = True
                             col_layers.children.link(coll_2)
 
             # 레이어 이름에 Layer0.이 포함된 중복 레이어 제거

--- a/release/scripts/startup/abler/general_tab/general.py
+++ b/release/scripts/startup/abler/general_tab/general.py
@@ -470,11 +470,13 @@ class ImportFBXOperator(bpy.types.Operator, AconImportHelper):
                         c.objects.unlink(obj)
                 col_imported.objects.link(obj)
 
-            # put col_imported in l_exclude
+            # 모든 씬의 l_exclude에 col_imported를 추가
             col_layers.children.link(col_imported)
-            added_l_exclude = context.scene.l_exclude.add()
-            added_l_exclude.name = col_imported.name
-            added_l_exclude.value = True
+            for scene in bpy.data.scenes:
+                print(scene)
+                added_l_exclude = scene.l_exclude.add()
+                added_l_exclude.name = col_imported.name
+                added_l_exclude.value = True
 
             # create group
             bpy.ops.acon3d.create_group()


### PR DESCRIPTION
## 관련 링크
[링크](https://www.notion.so/acon3d/Import-a64484b2a5454e5c9634377a77230c13)

## 발제/내용

- Import 기능 사용 시 현재 씬에만 레이어가 추가되고, 다른 씬에는 추가되지 않는 에러 발생
- ImportFBX에도 동일하게 발생

## 대응

### 어떤 조치를 취했나요?

- l_exclude 등록할 때 for문으로 모든 씬에 추가해줌
- ImportFBX에도 동일한 작업을 해줌