### PR TITLE
Material_UL_List 등록

### DIFF
--- a/release/scripts/startup/abler/style_tab/styles_control.py
+++ b/release/scripts/startup/abler/style_tab/styles_control.py
@@ -411,6 +411,7 @@ classes = (
     SunlightPanel,
     ShadowShadingPanel,
     ShadingPanel,
+    MATERIAL_UL_List,
     CloneMaterialOperator,
     ObjectPropertiesPanel,
     BloomPanel,


### PR DESCRIPTION
## 관련 링크

## 발제/내용

- 탭 분리 과정에서 Material_UL_List class가 누락됐습니다.

## 대응

### 어떤 조치를 취했나요?

- 누락된 class 등록시켜줬습니다.