### PR TITLE
Shadow / Shading 한꺼번에 on/off 하는 속성 추가

### DIFF
--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -260,6 +260,13 @@ class AconSceneProperty(bpy.types.PropertyGroup):
         update=shadow.change_sun_strength,
     )
 
+    toggle_shadow_shading: bpy.props.BoolProperty(
+        name="",
+        description="Express shadow and shading",
+        default=True,
+        update=shadow.toggle_shadow_shading,
+    )
+
     toggle_shadow: bpy.props.BoolProperty(
         # name="Shadow",
         name="",

--- a/release/scripts/startup/abler/lib/shadow.py
+++ b/release/scripts/startup/abler/lib/shadow.py
@@ -57,29 +57,8 @@ def change_sun_strength(self, context: Context) -> None:
 
 def toggle_shadow_shading(self, context: Context) -> None:
     prop = context.scene.ACON_prop
-
-    # Shadow
-    acon_sun: Optional[Object] = bpy.data.objects.get("ACON_sun")
-    if not acon_sun:
-        acon_sun = create_ACON_sun()
-
-    if acon_sun.data.type == "SUN":
-        acon_sun.data.use_shadow = prop.toggle_shadow_shading
-
-    # Shading
-    # obj: Optional[Object] = context.object
-    # if obj is None:
-    #     return
-    #
-    # mat: Optional[Material] = obj.active_material
-    # if not mat:
-    #     return
-    #
-    # shadingFactorValue: int = int(prop.toggle_shadow_shading)
-    # toonNode: Optional[Node] = mat.node_tree.nodes.get("ACON_nodeGroup_combinedToon")
-    # if not toonNode:
-    #     return
-    # toonNode.inputs[4].default_value = shadingFactorValue
+    prop.toggle_shadow = True if prop.toggle_shadow_shading else False
+    prop.toggle_toon_face = True if prop.toggle_shadow_shading else False
 
 
 def toggle_shadow(self, context: Context) -> None:

--- a/release/scripts/startup/abler/lib/shadow.py
+++ b/release/scripts/startup/abler/lib/shadow.py
@@ -57,8 +57,8 @@ def change_sun_strength(self, context: Context) -> None:
 
 def toggle_shadow_shading(self, context: Context) -> None:
     prop = context.scene.ACON_prop
-    prop.toggle_shadow = True if prop.toggle_shadow_shading else False
-    prop.toggle_toon_face = True if prop.toggle_shadow_shading else False
+    prop.toggle_shadow = prop.toggle_shadow_shading
+    prop.toggle_toon_face = prop.toggle_shadow_shading
 
 
 def toggle_shadow(self, context: Context) -> None:

--- a/release/scripts/startup/abler/lib/shadow.py
+++ b/release/scripts/startup/abler/lib/shadow.py
@@ -55,6 +55,33 @@ def change_sun_strength(self, context: Context) -> None:
         acon_sun.data.energy = prop.sun_strength
 
 
+def toggle_shadow_shading(self, context: Context) -> None:
+    prop = context.scene.ACON_prop
+
+    # Shadow
+    acon_sun: Optional[Object] = bpy.data.objects.get("ACON_sun")
+    if not acon_sun:
+        acon_sun = create_ACON_sun()
+
+    if acon_sun.data.type == "SUN":
+        acon_sun.data.use_shadow = prop.toggle_shadow_shading
+
+    # Shading
+    # obj: Optional[Object] = context.object
+    # if obj is None:
+    #     return
+    #
+    # mat: Optional[Material] = obj.active_material
+    # if not mat:
+    #     return
+    #
+    # shadingFactorValue: int = int(prop.toggle_shadow_shading)
+    # toonNode: Optional[Node] = mat.node_tree.nodes.get("ACON_nodeGroup_combinedToon")
+    # if not toonNode:
+    #     return
+    # toonNode.inputs[4].default_value = shadingFactorValue
+
+
 def toggle_shadow(self, context: Context) -> None:
     acon_sun: Optional[Object] = bpy.data.objects.get("ACON_sun")
     if not acon_sun:

--- a/release/scripts/startup/abler/style_tab/styles_control.py
+++ b/release/scripts/startup/abler/style_tab/styles_control.py
@@ -120,14 +120,15 @@ class ShadowShadingPanel(bpy.types.Panel):
         layout.prop(context.scene.ACON_prop, "toggle_shadow_shading", text="")
 
     def draw(self, context):
-        layout = self.layout
-        row = layout.row()
-        col = row.column()
-        col.scale_x = 3
-        col.separator()
-        col = row.column()
-        row = col.row()
-        row.prop(context.scene.ACON_prop, "toggle_shadow", text="Shadow")
+        if context.scene.ACON_prop.toggle_shadow_shading:
+            layout = self.layout
+            row = layout.row()
+            col = row.column()
+            col.scale_x = 3
+            col.separator()
+            col = row.column()
+            row = col.row()
+            row.prop(context.scene.ACON_prop, "toggle_shadow", text="Shadow")
 
 
 class ShadingPanel(bpy.types.Panel):
@@ -137,6 +138,10 @@ class ShadingPanel(bpy.types.Panel):
     bl_category = "Style"
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
+
+    @classmethod
+    def poll(self, context):
+        return context.scene.ACON_prop.toggle_shadow_shading
 
     def draw_header(self, context):
         layout = self.layout

--- a/release/scripts/startup/abler/style_tab/styles_control.py
+++ b/release/scripts/startup/abler/style_tab/styles_control.py
@@ -116,7 +116,6 @@ class ShadowShadingPanel(bpy.types.Panel):
 
     def draw_header(self, context):
         layout = self.layout
-        # TODO : header에 shadow/shading 모두 꺼주는 custom_properties 달아주기
         layout.prop(context.scene.ACON_prop, "toggle_shadow_shading", text="")
 
     def draw(self, context):

--- a/release/scripts/startup/abler/style_tab/styles_control.py
+++ b/release/scripts/startup/abler/style_tab/styles_control.py
@@ -140,7 +140,7 @@ class ShadingPanel(bpy.types.Panel):
     bl_region_type = "UI"
 
     @classmethod
-    def poll(self, context):
+    def poll(cls, context):
         return context.scene.ACON_prop.toggle_shadow_shading
 
     def draw_header(self, context):

--- a/release/scripts/startup/abler/style_tab/styles_control.py
+++ b/release/scripts/startup/abler/style_tab/styles_control.py
@@ -117,6 +117,7 @@ class ShadowShadingPanel(bpy.types.Panel):
     def draw_header(self, context):
         layout = self.layout
         # TODO : header에 shadow/shading 모두 꺼주는 custom_properties 달아주기
+        layout.prop(context.scene.ACON_prop, "toggle_shadow_shading", text="")
 
     def draw(self, context):
         layout = self.layout


### PR DESCRIPTION
## 관련 링크

[Shadow / Shading 한꺼번에 끄는 prop 추가](https://www.notion.so/acon3d/Shadow-Shading-prop-f2f91c63cc7841868b6f8662fdc9057a)


## 발제/내용

- Shadow / Shading 한꺼번에 끄는 토글이 아래 `Shadow / Shading` Subpanel의 헤더에 들어가도록 기획됨
- 그러나 해당 토글이 존재하지 않음


## 대응

### 어떤 조치를 취했나요?

- Custom Properties에 Shadow / Shading 을 한번에 토글할 수 있는 `toggle_shadow_shading` (`BoolProperty`) 속성 추가
- 이 속성 업데이트를 위해서 `abler` > `lib` > `shadow.py` 내부에 `toggle_shadow_shading` 함수 생성
- `bpy.types.Panel` 의 Classmethod `poll` 을 활용해서 toggle_shadow_shading 내부의 subpanel `ShadingPanel` 도 끌 수 있도록 업데이트
- Shadow / Shading 토글 업데이트 함수 내부에서 On/Off 결과에 따라 각 토글의 상태를 업데이트함

    ```python
    def toggle_shadow_shading(self, context: Context) -> None:
        prop = context.scene.ACON_prop
        prop.toggle_shadow = True if prop.toggle_shadow_shading else False
        prop.toggle_toon_face = True if prop.toggle_shadow_shading else False
    ```