### PR TITLE
Screen에 ACON3D가 있을때만 내부 area 탐색하기

### DIFF
--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -128,11 +128,11 @@ def grid_on_when_selected(dummy):
 
 
 def find_screen_acon3d() -> bool:
-    name = "ACON3D"
-    screen = bpy.data.screens[name]
-    areas = screen.areas
-
-    if name in bpy.data.screens.keys() and len(areas) > 0 and len(areas[0].spaces) > 0:
+    if (
+        "ACON3D" in bpy.data.screens.keys()
+        and len(bpy.data.screens["ACON3D"].areas) > 0
+        and len(bpy.data.screens["ACON3D"].areas[0].spaces) > 0
+    ):
         return True
 
 

--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -128,12 +128,11 @@ def grid_on_when_selected(dummy):
 
 
 def find_screen_acon3d() -> bool:
-    if (
+    return (
         "ACON3D" in bpy.data.screens.keys()
         and len(bpy.data.screens["ACON3D"].areas) > 0
         and len(bpy.data.screens["ACON3D"].areas[0].spaces) > 0
-    ):
-        return True
+    )
 
 
 def register():

--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -132,15 +132,8 @@ def find_screen_acon3d() -> bool:
     screen = bpy.data.screens[name]
     areas = screen.areas
 
-    return (
-        True
-        if (
-            "ACON3D" in bpy.data.screens.keys()
-            and len(areas) > 0
-            and len(areas[0].spaces) > 0
-        )
-        else False
-    )
+    if name in bpy.data.screens.keys() and len(areas) > 0 and len(areas[0].spaces) > 0:
+        return True
 
 
 def register():

--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -49,17 +49,10 @@ def init_setting(dummy):
 
 def hide_header(dummy):
     """
-    관련 Sentry 오류:
-    https://sentry.io/organizations/carpenstreet/issues/3652063572/?project=6046815&referrer=slack
-
-    유사한 문제 및 해결:
-    https://github.com/ACON3D/blender/pull/141
+    관련 오류:
+    https://www.notion.so/acon3d/pref-py-ACON3D-9718e7bb8516440b89f015b8862f9ede
     """
-    if (
-        "ACON3D" in bpy.data.screens.keys()
-        and len(bpy.data.screens["ACON3D"].areas) > 0
-        and len(bpy.data.screens["ACON3D"].areas[0].spaces) > 0
-    ):
+    if find_screen_acon3d():
         bpy.data.screens["ACON3D"].areas[0].spaces[0].show_region_header = False
 
 
@@ -128,14 +121,26 @@ def save_post_handler(dummy):
 
 def grid_on_when_selected(dummy):
     show_grid = len(bpy.context.selected_objects) > 0
-    if (
-        "ACON3D" in bpy.data.screens.keys()
-        and len(bpy.data.screens["ACON3D"].areas) > 0
-        and len(bpy.data.screens["ACON3D"].areas[0].spaces) > 0
-    ):
+    if find_screen_acon3d():
         viewport_overlay = bpy.data.screens["ACON3D"].areas[0].spaces[0].overlay
         viewport_overlay.show_ortho_grid = show_grid
         viewport_overlay.show_floor = show_grid
+
+
+def find_screen_acon3d() -> bool:
+    name = "ACON3D"
+    screen = bpy.data.screens[name]
+    areas = screen.areas
+
+    return (
+        True
+        if (
+            "ACON3D" in bpy.data.screens.keys()
+            and len(areas) > 0
+            and len(areas[0].spaces) > 0
+        )
+        else False
+    )
 
 
 def register():

--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -48,7 +48,19 @@ def init_setting(dummy):
 
 
 def hide_header(dummy):
-    bpy.data.screens["ACON3D"].areas[0].spaces[0].show_region_header = False
+    """
+    관련 Sentry 오류:
+    https://sentry.io/organizations/carpenstreet/issues/3652063572/?project=6046815&referrer=slack
+
+    유사한 문제 및 해결:
+    https://github.com/ACON3D/blender/pull/141
+    """
+    if (
+        "ACON3D" in bpy.data.screens.keys()
+        and len(bpy.data.screens["ACON3D"].areas) > 0
+        and len(bpy.data.screens["ACON3D"].areas[0].spaces) > 0
+    ):
+        bpy.data.screens["ACON3D"].areas[0].spaces[0].show_region_header = False
 
 
 @persistent
@@ -116,7 +128,11 @@ def save_post_handler(dummy):
 
 def grid_on_when_selected(dummy):
     show_grid = len(bpy.context.selected_objects) > 0
-    if "ACON3D" in bpy.data.screens.keys() and len(bpy.data.screens["ACON3D"].areas) > 0 and len(bpy.data.screens["ACON3D"].areas[0].spaces) > 0:
+    if (
+        "ACON3D" in bpy.data.screens.keys()
+        and len(bpy.data.screens["ACON3D"].areas) > 0
+        and len(bpy.data.screens["ACON3D"].areas[0].spaces) > 0
+    ):
         viewport_overlay = bpy.data.screens["ACON3D"].areas[0].spaces[0].overlay
         viewport_overlay.show_ortho_grid = show_grid
         viewport_overlay.show_floor = show_grid


### PR DESCRIPTION
- #141에 같은 부분이 있고, black 처리를 같이 해줬음

## 관련 링크

[[Notion] 태스크 카드](https://www.notion.so/acon3d/pref-py-ACON3D-9718e7bb8516440b89f015b8862f9ede)
[[Sentry] 에러 링크](https://sentry.io/organizations/carpenstreet/issues/3652063572/?project=6046815&referrer=slack)


## 발제/내용

- `.blend` 파일의 화면 속성에 `"ACON3D"` 가 없는 상태에서 파일을 오픈할 때 발생하는 것으로 보임
- 직접 화면 이름을 수정하는 방법 말고 다른 재현 방법을 당장 찾을 수 없어 Sentry에서 Resolve 처리함
- `"ACON3D"` 라는 이름의 스크린이 없는 상태에서 `"ACON3D"` 라는 스크린이 접근

    ```python
    # pref.py
    def hide_header(dummy):
        bpy.data.screens["ACON3D"].areas[0].spaces[0].show_region_header = False
    ```


## 대응

### 어떤 조치를 취했나요?

- Screen에서 `ACON3D` 가 있을 때만 하위 속성 탐색

    ```python
    def hide_header(dummy):
        bpy.data.screens["ACON3D"].areas[0].spaces[0].show_region_header = False

        if (
            "ACON3D" in bpy.data.screens.keys()
            and len(bpy.data.screens["ACON3D"].areas) > 0
            and len(bpy.data.screens["ACON3D"].areas[0].spaces) > 0
        ):
            bpy.data.screens["ACON3D"].areas[0].spaces[0].show_region_header = False
    ```