### PR TITLE
개선된 Scene UI에서 항목 더블클릭으로 씬 이름 변경

### DIFF
--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -26,7 +26,10 @@ from .lib.read_cookies import *
 
 class AconSceneColGroupProperty(bpy.types.PropertyGroup):
     name: bpy.props.StringProperty(
-        name="Scene_Item", description="Scene_Item", default=""
+        name="Scene_Item",
+        description="Scene_Item",
+        default="",
+        update=scenes.change_scene_name,
     )
 
     index: bpy.props.IntProperty()

--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -59,10 +59,12 @@ class AconWindowManagerProperty(bpy.types.PropertyGroup):
         default=False,
         update=version.remember_low_version_warning_hidden,
     )
-    
+
     scene_col: bpy.props.CollectionProperty(type=AconSceneColGroupProperty)
 
-    active_scene_index: bpy.props.IntProperty(update=scenes.load_scene_by_index)
+    active_scene_index: bpy.props.IntProperty(
+        update=scenes.load_scene_by_index, name="Scene"
+    )
 
 
 class CollectionLayerExcludeProperties(bpy.types.PropertyGroup):

--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -134,6 +134,15 @@ def load_scene_by_index(self, context: Context) -> None:
     load_scene(self, context)
 
 
+def change_scene_name(self, context):
+    prop = context.window_manager.ACON_prop
+
+    scene_col = prop.scene_col
+    active_scene_index = prop.active_scene_index
+
+    context.scene.name = scene_col[active_scene_index].name
+
+
 def add_scene_items(self, context: Context) -> List[Tuple[str, str, str]]:
     scene_items.clear()
     for scene in bpy.data.scenes:

--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -26,6 +26,8 @@ from math import radians
 from .tracker import tracker
 from . import cameras
 
+bool_change_scene_name = True
+
 
 def change_dof(self, context: Context) -> None:
     if use_dof := context.scene.ACON_prop.use_dof:
@@ -135,12 +137,20 @@ def load_scene_by_index(self, context: Context) -> None:
 
 
 def change_scene_name(self, context):
-    prop = context.window_manager.ACON_prop
+    global bool_change_scene_name
 
-    scene_col = prop.scene_col
-    active_scene_index = prop.active_scene_index
+    # CreateSceneOperator에서 create_scene 후에 change_scene_name이 실행되면서
+    # active_scene_index가 이전 씬을 가리킨 상태에서 씬 복사를 하면서 씬 네이밍이 어긋나는 문제가 발생
+    # 이를 위해 create_scene 후엔 change_scene_name을 실행하지 않도록 bool_change_scene_name을 False로 설정해
+    # 실제로 이름을 바꿀 때만 change_scene_name을 실행
+    if bool_change_scene_name:
+        prop = context.window_manager.ACON_prop
 
-    context.scene.name = scene_col[active_scene_index].name
+        scene_col = prop.scene_col
+        active_scene_index = prop.active_scene_index
+        bpy.context.scene.name = scene_col[active_scene_index].name
+
+    bool_change_scene_name = True
 
 
 def add_scene_items(self, context: Context) -> List[Tuple[str, str, str]]:
@@ -194,6 +204,8 @@ def load_scene(self, context: Context) -> None:
 
 
 def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
+    global bool_change_scene_name
+    bool_change_scene_name = False
 
     new_scene = old_scene.copy()
     new_scene.name = name

--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -26,6 +26,8 @@ from math import radians
 from .tracker import tracker
 from . import cameras
 
+# custom_properties에서 BoolProperty로 prop을 생성하면 버그가 발생해
+# is_scene_renamed를 글로벌 변수로 정의함 (참조 : lib.objects의 글로벌 변수 items)
 is_scene_renamed = True
 
 

--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -26,7 +26,7 @@ from math import radians
 from .tracker import tracker
 from . import cameras
 
-bool_change_scene_name = True
+is_scene_renamed = True
 
 
 def change_dof(self, context: Context) -> None:
@@ -137,20 +137,20 @@ def load_scene_by_index(self, context: Context) -> None:
 
 
 def change_scene_name(self, context):
-    global bool_change_scene_name
+    global is_scene_renamed
 
     # CreateSceneOperator에서 create_scene 후에 change_scene_name이 실행되면서
     # active_scene_index가 이전 씬을 가리킨 상태에서 씬 복사를 하면서 씬 네이밍이 어긋나는 문제가 발생
-    # 이를 위해 create_scene 후엔 change_scene_name을 실행하지 않도록 bool_change_scene_name을 False로 설정해
+    # 이를 위해 create_scene 후엔 change_scene_name을 실행하지 않도록 is_scene_renamed을 False로 설정해
     # 실제로 이름을 바꿀 때만 change_scene_name을 실행
-    if bool_change_scene_name:
+    if is_scene_renamed:
         prop = context.window_manager.ACON_prop
 
         scene_col = prop.scene_col
         active_scene_index = prop.active_scene_index
         bpy.context.scene.name = scene_col[active_scene_index].name
 
-    bool_change_scene_name = True
+    is_scene_renamed = True
 
 
 def add_scene_items(self, context: Context) -> List[Tuple[str, str, str]]:
@@ -204,8 +204,8 @@ def load_scene(self, context: Context) -> None:
 
 
 def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
-    global bool_change_scene_name
-    bool_change_scene_name = False
+    global is_scene_renamed
+    is_scene_renamed = False
 
     new_scene = old_scene.copy()
     new_scene.name = name

--- a/release/scripts/startup/abler/scene_tab/scene_control.py
+++ b/release/scripts/startup/abler/scene_tab/scene_control.py
@@ -50,8 +50,8 @@ class SCENE_UL_List(bpy.types.UIList):
     ):
         self.use_filter_show = True
         if self.layout_type in {"DEFAULT", "COMPACT"}:
-            # 칸 간격을 위해 공백 2칸을 앞에 넣어줌
-            layout.label(text="  " + item.name)
+            row = layout.row()
+            row.prop(item, "name", text="", emboss=False)
 
 
 class CreateSceneOperator(bpy.types.Operator):


### PR DESCRIPTION
## 관련 링크
[링크](URL)

## 발제/내용

- 개선된 Scene UI에서 씬 항목을 더블클릭으로 씬 이름 변경이 가능하게 기능 추가

## 대응

### 어떤 조치를 취했나요?

- [x]  이름 변경 가능한 prop 으로 변경
- [x]  이름 변경 시 `change_scene_name` 함수 실행
- [x] 씬을 추가하는 CreateSceneOperator 내에서 create_scene 후에 change_scene_name이 실행되어, change_scene_name이 실제로 이름을 직접 바꿀때만 실행하게끔 global `bool_change_scene_name` 변수를 create_scene에선 False로 바꿔 change_scene을 실행하지 않게함
- [x] 씬 항목 마우스 오버시 네이밍 'Scene'으로 툴팁 뜨게 설정(active_scene_index) 