### PR TITLE
Feature/group navigation single layer

### DIFF
--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -19,7 +19,7 @@
 
 import bpy
 from math import radians
-from .lib.layers import get_first_collection_name_of_object
+from .lib.layers import get_first_layer_name_of_object
 from .lib import scenes, cameras, shadow, objects
 from .lib.materials import materials_handler
 from . import object_control
@@ -78,10 +78,7 @@ class CollectionLayerExcludeProperties(bpy.types.PropertyGroup):
 
             if value:
                 for l in l_exclude:
-                    if (
-                        l.name == get_first_collection_name_of_object(obj)
-                        and not l.value
-                    ):
+                    if l.name == get_first_layer_name_of_object(obj) and not l.value:
                         value = False
                         break
 
@@ -118,7 +115,7 @@ class CollectionLayerExcludeProperties(bpy.types.PropertyGroup):
 
             if not lock:
                 for l in l_exclude:
-                    if l.name == get_first_collection_name_of_object(obj) and l.lock:
+                    if l.name == get_first_layer_name_of_object(obj) and l.lock:
                         lock = True
                         break
 

--- a/release/scripts/startup/abler/lib/layers.py
+++ b/release/scripts/startup/abler/lib/layers.py
@@ -23,11 +23,18 @@ from bpy.types import Collection, Object
 from typing import Any, List, Optional, Tuple, Union
 
 
-def get_first_collection_name_of_object(obj: Object):
+def get_first_layer_name_of_object(obj: Object):
     collections = obj.users_collection
-    if len(collections) == 0:
+    layer_collection = bpy.data.collections.get("Layers")
+
+    if not layer_collection:
         return None
-    return collections[0].name
+
+    for c in collections:
+        if c.name in layer_collection.children:
+            return c.name
+
+    return None
 
 
 def handleLayerVisibilityOnSceneChange(oldScene, newScene):
@@ -47,7 +54,7 @@ def handleLayerVisibilityOnSceneChange(oldScene, newScene):
                 # new scene 에서 변경될 object 의 레이어 정보를 가져옴
                 new_scene_layer = None
                 for l in newScene.l_exclude:
-                    if l.name == get_first_collection_name_of_object(cur):
+                    if l.name == get_first_layer_name_of_object(cur):
                         new_scene_layer = l
                         break
                 if new_scene_layer:
@@ -68,7 +75,7 @@ def handleLayerVisibilityOnSceneChange(oldScene, newScene):
 
         if new_value is not None:
             for l in newScene.l_exclude:
-                if l.name == get_first_collection_name_of_object(obj) and not l.value:
+                if l.name == get_first_layer_name_of_object(obj) and not l.value:
                     new_value = False
                     break
 
@@ -78,7 +85,7 @@ def handleLayerVisibilityOnSceneChange(oldScene, newScene):
         if new_lock is not None:
             if not new_lock:
                 for l in newScene.l_exclude:
-                    if l.name == get_first_collection_name_of_object(obj) and l.lock:
+                    if l.name == get_first_layer_name_of_object(obj) and l.lock:
                         new_lock = True
                         break
 

--- a/release/scripts/startup/abler/lib/layers.py
+++ b/release/scripts/startup/abler/lib/layers.py
@@ -23,25 +23,87 @@ from bpy.types import Collection, Object
 from typing import Any, List, Optional, Tuple, Union
 
 
-def handleLayerVisibilityOnSceneChange(oldScene, newScene):
+def get_first_collection_name_of_object(obj: Object):
+    collections = obj.users_collection
+    if len(collections) == 0:
+        return None
+    return collections[0].name
 
+
+def handleLayerVisibilityOnSceneChange(oldScene, newScene):
     if not oldScene or not newScene:
         print("Invalid oldScene / newScene given")
         return
 
-    for i, oldProp in enumerate(oldScene.l_exclude):
-        newProp = newScene.l_exclude[i]
+    visited = set()
 
-        if oldProp.value is not newProp.value:
-            target_layer = bpy.data.collections[newProp.name]
-            for objs in target_layer.objects:
-                objs.hide_viewport = not (newProp.value)
-                objs.hide_render = not (newProp.value)
+    def get_parent_values(obj: Object):
+        cur = obj.parent
+        parent_value = True
+        parent_lock = False
 
-        if oldProp.lock is not newProp.lock:
-            target_layer = bpy.data.collections[newProp.name]
-            for objs in target_layer.objects:
-                objs.hide_select = newProp.lock
+        while cur:
+            if parent_value or not parent_lock:
+                # new scene 에서 변경될 object 의 레이어 정보를 가져옴
+                new_scene_layer = None
+                for l in newScene.l_exclude:
+                    if l.name == get_first_collection_name_of_object(cur):
+                        new_scene_layer = l
+                        break
+                if new_scene_layer:
+                    if parent_value:
+                        parent_value = parent_value and new_scene_layer.value
+                    if not parent_lock:
+                        parent_lock = parent_lock or new_scene_layer.lock
+
+            if not parent_value and parent_lock:
+                return parent_value, parent_lock
+            cur = cur.parent
+        return parent_value, parent_lock
+
+    def update_info(obj: Object, new_value: bool, new_lock: bool):
+        if obj.name in visited:
+            return
+        visited.add(obj.name)
+
+        if new_value is not None:
+            for l in newScene.l_exclude:
+                if l.name == get_first_collection_name_of_object(obj) and not l.value:
+                    new_value = False
+                    break
+
+            obj.hide_viewport = not new_value
+            obj.hide_render = not new_value
+
+        if new_lock is not None:
+            if not new_lock:
+                for l in newScene.l_exclude:
+                    if l.name == get_first_collection_name_of_object(obj) and l.lock:
+                        new_lock = True
+                        break
+
+            obj.hide_select = new_lock
+
+        for o in obj.children:
+            update_info(o, new_value, new_lock)
+
+    for i, oldInfo in enumerate(oldScene.l_exclude):
+        newInfo = newScene.l_exclude[i]
+
+        is_value_equal = oldInfo.value is newInfo.value
+        is_lock_equal = oldInfo.lock is newInfo.lock
+
+        if not is_value_equal or not is_lock_equal:
+            target_layer = bpy.data.collections[newInfo.name]
+
+            new_value = newInfo.value if not is_value_equal else None
+            new_lock = newInfo.lock if not is_lock_equal else None
+
+            for obj in target_layer.objects:
+                parent_value, parent_lock = get_parent_values(obj)
+                new_value = new_value and parent_value
+                new_lock = new_lock or parent_lock
+                update_info(obj, new_value, new_lock)
 
 
 def up(group_list: List[Collection], group_item: Collection) -> Optional[Collection]:

--- a/release/scripts/startup/abler/lib/render.py
+++ b/release/scripts/startup/abler/lib/render.py
@@ -166,13 +166,6 @@ def clearCompositor(scene=None):
 
 
 def matchObjectVisibility():
-
-    for l_prop in bpy.context.scene.l_exclude:
-        if layer := bpy.data.collections.get(l_prop.name):
-            for objs in layer.objects:
-                objs.hide_viewport = not (l_prop.value)
-                objs.hide_render = not (l_prop.value)
-
     for obj in bpy.data.objects:
         if obj.hide_get():
             obj.hide_render = True


### PR DESCRIPTION
[이전 PR](https://github.com/ACON3D/blender/pull/186) 의 베이스 브랜치가 잘못 설정되어있어서 닫고 새롭게 올린 이슈입니다.

## 관련 링크
[관련 skp converter PR](https://github.com/ACON3D/SKP_Converter/pull/71) - 본 PR과 같이 머지되어야 제대로 동작합니다.
[개발 태스크 카드 1](https://www.notion.so/acon3d/skp2blend-f9fb0c15e2b143bca0320110c4130866)
[개발 태스크 카드2](https://www.notion.so/acon3d/284350eb02c84ca7a12d2045d49dee7a)

## 발제/내용
- skp2blend 에서 오브젝트가 최대 하나의 레이어에만 속하도록 변경되면서, 레이어의 visibility / lock 등의 프로퍼티를 사용하는 함수들을 수정해야함.

### `update_layer_visibility`, `update_layer_lock`

- value, lock 은 부모에 종속됨
    - 부모 오브젝트 off => 항상 off
    - 부모 오브젝트 on => 현재 오브젝트가 속한 레이어의 값으로 결정
- layer 의 커스텀 프로퍼티 `value`, `lock`의 update 핸들러
    1. 레이어의 오브젝트의 부모의 값을 가져옴
    2. 재귀적으로 자식들의 값을 지정
- 부모와 자식이 같은 레이어에 속해 있는 경우, 두 번 순회 하면서 비효율적인 케이스가 생길 수 있기 떄문에 `visited` 셋을 추가하여서 이미 변경된 object 가 다시 변경되는 경우를 제외

### `handle_layer_visibility_on_scene_change`

위와 거의 동일

- 씬이 변경되었을 때, value, lock 이 변경되는 레이어 내를 순회하면서 해당 레이어의 오브젝트 및 오브젝트의 자식들의 value, lock 을 변경
- 오브젝트를 순회하는 `update_info` 함수의 parameter 를 new_value, new_lock 으로 변경하고, 변경사항이 있는 경우에만 boolean 값을 전달
- `new_value`, `new_lock` 과 해당 오브젝트가 속한 레이어의 `value`, `lock` 으로 값 계산하여 변경
    1. 변경될 씬 (`newScene`) 에서의 오브젝트의 부모가 속한 레이어의 값을 가져옴
    2. 재귀적으로 자식들의 값을 지정
- 많은 레이어를 순회하는 경우가 있기 때문에 `visited` 셋을 추가하여서 이미 변경된 object 가 다시 변경되는 경우를 제외

### `match_object_visibility`

- 불필요해보이는 `hide_viewport`, `hide_render` setter 를 제거
