### PR TITLE
View_Camera 가 선택 가능한 에러

### DIFF
--- a/release/scripts/startup/abler/lib/cameras.py
+++ b/release/scripts/startup/abler/lib/cameras.py
@@ -85,6 +85,7 @@ def make_sure_camera_exists() -> None:
     bpy.context.scene.collection.objects.link(camera_object)
 
     camera_object.data.show_passepartout = False
+    camera_object.hide_select = True
 
     # set context camera
     bpy.context.scene.camera = camera_object

--- a/release/scripts/startup/abler/lib/cameras.py
+++ b/release/scripts/startup/abler/lib/cameras.py
@@ -96,7 +96,8 @@ def make_sure_camera_exists() -> None:
 
 def make_sure_camera_unselectable(self, context) -> None:
     # 씬을 로드할 때 camera 오브젝트들이 선택되지 않도록 설정
-    context.scene.camera.hide_select = True
+    if camera := context.scene.camera:
+        camera.hide_select = True
 
 
 # turn on camera view (set viewport to the current selected camera's view)

--- a/release/scripts/startup/abler/lib/cameras.py
+++ b/release/scripts/startup/abler/lib/cameras.py
@@ -93,6 +93,11 @@ def make_sure_camera_exists() -> None:
     bpy.context.view_layer.objects.active = camera_object
 
 
+def make_sure_camera_unselectable(self, context) -> None:
+    # 씬을 로드할 때 camera 오브젝트들이 선택되지 않도록 설정
+    context.scene.camera.hide_select = True
+
+
 # turn on camera view (set viewport to the current selected camera's view)
 def turn_on_camera_view(center_camera: bool = True) -> None:
     make_sure_camera_exists()

--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -200,6 +200,7 @@ def load_scene(self, context: Context) -> None:
     shadow.change_sun_strength(None, context)
     shadow.toggle_shadow(None, context)
     shadow.change_sun_rotation(None, context)
+    cameras.make_sure_camera_unselectable(self, context)
 
     # refresh look_at_me
     refresh_look_at_me()

--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -215,6 +215,7 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
     if old_scene.camera:
         new_scene.camera = old_scene.camera.copy()
         new_scene.camera.data = old_scene.camera.data.copy()
+        new_scene.camera.hide_select = True
         new_scene.collection.objects.link(new_scene.camera)
         try:
             new_scene.collection.objects.unlink(old_scene.camera)
@@ -228,6 +229,7 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
         obj = bpy.data.objects.new("View_Camera", cam)
         obj.location = (4.7063, 7.6888, 1.9738)
         obj.rotation_euler = (radians(90), radians(0), radians(-212))
+        obj.hide_select = True
         new_scene.collection.objects.link(obj)
         new_scene.camera = obj
         cameras.switch_to_rendered_view()


### PR DESCRIPTION
## 관련 링크
[링크](https://www.notion.so/acon3d/View_Camera-f1779444abb84a9e834f3fd3185a5a3d)

## 발제/내용

- 에이블러 뷰포트에서 카메라 오브젝트가 선택 가능함

## 대응

### 어떤 조치를 취했나요?

- [x]  load_scene에서 카메라 오브젝트의 `hide_select = True`
    - 파일 열 때 load_scene이 실행되므로 pref에서 따로 해줄 필요 X
- [x]  scene 생성, 카메라 생성시에도 카메라 오브젝트 `hide_select = True`
    - load_scene 이후에 추가로 카메라 생성할 때 선택될 수 있으므로