### PR TITLE
변경된 Scene UI 에서 파일 오픈 시 index 에러

### DIFF
--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -109,6 +109,12 @@ def add_scene_items_to_collection():
     prop = bpy.context.window_manager.ACON_prop
     prop.scene_col.clear()
     for i, scene in enumerate(bpy.data.scenes):
+        # 파일 열기 시 씬 이름들을 Scene UI에 넣는 과정에서 change_scene_name이 실행이 됨
+        # 실제 이름을 바꾸는 과정이 아니므로 is_scene_renamed를 설정
+        # 각 씬마다 change_scene_name 함수에 들어갔다 나오므로 for문 안에서 설정
+        global is_scene_renamed
+        is_scene_renamed = False
+
         new_scene = prop.scene_col.add()
         new_scene.name = scene.name
         new_scene.index = i

--- a/release/scripts/startup/abler/scene_tab/scene_control.py
+++ b/release/scripts/startup/abler/scene_tab/scene_control.py
@@ -48,7 +48,6 @@ class SCENE_UL_List(bpy.types.UIList):
     def draw_item(
         self, context, layout, data, item, icon, active_data, active_propname
     ):
-        self.use_filter_show = True
         if self.layout_type in {"DEFAULT", "COMPACT"}:
             row = layout.row()
             row.prop(item, "name", text="", emboss=False)


### PR DESCRIPTION
## 관련 링크
[링크](https://www.notion.so/acon3d/Scene-UI-index-14fb6e02c3cc4cf4a57be9344139dc1b)

## 발제/내용

- 파일 열기 시 현재 씬의 active_scene_index값이 열었던 파일에서의 index 값과 차이가 나 발생
- 파일 열기 시 각 씬들을 Scene UI에 넣는 `add_scene_items_to_collection` 함수에서 change_scene_name이 실행되서임

## 대응

### 어떤 조치를 취했나요?

- for문에서 각 씬을 넣을 때 is_scene_renamed = False 를 달아줌(global 변수)
- (+) 스펙 미팅에서 Scene UI 토글 꺼주기로 해서 관련 코드도 수정함(scene_control.py의 51줄)