### PR TITLE
Default 값 변경

### DIFF
--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -299,7 +299,7 @@ class AconSceneProperty(bpy.types.PropertyGroup):
         subtype="ANGLE",
         unit="ROTATION",
         step=100,
-        default=radians(60),
+        default=radians(20),
         update=shadow.change_sun_rotation,
     )
 
@@ -310,7 +310,7 @@ class AconSceneProperty(bpy.types.PropertyGroup):
         subtype="ANGLE",
         unit="ROTATION",
         step=100,
-        default=radians(0),
+        default=radians(130),
         update=shadow.change_sun_rotation,
     )
 

--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -188,7 +188,7 @@ class AconSceneProperty(bpy.types.PropertyGroup):
         name="",
         description="Amount of edges to be shown. (recommended: 1.2)",
         subtype="FACTOR",
-        default=2,
+        default=1,
         min=0,
         max=20,
         step=10,
@@ -299,7 +299,7 @@ class AconSceneProperty(bpy.types.PropertyGroup):
         subtype="ANGLE",
         unit="ROTATION",
         step=100,
-        default=radians(20),
+        default=radians(60),
         update=shadow.change_sun_rotation,
     )
 
@@ -310,7 +310,7 @@ class AconSceneProperty(bpy.types.PropertyGroup):
         subtype="ANGLE",
         unit="ROTATION",
         step=100,
-        default=radians(130),
+        default=radians(0),
         update=shadow.change_sun_rotation,
     )
 
@@ -476,7 +476,7 @@ class AconSceneProperty(bpy.types.PropertyGroup):
     bloom_intensity: bpy.props.FloatProperty(
         name="",
         description="Blend factor",
-        default=0.05,
+        default=0.5,
         min=0,
         max=1.0,
         update=bloom.change_bloom_intensity,

--- a/release/scripts/startup/abler/lib/cameras.py
+++ b/release/scripts/startup/abler/lib/cameras.py
@@ -74,6 +74,7 @@ def make_sure_camera_exists() -> None:
 
     # create camera if View_Camera does not exist
     camera_data: Camera = bpy.data.cameras.new("View_Camera")
+    camera_data.lens = 43
     camera_object: Object = bpy.data.objects.new("View_Camera", camera_data)
     camera_object.location[0] = 7.35889
     camera_object.location[1] = -6.92579

--- a/release/scripts/startup/abler/lib/materials/materials_setup.py
+++ b/release/scripts/startup/abler/lib/materials/materials_setup.py
@@ -414,10 +414,10 @@ def create_ACON_mat_node_groups():
     node_group.inputs[4].default_value = 1
     node_group.inputs[5].default_value = 1
     node_group.inputs[5].min_value = 0
-    node_group.inputs[6].default_value = 0.5
+    node_group.inputs[6].default_value = 1.0
     node_group.inputs[6].min_value = 0
     node_group.inputs[6].max_value = 1
-    node_group.inputs[7].default_value = 0
+    node_group.inputs[7].default_value = 0.8
     node_group.inputs[7].min_value = 0
     node_group.inputs[7].max_value = 1
     node_group.inputs[8].default_value = 1

--- a/release/scripts/startup/abler/lib/materials/materials_setup.py
+++ b/release/scripts/startup/abler/lib/materials/materials_setup.py
@@ -475,7 +475,7 @@ def apply_ACON_toon_style():
 
         node_texImage = None
         baseColor = (1, 1, 1, 1)
-        nega_alpha = 0.8
+        nega_alpha = None
         node_combinedToon = None
 
         for node in nodes:
@@ -552,7 +552,10 @@ def apply_ACON_toon_style():
         node_combinedToon = nodes.new(type="ShaderNodeGroup")
         node_combinedToon.name = "ACON_nodeGroup_combinedToon"
         node_combinedToon.node_tree = node_group_data_combined
-        node_combinedToon.inputs[7].default_value = nega_alpha
+        # BSDF_Prinipled 노드에서 변환된 머터리얼은 nega_alpha가 업데이트 되므로
+        # nega_alpha가 있을 때만 Transparent가 업데이트 되도록 변경
+        if nega_alpha:
+            node_combinedToon.inputs[7].default_value = nega_alpha
         mat.node_tree.links.new(node_combinedToon.outputs[0], out_node.inputs[0])
 
         if node_texImage:

--- a/release/scripts/startup/abler/lib/materials/materials_setup.py
+++ b/release/scripts/startup/abler/lib/materials/materials_setup.py
@@ -475,7 +475,7 @@ def apply_ACON_toon_style():
 
         node_texImage = None
         baseColor = (1, 1, 1, 1)
-        nega_alpha = 0
+        nega_alpha = 0.8
         node_combinedToon = None
 
         for node in nodes:

--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -230,7 +230,7 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
 
     else:
         cam = bpy.data.cameras.new("View_Camera")
-        cam.lens = 30
+        cam.lens = 43
         cam.show_passepartout = False
         obj = bpy.data.objects.new("View_Camera", cam)
         obj.location = (4.7063, 7.6888, 1.9738)


### PR DESCRIPTION
## 관련 링크
[링크](https://www.notion.so/acon3d/default-516d52a031654335a67fba0e582b3f0a)

## 발제/내용

- 프로퍼티 중 default 값 변경 요청 PR입니다.

## 대응

### 어떤 조치를 취했나요?

### Custom_properties 및 카메라 default값 변경으로 적용

- [x]  라인 디테일 : `2.5` → `1.0` 로 변경한다.
- [x]  코니룸 Bloom : Intensity `0.05` → `0.5`
- [x]  카메라 생성 시 lens 43mm 적용하도록 코드 변경
    - `create_scene`에서 old_scene에 카메라 없을 때 카메라 생성 시 lens 43mm 적용
    - `make_sure_camera_exists`에서 카메라 없을 때 카메라 생성 시 lens 43mm 적용

### importSKP에서만 적용되는 값

- [x]  Reflection `0.5` → `1.0`
- [x]  Transparent `0` → `0.8`
    - ImportSKP가 transparent 다르게 나오는 이유 : [Transparent 코드 분석](https://www.notion.so/Transparent-c47df7721b2248599df172c9e8566e96)

### 코니룸 파일(startup.blend)을 변경
- [x]  Focal Length `30mm` → `43mm`에 맞게 코니룸 오브젝트 조정