### PR TITLE
make_sure_camera_exists에서 카메라가 위치, 방향이 다른 에러

### DIFF
--- a/release/scripts/startup/abler/lib/cameras.py
+++ b/release/scripts/startup/abler/lib/cameras.py
@@ -74,13 +74,7 @@ def make_sure_camera_exists() -> None:
         return
 
     # create camera if View_Camera does not exist
-    cam = bpy.data.cameras.new("View_Camera")
-    cam.lens = 30
-    cam.show_passepartout = False
-    obj = bpy.data.objects.new("View_Camera", cam)
-    obj.location = (4.7063, 7.6888, 1.9738)
-    obj.rotation_euler = (radians(90), radians(0), radians(-212))
-    obj.hide_select = True
+    obj = make_camera()
     bpy.context.scene.collection.objects.link(obj)
 
     # set context camera
@@ -88,6 +82,18 @@ def make_sure_camera_exists() -> None:
 
     # View_Camera 오브젝트 활성화
     bpy.context.view_layer.objects.active = obj
+
+
+def make_camera():
+    cam = bpy.data.cameras.new("View_Camera")
+    cam.lens = 43
+    cam.show_passepartout = False
+    obj = bpy.data.objects.new("View_Camera", cam)
+    obj.location = (4.7063, 7.6888, 1.9738)
+    obj.rotation_euler = (radians(90), radians(0), radians(-212))
+    obj.hide_select = True
+
+    return obj
 
 
 def make_sure_camera_unselectable(self, context) -> None:

--- a/release/scripts/startup/abler/lib/cameras.py
+++ b/release/scripts/startup/abler/lib/cameras.py
@@ -17,6 +17,7 @@
 # ##### END GPL LICENSE BLOCK #####
 
 from typing import Any, Dict, List, Union, Tuple, Optional
+from math import radians
 import bpy
 from bpy.types import Collection, Object, Camera
 
@@ -73,25 +74,20 @@ def make_sure_camera_exists() -> None:
         return
 
     # create camera if View_Camera does not exist
-    camera_data: Camera = bpy.data.cameras.new("View_Camera")
-    camera_object: Object = bpy.data.objects.new("View_Camera", camera_data)
-    camera_object.location[0] = 7.35889
-    camera_object.location[1] = -6.92579
-    camera_object.location[2] = 4.9583
-    camera_object.rotation_mode = "XYZ"
-    camera_object.rotation_euler[0] = 1.109319
-    camera_object.rotation_euler[1] = 0
-    camera_object.rotation_euler[2] = 0.814928
-    bpy.context.scene.collection.objects.link(camera_object)
-
-    camera_object.data.show_passepartout = False
-    camera_object.hide_select = True
+    cam = bpy.data.cameras.new("View_Camera")
+    cam.lens = 30
+    cam.show_passepartout = False
+    obj = bpy.data.objects.new("View_Camera", cam)
+    obj.location = (4.7063, 7.6888, 1.9738)
+    obj.rotation_euler = (radians(90), radians(0), radians(-212))
+    obj.hide_select = True
+    bpy.context.scene.collection.objects.link(obj)
 
     # set context camera
-    bpy.context.scene.camera = camera_object
+    bpy.context.scene.camera = obj
 
     # View_Camera 오브젝트 활성화
-    bpy.context.view_layer.objects.active = camera_object
+    bpy.context.view_layer.objects.active = obj
 
 
 def make_sure_camera_unselectable(self, context) -> None:

--- a/release/scripts/startup/abler/lib/cameras.py
+++ b/release/scripts/startup/abler/lib/cameras.py
@@ -89,7 +89,7 @@ def make_camera():
     cam.lens = 43
     cam.show_passepartout = False
     obj = bpy.data.objects.new("View_Camera", cam)
-    obj.location = (4.7063, 7.6888, 1.9738)
+    obj.location = (6.487949371337891, 10.378044128417969, 1.9881811141967773)
     obj.rotation_euler = (radians(90), radians(0), radians(-212))
     obj.hide_select = True
 

--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -229,13 +229,7 @@ def create_scene(old_scene: Scene, type: str, name: str) -> Optional[Scene]:
             print("Failed to unlink camera from old scene.")
 
     else:
-        cam = bpy.data.cameras.new("View_Camera")
-        cam.lens = 30
-        cam.show_passepartout = False
-        obj = bpy.data.objects.new("View_Camera", cam)
-        obj.location = (4.7063, 7.6888, 1.9738)
-        obj.rotation_euler = (radians(90), radians(0), radians(-212))
-        obj.hide_select = True
+        obj = cameras.make_camera()
         new_scene.collection.objects.link(obj)
         new_scene.camera = obj
         cameras.switch_to_rendered_view()


### PR DESCRIPTION
## 관련 링크
[링크](https://www.notion.so/acon3d/make_sure_camera_exists-c0b68a7fb9d64f5ea56a38601735258d)

## 발제/내용

- make_sure_camera_exists에서 카메라가 위치, 방향이 다른 에러 발생

## 대응

### 어떤 조치를 취했나요?

-  create_scene() 내 카메라 생성 조건을 `make_camera()` 함수로 빼서 make_sure_camera_exists()에도 똑같이 넣어줌
   -  location, rotation 값만 바꾸는 것보다 create_scene()과 동일하게 해야 헷갈리지 않을 거 같음
- 업데이트 된 startup.blend의 bpy.context.scene.camera.rotation_euler이 위의 값이 아닌 (1.5707963705062866, 0.0, -3.7000980377197266)인 radians로 나타내기 힘든 값이라 startup.blend의 rotation_euler만 `(radians(90), radians(0), radians(-212))`로 변경한 뒤 업데이트 해줌