### PR TITLE
실시간으로 변하는 프로그레스 바 팝업 구현

### DIFF
--- a/release/scripts/startup/abler/export_tab/export_control.py
+++ b/release/scripts/startup/abler/export_tab/export_control.py
@@ -85,6 +85,33 @@ class Acon3dHighQualityRenderPanel(bpy.types.Panel):
             # row.prop(prop, "background_color", text="Background Color")
 
 
+class AconRenderProgressPanel(bpy.types.Panel):
+    """TODO"""
+
+    bl_parent_id = "ACON3D_PT_high_quality_render"
+    bl_idname = "ACON3D_PT_render_progress_panel"
+    bl_label = "Progress"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "Export"
+
+    # @classmethod
+    # def poll(cls, context):
+    #     return context.window_manager.progress_prop.is_progress_shown
+
+    def draw(self, context):
+        layout = self.layout
+        cur_progress = context.window_manager.get_progress()
+
+        prop = context.window_manager.progress_prop
+        render_progress = 0
+        if prop.total_render_num:
+            render_progress = (prop.complete_num + cur_progress) / prop.total_render_num
+
+        layout.template_progress_bar(progress=render_progress)
+        layout.operator("wm.stop_render", text="Cancel")
+
+
 class Acon3dQuickRenderPanel(bpy.types.Panel):
     """Creates a Panel in the scene context of the properties editor"""
 
@@ -143,6 +170,7 @@ class Acon3dSnipRenderPanel(bpy.types.Panel):
 
 classes = (
     Acon3dHighQualityRenderPanel,
+    AconRenderProgressPanel,
     Acon3dQuickRenderPanel,
     Acon3dSnipRenderPanel,
     RENDER_UL_List,

--- a/release/scripts/startup/abler/export_tab/export_control.py
+++ b/release/scripts/startup/abler/export_tab/export_control.py
@@ -11,6 +11,7 @@ bl_info = {
     "category": "ACON3D",
 }
 import bpy
+from time import time, strftime, localtime, gmtime
 
 
 class RENDER_UL_List(bpy.types.UIList):
@@ -21,6 +22,15 @@ class RENDER_UL_List(bpy.types.UIList):
             layout.separator()
             layout.prop(item, "is_render_selected", text="")
             layout.prop(item, "name", text="", emboss=False)
+
+
+# TODO Util 함수 어디에 넣어야 할지 확인
+def timestamp_to_string(timestamp, is_date=True):
+    if not timestamp:
+        return "- - -"
+    if is_date:
+        return strftime("%Y-%m-%d %H:%M:%S", localtime(timestamp))
+    return strftime("%H:%M:%S", gmtime(timestamp))
 
 
 class Acon3dHighQualityRenderPanel(bpy.types.Panel):
@@ -84,32 +94,67 @@ class Acon3dHighQualityRenderPanel(bpy.types.Panel):
             # prop = context.scene.ACON_prop
             # row.prop(prop, "background_color", text="Background Color")
 
+            self.draw_progress(context, layout)
 
-class AconRenderProgressPanel(bpy.types.Panel):
-    """TODO"""
+    def draw_progress(self, context, layout):
+        progress_prop = context.window_manager.progress_prop
+        if not progress_prop.start_date:
+            return
 
-    bl_parent_id = "ACON3D_PT_high_quality_render"
-    bl_idname = "ACON3D_PT_render_progress_panel"
-    bl_label = "Progress"
-    bl_space_type = "VIEW_3D"
-    bl_region_type = "UI"
-    bl_category = "Export"
+        box = layout.box()
 
-    # @classmethod
-    # def poll(cls, context):
-    #     return context.window_manager.progress_prop.is_progress_shown
-
-    def draw(self, context):
-        layout = self.layout
         cur_progress = context.window_manager.get_progress()
 
-        prop = context.window_manager.progress_prop
         render_progress = 0
-        if prop.total_render_num:
-            render_progress = (prop.complete_num + cur_progress) / prop.total_render_num
+        if progress_prop.total_render_num:
+            render_progress = (
+                progress_prop.complete_num + cur_progress
+            ) / progress_prop.total_render_num
 
-        layout.template_progress_bar(progress=render_progress)
-        layout.operator("wm.stop_render", text="Cancel")
+        box.label(text="Total Rendering")
+        sub = box.split(align=True, factor=0.20)
+        col = sub.column(align=True)
+        col.label(
+            text=f"{min(progress_prop.complete_num + 1, progress_prop.total_render_num)} / {progress_prop.total_render_num} "
+        )
+        col = sub.column(align=True)
+        col.template_progress_bar(progress=render_progress)
+
+        for info in progress_prop.render_scene_infos:
+            box.label(text=info.render_scene_name)
+            if info.status == "waiting":
+                box.template_progress_bar(progress=0.0)
+            elif info.status == "in progress":
+                box.template_progress_bar(progress=cur_progress)
+            else:
+                box.template_progress_bar(progress=1.0)
+
+        sub = box.split(align=True, factor=0.25)
+
+        col = sub.column(align=True)
+        col.label(text="Start", icon="DOT")
+        col.label(text="Finish", icon="DOT")
+        col.label(text="Time Span", icon="DOT")
+
+        start_string = timestamp_to_string(progress_prop.start_date)
+        end_string = timestamp_to_string(progress_prop.end_date)
+
+        if not progress_prop.start_date:
+            span = 0
+        elif not progress_prop.end_date:
+            span = time() - progress_prop.start_date
+        else:
+            span = progress_prop.end_date - progress_prop.start_date
+        span_string = timestamp_to_string(span, is_date=False)
+
+        col = sub.column(align=True)
+        col.label(text=": " + start_string)
+        col.label(text=": " + end_string)
+        col.label(text=": " + span_string)
+
+        layout.operator("acon3d.close_progress", text="OK")
+        # TODO 렌더 cancel
+        # layout.operator("wm.stop_render", text="Cancel")
 
 
 class Acon3dQuickRenderPanel(bpy.types.Panel):
@@ -170,7 +215,6 @@ class Acon3dSnipRenderPanel(bpy.types.Panel):
 
 classes = (
     Acon3dHighQualityRenderPanel,
-    AconRenderProgressPanel,
     Acon3dQuickRenderPanel,
     Acon3dSnipRenderPanel,
     RENDER_UL_List,

--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -16,14 +16,13 @@
 #
 # ##### END GPL LICENSE BLOCK #####
 
-
 import bpy, platform, os, subprocess
 from bpy_extras.io_utils import ImportHelper, ExportHelper
 from ..lib import render, cameras
 from ..lib.materials import materials_handler
 from ..lib.tracker import tracker
 from .. import startup_flow
-from bpy.props import StringProperty
+from time import time
 
 
 bl_info = {
@@ -423,9 +422,25 @@ class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
     def __init__(self):
         super().__init__()
 
+    def pre_render(self, dummy, dum):
+        super().pre_render(dummy, dum)
+        _, scene = self.render_queue[0]
+        info = find_target_render_scene_info(
+            scene.name, bpy.context.window_manager.progress_prop.render_scene_infos
+        )
+        if info:
+            info.status = "in progress"
+
     def post_render(self, dummy, dum):
+        progress_prop = bpy.context.window_manager.progress_prop
+        _, scene = self.render_queue[0]
+        info = find_target_render_scene_info(
+            scene.name, bpy.context.window_manager.progress_prop.render_scene_infos
+        )
+        if info:
+            info.status = "finished"
+        progress_prop.complete_num += 1
         super().post_render(dummy, dum)
-        bpy.context.window_manager.progress_prop.complete_num += 1
 
     def prepare_render(self):
         render.clear_compositor()
@@ -437,14 +452,22 @@ class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
         # 현재 씬을 복사한 씬으로 적용
         bpy.data.window_managers["WinMan"].ACON_prop.scene = scene.name
 
-        # 렌더를 위한 씬 이름를 폴더명으로 설정하기 위한 queue에 추가
+        # 렌더를 위한 씬 이름을 폴더명으로 설정하기 위한 queue에 추가
         self.render_queue.append((base_scene.name, scene))
+
         self.temp_scenes.append(scene)
 
         bpy.context.window_manager.progress_prop.total_render_num += 1
 
+        scene.name = f"{base_scene.name}_{render_type}"
         scene.eevee.use_bloom = False
-        scene.render.use_lock_interface = True
+        scene.render.use_lock_interface = False
+
+        # scene_info - UI 에 이름과 진행 상황을 보여주기 위한 데이터
+        # FIXME scnee_info 에 scene 을 담고, temp_scenes 를 없애면 더 깔끔하지 않을까?
+        scene_info = bpy.context.window_manager.progress_prop.render_scene_infos.add()
+        scene_info.render_scene_name = scene.name
+        scene_info.status = "waiting"
 
         for mat in bpy.data.materials:
             mat.blend_method = "OPAQUE"
@@ -453,7 +476,6 @@ class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
                 toonNode.inputs[1].default_value = 0
                 toonNode.inputs[3].default_value = 1
 
-        scene.name = f"{base_scene.name}_{render_type}"
         prop = scene.ACON_prop
         if render_type == "line":
             prop.toggle_texture = False
@@ -471,6 +493,9 @@ class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
         progress_prop.total_render_num = 0
         progress_prop.complete_num = 0
         progress_prop.is_progress_shown = True
+        progress_prop.start_date = time()
+        progress_prop.end_date = 0
+        progress_prop.render_scene_infos.clear()
 
         render_prop = context.window_manager.ACON_prop
         for s_col in render_prop.scene_col:
@@ -495,6 +520,8 @@ class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
         return {"RUNNING_MODAL"}
 
     def on_render_finish(self, context):
+        context.window_manager.progress_prop.end_date = time()
+
         for mat in bpy.data.materials:
             materials_handler.set_material_parameters_by_type(mat)
 
@@ -522,24 +549,61 @@ class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
         return is_method_selected and is_scene_selected
 
 
+class Acon3dCloseProgressOperator(bpy.types.Operator):
+    bl_idname = "acon3d.close_progress"
+    bl_label = "OK"
+    bl_description = "Close Progress Panel"
+    bl_translation_context = "*"
+
+    @classmethod
+    def poll(cls, context):
+        prop = context.window_manager.progress_prop
+
+        return prop.total_render_num == prop.complete_num
+
+    def execute(self, context):
+        progress_prop = context.window_manager.progress_prop
+        progress_prop.total_render_num = 0
+        progress_prop.complete_num = 0
+        progress_prop.start_date = 0
+        progress_prop.end_date = 0
+        progress_prop.render_scene_infos.clear()
+        progress_prop.is_progress_shown = False
+
+        return {"FINISHED"}
+
+
+def find_target_render_scene_info(render_scene_name, infos):
+    for info in infos:
+        if render_scene_name == info.render_scene_name:
+            return info
+    return None
+
+
+class RenderSceneInfoProperty(bpy.types.PropertyGroup):
+    # line, texture 등이 뒤에 붙은 render 할 때만 생성되는 scene 의 이름
+    render_scene_name: bpy.props.StringProperty()
+    # waiting, finished, in progress
+    status: bpy.props.StringProperty(default="waiting")
+
+
 class RenderProperty(bpy.types.PropertyGroup):
-    complete_num: bpy.props.IntProperty(
-        name="Complete Num", description="Complete number", default=0
-    )
-
-    total_render_num: bpy.props.IntProperty(
-        name="Total Num", description="Total number", default=0
-    )
-
-    is_progress_shown: bpy.props.BoolProperty(name="show progress", default=False)
+    start_date: bpy.props.IntProperty(default=0)
+    end_date: bpy.props.IntProperty(default=0)
+    complete_num: bpy.props.IntProperty(default=0)
+    total_render_num: bpy.props.IntProperty(default=0)
+    is_progress_shown: bpy.props.BoolProperty(default=False)
+    render_scene_infos: bpy.props.CollectionProperty(type=RenderSceneInfoProperty)
 
 
 classes = (
+    RenderSceneInfoProperty,
+    RenderProperty,
     Acon3dCameraViewOperator,
     Acon3dRenderHighQualityOperator,
     Acon3dRenderSnipOperator,
     Acon3dRenderQuickOperator,
-    RenderProperty,
+    Acon3dCloseProgressOperator,
 )
 
 

--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -16,6 +16,7 @@
 #
 # ##### END GPL LICENSE BLOCK #####
 
+
 import bpy, platform, os, subprocess
 from bpy_extras.io_utils import ImportHelper, ExportHelper
 from ..lib import render, cameras

--- a/release/scripts/startup/bl_operators/wm.py
+++ b/release/scripts/startup/bl_operators/wm.py
@@ -2313,6 +2313,7 @@ class WM_OT_toolbar_prompt(Operator):
                 'WHEELDOWNMOUSE', 'WHEELUPMOUSE', 'WHEELINMOUSE', 'WHEELOUTMOUSE',
                 'ESC',
         }:
+            print("set 111")
             context.workspace.status_text_set(None)
             return {'CANCELLED', 'PASS_THROUGH'}
 
@@ -2325,6 +2326,7 @@ class WM_OT_toolbar_prompt(Operator):
                 tool_idname = properties["name"]
                 bpy.ops.wm.tool_set_by_id(name=tool_idname)
 
+            print("set 2222")
             context.workspace.status_text_set(None)
             return {'FINISHED'}
 
@@ -2332,6 +2334,7 @@ class WM_OT_toolbar_prompt(Operator):
         if event_type == self._init_event_type:
             if event_value == 'RELEASE':
                 if not (event.ctrl or event.alt or event.shift or event.oskey):
+                    print("set 333333")
                     context.workspace.status_text_set(None)
                     return {'CANCELLED'}
 
@@ -2377,6 +2380,7 @@ class WM_OT_toolbar_prompt(Operator):
 
         self._keymap = keymap
 
+        print("set 44444")
         context.workspace.status_text_set(status_text_fn)
 
         context.window_manager.modal_handler_add(self)

--- a/release/scripts/startup/bl_operators/wm.py
+++ b/release/scripts/startup/bl_operators/wm.py
@@ -2313,7 +2313,6 @@ class WM_OT_toolbar_prompt(Operator):
                 'WHEELDOWNMOUSE', 'WHEELUPMOUSE', 'WHEELINMOUSE', 'WHEELOUTMOUSE',
                 'ESC',
         }:
-            print("set 111")
             context.workspace.status_text_set(None)
             return {'CANCELLED', 'PASS_THROUGH'}
 
@@ -2326,7 +2325,6 @@ class WM_OT_toolbar_prompt(Operator):
                 tool_idname = properties["name"]
                 bpy.ops.wm.tool_set_by_id(name=tool_idname)
 
-            print("set 2222")
             context.workspace.status_text_set(None)
             return {'FINISHED'}
 
@@ -2334,7 +2332,6 @@ class WM_OT_toolbar_prompt(Operator):
         if event_type == self._init_event_type:
             if event_value == 'RELEASE':
                 if not (event.ctrl or event.alt or event.shift or event.oskey):
-                    print("set 333333")
                     context.workspace.status_text_set(None)
                     return {'CANCELLED'}
 
@@ -2380,7 +2377,6 @@ class WM_OT_toolbar_prompt(Operator):
 
         self._keymap = keymap
 
-        print("set 44444")
         context.workspace.status_text_set(status_text_fn)
 
         context.window_manager.modal_handler_add(self)

--- a/source/blender/editors/include/UI_interface.h
+++ b/source/blender/editors/include/UI_interface.h
@@ -2187,6 +2187,7 @@ void uiTemplateImageInfo(uiLayout *layout,
                          struct Image *ima,
                          struct ImageUser *iuser);
 void uiTemplateRunningJobs(uiLayout *layout, struct bContext *C);
+void uiTemplateProgressBar(uiLayout *layout, struct bContext *C, const float progress);
 void UI_but_func_operator_search(uiBut *but);
 void uiTemplateOperatorSearch(uiLayout *layout);
 

--- a/source/blender/editors/interface/interface_templates.c
+++ b/source/blender/editors/interface/interface_templates.c
@@ -5810,6 +5810,52 @@ static char *progress_tooltip_func(bContext *UNUSED(C), void *argN, const char *
       elapsed_str);
 }
 
+void uiTemplateProgressBar(uiLayout *layout, bContext *C, const float progress)
+{
+  wmWindowManager *wm = CTX_wm_manager(C);
+
+  uiBlock *block = uiLayoutGetBlock(layout);
+  UI_block_layout_set_current(block, layout);
+
+  UI_block_func_handle_set(block, do_running_jobs, NULL);
+
+  const uiFontStyle *fstyle = UI_FSTYLE_WIDGET;
+
+  uiLayout *row = uiLayoutRow(layout, false);
+  block = uiLayoutGetBlock(row);
+
+  char text[8];
+  BLI_snprintf(text, 8, "%d%%", (int)(progress * 100));
+
+  /* stick progress bar and cancel button together */
+  row = uiLayoutRow(layout, true);
+  uiLayoutSetActive(row, true);
+  block = uiLayoutGetBlock(row);
+
+  {
+    struct ProgressTooltip_Store *tip_arg = MEM_mallocN(sizeof(*tip_arg), __func__);
+    tip_arg->wm = wm;
+    uiButProgressbar *but_progress = (uiButProgressbar *)uiDefIconTextBut(block,
+                                                                          UI_BTYPE_PROGRESS_BAR,
+                                                                          0,
+                                                                          0,
+                                                                          text,
+                                                                          UI_UNIT_X,
+                                                                          0,
+                                                                          UI_UNIT_X * 6.0f,
+                                                                          UI_UNIT_Y,
+                                                                          NULL,
+                                                                          0.0f,
+                                                                          0.0f,
+                                                                          0.0f,
+                                                                          0,
+                                                                          NULL);
+
+    but_progress->progress = progress;
+    UI_but_func_tooltip_set(&but_progress->but, progress_tooltip_func, tip_arg, MEM_freeN);
+  }
+}
+
 void uiTemplateRunningJobs(uiLayout *layout, bContext *C)
 {
   Main *bmain = CTX_data_main(C);

--- a/source/blender/editors/space_view3d/space_view3d.c
+++ b/source/blender/editors/space_view3d/space_view3d.c
@@ -1702,6 +1702,10 @@ static void view3d_buttons_region_listener(const wmRegionListenerParams *params)
       if (wmn->data == ND_XR_DATA_CHANGED) {
         ED_region_tag_redraw(region);
       }
+      /* 프로그레스바를 실시간으로 그리기 위한 조건 추가 */
+      else if (wmn->data == ND_JOB && region && region->type->regionid == RGN_TYPE_UI) {
+        ED_region_tag_redraw(region);
+      }
       break;
   }
 }

--- a/source/blender/makesrna/intern/rna_ui_api.c
+++ b/source/blender/makesrna/intern/rna_ui_api.c
@@ -1711,6 +1711,12 @@ void RNA_api_ui_layout(StructRNA *srna)
   func = RNA_def_function(srna, "template_running_jobs", "uiTemplateRunningJobs");
   RNA_def_function_flag(func, FUNC_USE_CONTEXT);
 
+  func = RNA_def_function(srna, "template_progress_bar", "uiTemplateProgressBar");
+  RNA_def_function_flag(func, FUNC_USE_CONTEXT);
+  RNA_def_float(
+      func, "progress", 0, 0, 1.0, "", "Current Progress", 0, 1.0);
+  RNA_def_parameter_flags(parm, 0, PARM_REQUIRED);
+
   RNA_def_function(srna, "template_operator_search", "uiTemplateOperatorSearch");
   RNA_def_function(srna, "template_menu_search", "uiTemplateMenuSearch");
 

--- a/source/blender/windowmanager/intern/wm_operators.c
+++ b/source/blender/windowmanager/intern/wm_operators.c
@@ -3806,6 +3806,7 @@ void wm_operatortypes_register(void)
   WM_operatortype_append(WM_OT_call_panel);
   WM_operatortype_append(WM_OT_radial_control);
   WM_operatortype_append(WM_OT_stereo3d_set);
+  WM_operatortype_append(WM_OT_stop_render);
 #if defined(WIN32)
   WM_operatortype_append(WM_OT_console_toggle);
 #endif

--- a/source/blender/windowmanager/intern/wm_splash_screen.c
+++ b/source/blender/windowmanager/intern/wm_splash_screen.c
@@ -64,6 +64,7 @@
 #include "WM_api.h"
 #include "WM_types.h"
 
+#include "BKE_global.h"
 #include "BLT_lang.h"
 #include "wm.h"
 
@@ -851,6 +852,21 @@ void WM_OT_splash_tutorial_close(wmOperatorType *ot)
   ot->description = "Close the tutorial screen";
 
   ot->invoke = wm_tutorial_close_invoke;
+  ot->poll = WM_operator_winactive;
+}
+
+static int wm_stop_render_execute(bContext *C, wmOperator *op)
+{
+  G.is_break = true;
+  return OPERATOR_FINISHED;
+}
+
+void WM_OT_stop_render(wmOperatorType *ot) {
+  ot->name = "Stop Render";
+  ot->idname = "WM_OT_stop_render";
+  ot->description = "Stop Render";
+
+  ot->exec = wm_stop_render_execute;
   ot->poll = WM_operator_winactive;
 }
 

--- a/source/blender/windowmanager/wm.h
+++ b/source/blender/windowmanager/wm.h
@@ -87,6 +87,7 @@ void WM_OT_splash_tutorial_3(wmOperatorType *ot);
 void WM_OT_splash_tutorial_close(wmOperatorType *ot);
 void WM_OT_splash_modal(wmOperatorType *ot);
 void WM_OT_splash_modal_close(wmOperatorType *ot);
+void WM_OT_stop_render(wmOperatorType *ot);
 
 /* wm_stereo.c */
 void wm_stereo3d_draw_sidebyside(wmWindow *win, int view);


### PR DESCRIPTION
## 관련 링크
[태스크 카드](https://www.notion.so/acon3d/328b595e2570421d8aabadead6e5496d)

## 발제/내용

- 사이드바에 렌더 프로그레스바와 관련 UI 를 추가함

## 대응

### 어떤 조치를 취했나요?

- C
  - stop render operator : 현재 진행되고 있는 렌더를 멈추는 오퍼레이터 추가
  - `get_progress` : 현재 렌더의 진행상황을 반환하는 함수 추가
  - `template_progress_bar` :  프로그레스바를 그려주는 함수 추가
  - `view3d_buttons_region_listener` : ND_JOB 이벤트의 경우에도 다시 그리도록 수정

- python
  - 렌더링에 쓰일 `progress_prop` 을 window_manager 에 추가
  - `export_panel` 에 `draw_progress` 함수 추가