### PR TITLE
Active object가 없을 때 재질 속성에 접근하는 문제

### DIFF
--- a/release/scripts/startup/abler/lib/materials/materials_handler.py
+++ b/release/scripts/startup/abler/lib/materials/materials_handler.py
@@ -259,11 +259,12 @@ def change_material_type(self, context: Context) -> None:
         if not context:
             context = bpy.context
 
-        material_slots: List[MaterialSlot] = context.active_object.material_slots
+        if context.active_object:
+            material_slots: List[MaterialSlot] = context.active_object.material_slots
 
-        for mat_slot in material_slots:
-            mat: Material = mat_slot.material
-            set_material_parameters_by_type(mat)
+            for mat_slot in material_slots:
+                mat: Material = mat_slot.material
+                set_material_parameters_by_type(mat)
 
     except:
         print("ACON Material Type change handler could not complete.")


### PR DESCRIPTION
## 관련 링크

[Active object가 없을 때 재질 속성에 접근하는 문제](https://www.notion.so/acon3d/Active-object-NoneType-10aa978fcc604f2da3e99327bb4144b2)


## 발제/내용

- Active object가 NoneType 이면 재질을 가져올 수 없어서 SKP Importer 과정에서 에러가 발생하고 있었음


## 대응

### 어떤 조치를 취했나요?

- `context.active_object` 가 있을 때만 `material_slots` 를 가져올 수 있도록 변경