### PR TITLE
context.object가 없을 경우 update 함수가 돌아가지 않는 경우에 대한 방어코드 작성

### DIFF
--- a/release/scripts/startup/abler/lib/objects.py
+++ b/release/scripts/startup/abler/lib/objects.py
@@ -6,13 +6,13 @@ from .tracker import tracker
 
 
 def toggle_constraint_to_camera(self, context):
-    obj = context.object
-    if obj.ACON_prop.constraint_to_camera_rotation_z:
-        tracker.look_at_me()
+    if obj := context.object:
+        if obj.ACON_prop.constraint_to_camera_rotation_z:
+            tracker.look_at_me()
 
-    cameras.make_sure_camera_exists()
+        cameras.make_sure_camera_exists()
 
-    set_constraint_to_camera_by_object(obj, context)
+        set_constraint_to_camera_by_object(obj, context)
 
 
 # items should be a global variable due to a bug in EnumProperty


### PR DESCRIPTION
## 관련 링크
[논의 링크](https://acontainer.slack.com/archives/C02K1NPTV42/p1667972995587609)

## 발제/내용
```
def toggle_constraint_to_camera(self, context):
    obj = context.object
    if obj.ACON_prop.constraint_to_camera_rotation_z:
        tracker.look_at_me()

    cameras.make_sure_camera_exists()
    set_constraint_to_camera_by_object(obj, context)
```
- context.object가 없을 경우 생기는 오류로, 방어코드 작성이 필요함.

## 대응

### 어떤 조치를 취했나요?

- obj에 if문과 바다코끼리를 사용해서 필터링함.