### PR TITLE
skp-importer에도 발생하고 있는 현상이라 테스트 정합성을 위해 추가함

### DIFF
--- a/release/scripts/startup/abler/lib/objects.py
+++ b/release/scripts/startup/abler/lib/objects.py
@@ -6,13 +6,13 @@ from .tracker import tracker
 
 
 def toggle_constraint_to_camera(self, context):
-    obj = context.object
-    if obj.ACON_prop.constraint_to_camera_rotation_z:
-        tracker.look_at_me()
+    if obj := context.object:
+        if obj.ACON_prop.constraint_to_camera_rotation_z:
+            tracker.look_at_me()
 
-    cameras.make_sure_camera_exists()
+        cameras.make_sure_camera_exists()
 
-    set_constraint_to_camera_by_object(obj, context)
+        set_constraint_to_camera_by_object(obj, context)
 
 
 # items should be a global variable due to a bug in EnumProperty


### PR DESCRIPTION
## 관련 링크
[에러 카드 링크](https://www.notion.so/acon3d/skp-importer-always-face-camera-cebd55eff7ea41659b61d45c5420d07f
)

## 발제/내용

- skp import 시에 오류 메시지로 변환 완료가 잘 안되는 경우가 있음.

## 대응

### 어떤 조치를 취했나요?

- context.object가 없을 경우를 대비하여 방어구문을 만들어줌.