### PR TITLE
Feature/export tab text

### DIFF
--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -72,18 +72,24 @@ class AconWindowManagerProperty(bpy.types.PropertyGroup):
     )
 
     hq_render_full: bpy.props.BoolProperty(
-        name="Full Render", description="Render according to the set pixel"
+        name="Full Render",
+        description="Render according to the set pixel",
+        default=True,
     )
     hq_render_line: bpy.props.BoolProperty(
-        name="Line Render", description="Render only lines according to the set pixel"
+        name="Line Render",
+        description="Render only lines according to the set pixel",
+        default=True,
     )
     hq_render_texture: bpy.props.BoolProperty(
         name="Texture Render",
         description="Render only textures according to the set pixel",
+        default=True,
     )
     hq_render_shadow: bpy.props.BoolProperty(
         name="Shadow Render",
         description="Render only shadow according to the set pixel",
+        default=True,
     )
 
 

--- a/release/scripts/startup/abler/export_tab/export_control.py
+++ b/release/scripts/startup/abler/export_tab/export_control.py
@@ -37,7 +37,7 @@ class Acon3dHighQualityRenderPanel(bpy.types.Panel):
     """Creates a Panel in the scene context of the properties editor"""
 
     bl_idname = "ACON3D_PT_high_quality_render"
-    bl_label = "High Quality Render"
+    bl_label = "High-Quality Render"
     bl_category = "Export"
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"

--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -314,7 +314,6 @@ class Acon3dRenderDirOperator(Acon3dRenderOperator, ImportHelper):
             self.filepath = self.basename
 
     def execute(self, context):
-        print(self.filepath)
         if not os.path.isdir(self.filepath) and os.path.isfile(self.filepath):
             bpy.ops.acon3d.alert(
                 "INVOKE_DEFAULT",

--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -78,7 +78,6 @@ class Acon3dCameraViewOperator(bpy.types.Operator):
 
     bl_idname = "acon3d.camera_view"
     bl_label = "Camera View"
-    bl_description = "Fit render region to viewport."
     bl_translation_context = "*"
     bl_options = {"REGISTER", "UNDO"}
 
@@ -152,8 +151,6 @@ class Acon3dRenderSaveOpertor(bpy.types.Operator):
 
 class Acon3dRenderOperator(bpy.types.Operator):
 
-    filename_ext = ".png"
-    filter_glob: bpy.props.StringProperty(default="*.png", options={"HIDDEN"})
     show_on_completion: bpy.props.BoolProperty(
         name="Show in folder on completion", default=True
     )
@@ -227,6 +224,9 @@ class Acon3dRenderQuickOperator(Acon3dRenderOperator, ExportHelper):
     bl_description = "Take a snapshot of the active viewport"
     bl_translation_context = "*"
 
+    filename_ext = ".png"
+    filter_glob: bpy.props.StringProperty(default="*.png", options={"HIDDEN"})
+
     def __init__(self):
         scene = bpy.context.scene
         self.filepath = f"{scene.name}{self.filename_ext}"
@@ -296,6 +296,8 @@ class Acon3dRenderQuickOperator(Acon3dRenderOperator, ExportHelper):
 class Acon3dRenderDirOperator(Acon3dRenderOperator, ImportHelper):
     # Render Type : High Quality, Snip
 
+    filter_glob: bpy.props.StringProperty(default="Folders", options={"HIDDEN"})
+
     def __init__(self):
         # Get basename without file extension
         self.filepath = bpy.context.blend_data.filepath
@@ -310,6 +312,17 @@ class Acon3dRenderDirOperator(Acon3dRenderOperator, ImportHelper):
                 self.basename = ".".join(self.basename.split(".")[:-1])
 
             self.filepath = self.basename
+
+    def execute(self, context):
+        print(self.filepath)
+        if not os.path.isdir(self.filepath) and os.path.isfile(self.filepath):
+            bpy.ops.acon3d.alert(
+                "INVOKE_DEFAULT",
+                title="File Select Error",
+                message_1="No selected file.",
+            )
+            return {"FINISHED"}
+        return super().execute(context)
 
     def render_handler(self):
         progress_prop = bpy.context.window_manager.progress_prop
@@ -487,11 +500,10 @@ class Acon3dRenderSnipOperator(Acon3dRenderDirOperator):
 
 
 class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
-    """Render according to the set pixel"""
+    """Render with high quality according to the set pixel"""
 
     bl_idname = "acon3d.render_high_quality"
     bl_label = "Render Selected Scenes"
-    bl_description = "Render with high quality according to the set pixel"
     bl_translation_context = "*"
 
     # 렌더를 위해 임시로 만들어진 scene list

--- a/source/blender/editors/interface/interface_templates.c
+++ b/source/blender/editors/interface/interface_templates.c
@@ -5852,7 +5852,6 @@ void uiTemplateProgressBar(uiLayout *layout, bContext *C, const float progress)
                                                                           NULL);
 
     but_progress->progress = progress;
-    UI_but_func_tooltip_set(&but_progress->but, progress_tooltip_func, tip_arg, MEM_freeN);
   }
 }
 


### PR DESCRIPTION
## 관련 링크
[태스크 카드](https://www.notion.so/acon3d/UI-0b4f7b66aaeb44d5afbce1bed20d97dd)
[프로그레스바 툴팁 삭제 관련 슬랙 쓰레드](https://acontainer.slack.com/archives/C02K1NPTV42/p1667960416494249)

## 발제/내용

- Export Tab 의 문구 및 값을 사양서에 맞게 변경하였습니다.

## 대응

### 어떤 조치를 취했나요?

- 프로그래스바의 툴팁을 삭제하였습니다.
- HQ 렌더의 옵션들의 디폴트 값 (true)을 설정하였습니다.
- RenderDirOperator 의 필터 조건을 폴더로 변경하였습니다.
  - 폴더 외의 파일을 선택하면 기존 Import 에서 떴던 에러 모달이 뜨도록 변경하였습니다.
- 상위 클래스에 있던 필터 조건을 RenderQuickOperator 내로 옮겼습니다.
- 라벨 및 문구를 사양서에 맞게 수정하고 중복을 제거하였습니다.