### PR TITLE
믹스패널 렌더 고도화 작업

### DIFF
--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -588,20 +588,22 @@ class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
             if s_col.is_render_selected and s_col.name in bpy.data.scenes:
                 scene = bpy.data.scenes[s_col.name]
 
+                render_data = {"Scene": scene.name, "Filepath": bpy.data.filepath}
+
                 if render_prop.hq_render_full:
-                    tracker.render_full()
+                    tracker.render_full(render_data)
                     self.prepare_temp_scene(scene, render_type="full")
 
                 if render_prop.hq_render_line:
-                    tracker.render_line()
+                    tracker.render_line(render_data)
                     self.prepare_temp_scene(scene, render_type="line")
 
                 if render_prop.hq_render_shadow:
-                    tracker.render_shadow()
+                    tracker.render_shadow(render_data)
                     self.prepare_temp_scene(scene, render_type="shadow")
 
                 if render_prop.hq_render_texture:
-                    tracker.render_texture(scene.name, bpy.data.filepath)
+                    tracker.render_texture(render_data)
                     self.prepare_temp_scene(scene, render_type="texture")
 
         progress_prop.is_loaded = True

--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -17,13 +17,12 @@
 # ##### END GPL LICENSE BLOCK #####
 
 
-import bpy, platform, os, subprocess
+import bpy, platform, os, subprocess, datetime
 from bpy_extras.io_utils import ImportHelper, ExportHelper
 from ..lib import render, cameras
 from ..lib.materials import materials_handler
 from ..lib.tracker import tracker
 from time import time
-import datetime
 from ..warning_modal import BlockingModalOperator
 
 

--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -601,7 +601,7 @@ class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
                     self.prepare_temp_scene(scene, render_type="shadow")
 
                 if render_prop.hq_render_texture:
-                    tracker.render_texture(scene.name)
+                    tracker.render_texture(scene.name, bpy.data.filepath)
                     self.prepare_temp_scene(scene, render_type="texture")
 
         progress_prop.is_loaded = True

--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -348,7 +348,7 @@ class Acon3dRenderDirOperator(Acon3dRenderOperator, ImportHelper):
 
             elif self.rendering is False:
 
-                name_item, qitem = self.render_queue[0]
+                name_item, qitem, _ = self.render_queue[0]
                 if name_item:
                     dirname_temp = os.path.join(self.filepath, name_item)
                     if not os.path.exists(dirname_temp):
@@ -506,7 +506,7 @@ class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
 
     def pre_render(self, dummy, dum):
         super().pre_render(dummy, dum)
-        _, scene = self.render_queue[0]
+        _, scene, _ = self.render_queue[0]
         info = find_target_render_scene_info(
             scene.name, bpy.context.window_manager.progress_prop.render_scene_infos
         )
@@ -514,6 +514,7 @@ class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
             info.status = "in progress"
 
     def post_render(self, dummy, dum):
+        base_scene_name, scene, render_type = self.render_queue[0]
         render_prop = bpy.context.window_manager.ACON_prop
         scene = bpy.context.scene
         render_data = {"Scene": scene.name, "Filepath": bpy.data.filepath}
@@ -558,7 +559,7 @@ class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
         bpy.data.window_managers["WinMan"].ACON_prop.scene = scene.name
 
         # 렌더를 위한 씬 이름을 폴더명으로 설정하기 위한 queue에 추가
-        self.render_queue.append((base_scene.name, scene))
+        self.render_queue.append((base_scene.name, scene, render_type))
 
         self.temp_scenes.append(scene)
 

--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -164,6 +164,7 @@ class Acon3dRenderOperator(bpy.types.Operator):
     timer_event = None
     initial_scene = None
     initial_display_type = None
+    render_start_time = None
 
     def pre_render(self, dummy, dum):
         self.rendering = True
@@ -516,7 +517,11 @@ class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
     def post_render(self, dummy, dum):
         base_scene_name, scene, render_type = self.render_queue[0]
         render_prop = bpy.context.window_manager.ACON_prop
-        render_data = {"Scene": base_scene_name, "Filepath": bpy.data.filepath}
+        render_time = time() - self.render_start_time
+        self.render_start_time = time()
+        render_data = {"Scene": base_scene_name, "Filepath": bpy.data.filepath, "Render time": render_time}
+
+        print(f"render_time: {render_time}")
 
         # 현재 렌더가 어떤 렌더인지만 받아오기
         if render_type == "full":
@@ -602,6 +607,7 @@ class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
         progress_prop.end_date = 0
         progress_prop.render_scene_infos.clear()
         progress_prop.is_loaded = False
+        self.render_start_time = time()
 
         render_prop = context.window_manager.ACON_prop
         for s_col in render_prop.scene_col:

--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -516,12 +516,13 @@ class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
 
     def post_render(self, dummy, dum):
         base_scene_name, scene, render_type = self.render_queue[0]
-        render_prop = bpy.context.window_manager.ACON_prop
         render_time = time() - self.render_start_time
         self.render_start_time = time()
-        render_data = {"Scene": base_scene_name, "Filepath": bpy.data.filepath, "Render time": render_time}
-
-        print(f"render_time: {render_time}")
+        render_data = {
+            "Scene": base_scene_name,
+            "Filepath": bpy.data.filepath,
+            "Render time": render_time,
+        }
 
         # 현재 렌더가 어떤 렌더인지만 받아오기
         if render_type == "full":

--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -516,30 +516,26 @@ class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
     def post_render(self, dummy, dum):
         base_scene_name, scene, render_type = self.render_queue[0]
         render_prop = bpy.context.window_manager.ACON_prop
-        scene = bpy.context.scene
-        render_data = {"Scene": scene.name, "Filepath": bpy.data.filepath}
+        render_data = {"Scene": base_scene_name, "Filepath": bpy.data.filepath}
 
-        for s_col in render_prop.scene_col:
-            # print(s_col.name)
-            if s_col.is_render_selected and s_col.name in bpy.data.scenes:
-                if render_prop.hq_render_full:
-                    tracker.render_full(render_data)
-                    # print("full")
+        # 현재 렌더가 어떤 렌더인지만 받아오기
+        if render_type == "full":
+            tracker.render_full(render_data)
+            print("full")
 
-                if render_prop.hq_render_line:
-                    tracker.render_line(render_data)
-                    # print("line")
+        elif render_type == "line":
+            tracker.render_line(render_data)
+            print("line")
 
-                if render_prop.hq_render_shadow:
-                    tracker.render_shadow(render_data)
-                    # print("shadow")
+        elif render_type == "shadow":
+            tracker.render_shadow(render_data)
+            print("shadow")
 
-                if render_prop.hq_render_texture:
-                    tracker.render_texture(render_data)
-                    # print("texture")
+        elif render_type == "texture":
+            tracker.render_texture(render_data)
+            print("texture")
 
         progress_prop = bpy.context.window_manager.progress_prop
-        _, scene = self.render_queue[0]
         info = find_target_render_scene_info(
             scene.name, bpy.context.window_manager.progress_prop.render_scene_infos
         )

--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -514,6 +514,29 @@ class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
             info.status = "in progress"
 
     def post_render(self, dummy, dum):
+        render_prop = bpy.context.window_manager.ACON_prop
+        scene = bpy.context.scene
+        render_data = {"Scene": scene.name, "Filepath": bpy.data.filepath}
+
+        for s_col in render_prop.scene_col:
+            # print(s_col.name)
+            if s_col.is_render_selected and s_col.name in bpy.data.scenes:
+                if render_prop.hq_render_full:
+                    tracker.render_full(render_data)
+                    # print("full")
+
+                if render_prop.hq_render_line:
+                    tracker.render_line(render_data)
+                    # print("line")
+
+                if render_prop.hq_render_shadow:
+                    tracker.render_shadow(render_data)
+                    # print("shadow")
+
+                if render_prop.hq_render_texture:
+                    tracker.render_texture(render_data)
+                    # print("texture")
+
         progress_prop = bpy.context.window_manager.progress_prop
         _, scene = self.render_queue[0]
         info = find_target_render_scene_info(
@@ -591,19 +614,19 @@ class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
                 render_data = {"Scene": scene.name, "Filepath": bpy.data.filepath}
 
                 if render_prop.hq_render_full:
-                    tracker.render_full(render_data)
+                    # tracker.render_full(render_data)
                     self.prepare_temp_scene(scene, render_type="full")
 
                 if render_prop.hq_render_line:
-                    tracker.render_line(render_data)
+                    # tracker.render_line(render_data)
                     self.prepare_temp_scene(scene, render_type="line")
 
                 if render_prop.hq_render_shadow:
-                    tracker.render_shadow(render_data)
+                    # tracker.render_shadow(render_data)
                     self.prepare_temp_scene(scene, render_type="shadow")
 
                 if render_prop.hq_render_texture:
-                    tracker.render_texture(render_data)
+                    # tracker.render_texture(render_data)
                     self.prepare_temp_scene(scene, render_type="texture")
 
         progress_prop.is_loaded = True

--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -23,6 +23,7 @@ from ..lib import render, cameras
 from ..lib.materials import materials_handler
 from ..lib.tracker import tracker
 from time import time
+import datetime
 from ..warning_modal import BlockingModalOperator
 
 
@@ -518,7 +519,9 @@ class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
 
     def post_render(self, dummy, dum):
         base_scene_name, scene, render_type = self.render_queue[0]
-        render_time = time() - self.render_start_time
+        render_time = str(
+            datetime.timedelta(seconds=round(time() - self.render_start_time))
+        )
         render_data = {
             "Scene": base_scene_name,
             "Filepath": bpy.data.filepath,

--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -601,7 +601,7 @@ class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
                     self.prepare_temp_scene(scene, render_type="shadow")
 
                 if render_prop.hq_render_texture:
-                    tracker.render_texture()
+                    tracker.render_texture(scene.name)
                     self.prepare_temp_scene(scene, render_type="texture")
 
         progress_prop.is_loaded = True

--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -528,24 +528,17 @@ class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
             "Render time": render_time,
         }
 
-        print(f"render_time: {render_time}")
-
-        # 현재 렌더가 어떤 렌더인지만 받아오기
         if render_type == "full":
             tracker.render_full(render_data)
-            print("full")
 
         elif render_type == "line":
             tracker.render_line(render_data)
-            print("line")
 
         elif render_type == "shadow":
             tracker.render_shadow(render_data)
-            print("shadow")
 
         elif render_type == "texture":
             tracker.render_texture(render_data)
-            print("texture")
 
         progress_prop = bpy.context.window_manager.progress_prop
         info = find_target_render_scene_info(
@@ -620,22 +613,16 @@ class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
             if s_col.is_render_selected and s_col.name in bpy.data.scenes:
                 scene = bpy.data.scenes[s_col.name]
 
-                render_data = {"Scene": scene.name, "Filepath": bpy.data.filepath}
-
                 if render_prop.hq_render_full:
-                    # tracker.render_full(render_data)
                     self.prepare_temp_scene(scene, render_type="full")
 
                 if render_prop.hq_render_line:
-                    # tracker.render_line(render_data)
                     self.prepare_temp_scene(scene, render_type="line")
 
                 if render_prop.hq_render_shadow:
-                    # tracker.render_shadow(render_data)
                     self.prepare_temp_scene(scene, render_type="shadow")
 
                 if render_prop.hq_render_texture:
-                    # tracker.render_texture(render_data)
                     self.prepare_temp_scene(scene, render_type="texture")
 
         progress_prop.is_loaded = True

--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -506,6 +506,8 @@ class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
         return super().invoke(context, event)
 
     def pre_render(self, dummy, dum):
+        self.render_start_time = time()
+
         super().pre_render(dummy, dum)
         _, scene, _ = self.render_queue[0]
         info = find_target_render_scene_info(
@@ -517,12 +519,13 @@ class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
     def post_render(self, dummy, dum):
         base_scene_name, scene, render_type = self.render_queue[0]
         render_time = time() - self.render_start_time
-        self.render_start_time = time()
         render_data = {
             "Scene": base_scene_name,
             "Filepath": bpy.data.filepath,
             "Render time": render_time,
         }
+
+        print(f"render_time: {render_time}")
 
         # 현재 렌더가 어떤 렌더인지만 받아오기
         if render_type == "full":
@@ -608,7 +611,6 @@ class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
         progress_prop.end_date = 0
         progress_prop.render_scene_infos.clear()
         progress_prop.is_loaded = False
-        self.render_start_time = time()
 
         render_prop = context.window_manager.ACON_prop
         for s_col in render_prop.scene_col:

--- a/release/scripts/startup/abler/lib/tracker/_tracker.py
+++ b/release/scripts/startup/abler/lib/tracker/_tracker.py
@@ -165,17 +165,17 @@ class Tracker(metaclass=ABCMeta):
     def render_quick(self):
         self._track(EventKind.render_quick.value)
 
-    def render_full(self):
-        self._track(EventKind.render_full.value)
+    def render_full(self, data):
+        self._track(EventKind.render_full.value, data)
 
-    def render_line(self):
-        self._track(EventKind.render_line.value)
+    def render_line(self, data):
+        self._track(EventKind.render_line.value, data)
 
-    def render_shadow(self):
-        self._track(EventKind.render_shadow.value)
+    def render_shadow(self, data):
+        self._track(EventKind.render_shadow.value, data)
 
-    def render_texture(self, name, filepath):
-        self._track(EventKind.render_texture.value, {"name": name, "filepath": filepath})
+    def render_texture(self, data):
+        self._track(EventKind.render_texture.value, data)
 
     def render_all_scenes(self):
         self._track(EventKind.render_all_scenes.value)

--- a/release/scripts/startup/abler/lib/tracker/_tracker.py
+++ b/release/scripts/startup/abler/lib/tracker/_tracker.py
@@ -174,8 +174,8 @@ class Tracker(metaclass=ABCMeta):
     def render_shadow(self):
         self._track(EventKind.render_shadow.value)
 
-    def render_texture(self):
-        self._track(EventKind.render_texture.value)
+    def render_texture(self, name):
+        self._track(EventKind.render_texture.value, {"name": name})
 
     def render_all_scenes(self):
         self._track(EventKind.render_all_scenes.value)

--- a/release/scripts/startup/abler/lib/tracker/_tracker.py
+++ b/release/scripts/startup/abler/lib/tracker/_tracker.py
@@ -20,7 +20,6 @@ class EventKind(enum.Enum):
     render_line = "Render Line"
     render_shadow = "Render Shadow"
     render_texture = "Render Texture"
-    render_all_scenes = "Render All Scenes"
     render_snip = "Render Snip"
     import_blend = "Import *.blend"
     import_blend_fail = "Import *.blend Fail"
@@ -176,9 +175,6 @@ class Tracker(metaclass=ABCMeta):
 
     def render_texture(self, data):
         self._track(EventKind.render_texture.value, data)
-
-    def render_all_scenes(self):
-        self._track(EventKind.render_all_scenes.value)
 
     def render_snip(self):
         self._track(EventKind.render_snip.value)

--- a/release/scripts/startup/abler/lib/tracker/_tracker.py
+++ b/release/scripts/startup/abler/lib/tracker/_tracker.py
@@ -174,8 +174,8 @@ class Tracker(metaclass=ABCMeta):
     def render_shadow(self):
         self._track(EventKind.render_shadow.value)
 
-    def render_texture(self, name):
-        self._track(EventKind.render_texture.value, {"name": name})
+    def render_texture(self, name, filepath):
+        self._track(EventKind.render_texture.value, {"name": name, "filepath": filepath})
 
     def render_all_scenes(self):
         self._track(EventKind.render_all_scenes.value)


### PR DESCRIPTION
## 관련 링크

[믹스패널 렌더 고도화 작업](https://www.notion.so/acon3d/37ec9fa8a570467daffb8b572156a5ff)


## 발제/내용

- 고품질 렌더 하위에 속하는 각각의 렌더 track 함수는 일단 유지
- 각 렌더 track 함수에서 믹스패널에 보낼 때 다음 사항 추가
    - 파일 경로
    - 씬 이름
    - 소요시간
- 각 렌더 소요 시간의 합을 고품질 렌더의 소요 시간으로 일단 봐도 될 것 같음
- 데이터 정리는 믹스패널에서 해보기


## 대응

### 어떤 조치를 취했나요?

- [x]  render에 scene.name 같이 태워보기
- [x]  + filepath 탑승
    - 현재 render operator를 실행하면 바로 tracker 함수가 실행되고 있음. 그래서 렌더가 완료되기 전에 데이터가 넘어가서, 렌더가 성공했는지 아닌지 제대로 확인하지 못하는 문제가 있음.
- [x]  각각의 렌더가 끝났을 때 tracker 실행
- [x]  현재 렌더되는 type을 보내기
- [x]  각 렌더별 소요시간 측정 + 믹스패널 탑승
- [x]  render_start_time이 실제 시작할 때만 업데이트 해주기
- [x]  seconds → H:M:S 형태로 출력

### 논의

- [x]  파일 변경 사항 없는 코니룸일 때 → `(empty string)` : 공유 완료
    [https://acontainer.slack.com/archives/C01K142MCNS/p1667977988266589](https://acontainer.slack.com/archives/C01K142MCNS/p1667977988266589)
    
- [ ]  Filepath 데이터에서 파일명만 남길 필요 있는지 고민
    - 유저명으로 고유성을 가질 수 있는지 확인 필요
    - 파일명만 남기면 고유성을 잃을 수 있음