### PR TITLE
튜토리얼 가이드 믹스패널 추가

### DIFF
--- a/release/scripts/startup/abler/general_tab/general.py
+++ b/release/scripts/startup/abler/general_tab/general.py
@@ -75,6 +75,8 @@ class AconTutorialGuidePopUpOperator(bpy.types.Operator):
     bl_translation_context = "abler"
 
     def execute(self, context):
+        tracker.tutorial_guide_on()
+
         userInfo = bpy.data.meshes.get("ACON_userInfo")
         prop = userInfo.ACON_prop
         prop.show_guide = read_remembered_show_guide()

--- a/release/scripts/startup/abler/lib/tracker/_tracker.py
+++ b/release/scripts/startup/abler/lib/tracker/_tracker.py
@@ -49,6 +49,7 @@ class EventKind(enum.Enum):
     group_navigate_top = "Group Navigate Top"
     group_navigate_down = "Group Navigate Down"
     group_navigate_up = "Group Navigate Up"
+    tutorial_guide_on = "Quick Start Guide On"
 
 
 def accumulate(interval=0):
@@ -266,6 +267,9 @@ class Tracker(metaclass=ABCMeta):
 
     def group_navigate_up(self):
         self._track(EventKind.group_navigate_up.value)
+
+    def tutorial_guide_on(self):
+        self._track(EventKind.tutorial_guide_on.value)
 
 
 class DummyTracker(Tracker):

--- a/release/scripts/startup/abler/startup_flow.py
+++ b/release/scripts/startup/abler/startup_flow.py
@@ -265,7 +265,7 @@ class Acon3dModalOperator(BlockingModalOperator):
 
     def after_close(self, context, event):
         if read_remembered_show_guide():
-            bpy.ops.acon3d.tutorial_guide_popup()
+            bpy.ops.wm.splash_tutorial_1("INVOKE_DEFAULT")
 
 
 class NamedException(Exception):

--- a/release/scripts/startup/abler/startup_flow.py
+++ b/release/scripts/startup/abler/startup_flow.py
@@ -265,6 +265,8 @@ class Acon3dModalOperator(BlockingModalOperator):
 
     def after_close(self, context, event):
         if read_remembered_show_guide():
+            # 버튼을 누를 때만 믹스패널의 tracker.tutorial_guide_on을 실행하기 위해
+            # 에이블러 첫 실행시 가이드는 wm 오퍼레이터를 직접 실행
             bpy.ops.wm.splash_tutorial_1("INVOKE_DEFAULT")
 
 


### PR DESCRIPTION
## 관련 링크
[링크](https://www.notion.so/acon3d/661ed2130d2d4371ae9934662261fe6b)

## 발제/내용

- 실제로 튜토리얼 가이드 버튼을 눌렀을 때만 믹스패널에 출력

## 대응

### 어떤 조치를 취했나요?

- [x]  믹스패널에 value 추가
- [x]  acon3d.tutorial_guide_popup 내에 tracker 추가
- [x]  에이블러 처음 시작시 실행되는 가이드도 tracker가 찍힘
    - startup_flow.py에서 `acon3d.tutorial_guide_popup` 를 실행함
    - `acon3d.tutorial_guide_popup` → `bpy.ops.wm.splash_tutorial_1("INVOKE_DEFAULT")` 로 직접 실행해 믹스패널 거치지 않는걸로 수정