### PR TITLE
렌더 프로그레스 사양서에 맞게 수정

### DIFF
--- a/release/scripts/startup/abler/export_tab/export_control.py
+++ b/release/scripts/startup/abler/export_tab/export_control.py
@@ -152,13 +152,15 @@ class Acon3dHighQualityRenderPanel(bpy.types.Panel):
         col.template_progress_bar(progress=render_progress)
 
         for info in progress_prop.render_scene_infos:
-            box.label(text=info.render_scene_name)
+            col = box.column()
+            col.scale_y = 0.8
+            col.label(text=info.render_scene_name)
             if info.status == "waiting":
-                box.template_progress_bar(progress=0.0)
+                col.template_progress_bar(progress=0.0)
             elif info.status == "in progress":
-                box.template_progress_bar(progress=cur_progress)
+                col.template_progress_bar(progress=cur_progress)
             else:
-                box.template_progress_bar(progress=1.0)
+                col.template_progress_bar(progress=1.0)
 
         sub = box.split(align=True, factor=0.25)
 

--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -512,6 +512,23 @@ class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
     def __init__(self):
         super().__init__()
 
+    def draw(self, context):
+        layout = self.layout
+        box = layout.box()
+        box.scale_y = 0.5
+        box.use_property_split = True
+        box.use_property_decorate = False
+        box.label(
+            icon="ERROR",
+            text="Please select the path in",
+        )
+        box.label(
+            text="which the rendered images",
+        )
+        box.label(
+            text="will be saved.",
+        )
+
     def invoke(self, context, event):
         bpy.ops.acon3d.close_blocking_modal("INVOKE_DEFAULT")
         return super().invoke(context, event)


### PR DESCRIPTION
## 관련 링크
[태스크 카드 링크](https://www.notion.so/acon3d/bbc46458ba3941bca1a7f01f84fa4e6b)

## 발제/내용

- 사양서와 현 렌더 모달 및 렌더 패널이 맞지 않는 내용이 있음

## 대응

### 어떤 조치를 취했나요?

- HQ 렌더 모달 우측에 경고 문구를 추가했습니다

- 씬별 프로그레스의 제목-바 간격을 줄였습니다