### PR TITLE
Sunlight, Bloom 토글 해제 시 패널 닫히지 않는 문제

### DIFF
--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -499,6 +499,16 @@ class AconSceneProperty(bpy.types.PropertyGroup):
         update=bloom.change_bloom_radius,
     )
 
+    bloom_color: bpy.props.FloatVectorProperty(
+        name="",
+        description="Select color of bloom effect",
+        subtype="COLOR",
+        default=(1.0, 1.0, 1.0),
+        min=0,
+        max=1.0,
+        update=bloom.change_bloom_color,
+    )
+
     bloom_intensity: bpy.props.FloatProperty(
         name="",
         description="Change bloom intensity (Range: 0 ~ 1)",

--- a/release/scripts/startup/abler/lib/bloom.py
+++ b/release/scripts/startup/abler/lib/bloom.py
@@ -26,6 +26,14 @@ def change_bloom_radius(self, context: Context) -> None:
     eevee_prop.bloom_radius = value
 
 
+def change_bloom_color(self, context: Context) -> None:
+    eevee_prop = context.scene.eevee
+    prop = context.scene.ACON_prop
+    value = prop.bloom_color
+
+    eevee_prop.bloom_color = value
+
+
 def change_bloom_intensity(self, context: Context) -> None:
     eevee_prop = context.scene.eevee
     prop = context.scene.ACON_prop

--- a/release/scripts/startup/abler/style_tab/styles_control.py
+++ b/release/scripts/startup/abler/style_tab/styles_control.py
@@ -306,22 +306,23 @@ class BloomPanel(bpy.types.Panel):
         layout.prop(scene.ACON_prop, "use_bloom", text="")
 
     def draw(self, context):
-        layout = self.layout
-        layout.use_property_split = True
-        layout.use_property_decorate = False  # No animation.
+        if context.scene.ACON_prop.use_bloom:
+            layout = self.layout
+            layout.use_property_split = True
+            layout.use_property_decorate = False  # No animation.
 
-        scene = context.scene
-        eevee_prop = scene.eevee
-        prop = scene.ACON_prop
+            scene = context.scene
+            eevee_prop = scene.eevee
+            prop = scene.ACON_prop
 
-        layout.active = eevee_prop.use_bloom
-        col = layout.column()
-        col.prop(prop, "bloom_threshold", text="Threshold", slider=True)
-        col.prop(prop, "bloom_knee", text="Knee", slider=True)
-        col.prop(prop, "bloom_radius", text="Radius", slider=True)
-        col.prop(eevee_prop, "bloom_color")
-        col.prop(prop, "bloom_intensity", text="Intensity", slider=True)
-        col.prop(prop, "bloom_clamp", text="Clamp", slider=True)
+            layout.active = eevee_prop.use_bloom
+            col = layout.column()
+            col.prop(prop, "bloom_threshold", text="Threshold", slider=True)
+            col.prop(prop, "bloom_knee", text="Knee", slider=True)
+            col.prop(prop, "bloom_radius", text="Radius", slider=True)
+            col.prop(eevee_prop, "bloom_color")
+            col.prop(prop, "bloom_intensity", text="Intensity", slider=True)
+            col.prop(prop, "bloom_clamp", text="Clamp", slider=True)
 
 
 class ColorAdjustmentPanel(bpy.types.Panel):

--- a/release/scripts/startup/abler/style_tab/styles_control.py
+++ b/release/scripts/startup/abler/style_tab/styles_control.py
@@ -98,15 +98,16 @@ class SunlightPanel(bpy.types.Panel):
         layout.prop(context.scene.ACON_prop, "toggle_sun", text="")
 
     def draw(self, context):
-        layout = self.layout
-        layout.use_property_decorate = False  # No animation.
-        layout.use_property_split = True
-        row = layout.row(align=True)
-        row.prop(context.scene.ACON_prop, "sun_strength", text="Strength")
-        row = layout.row(align=True)
-        row.prop(context.scene.ACON_prop, "sun_rotation_x", text="Altitude")
-        row = layout.row(align=True)
-        row.prop(context.scene.ACON_prop, "sun_rotation_z", text="Azimuth")
+        if context.scene.ACON_prop.toggle_sun:
+            layout = self.layout
+            layout.use_property_decorate = False  # No animation.
+            layout.use_property_split = True
+            row = layout.row(align=True)
+            row.prop(context.scene.ACON_prop, "sun_strength", text="Strength")
+            row = layout.row(align=True)
+            row.prop(context.scene.ACON_prop, "sun_rotation_x", text="Altitude")
+            row = layout.row(align=True)
+            row.prop(context.scene.ACON_prop, "sun_rotation_z", text="Azimuth")
 
 
 class ShadowShadingPanel(bpy.types.Panel):

--- a/release/scripts/startup/abler/style_tab/styles_control.py
+++ b/release/scripts/startup/abler/style_tab/styles_control.py
@@ -320,7 +320,7 @@ class BloomPanel(bpy.types.Panel):
             col.prop(prop, "bloom_threshold", text="Threshold", slider=True)
             col.prop(prop, "bloom_knee", text="Knee", slider=True)
             col.prop(prop, "bloom_radius", text="Radius", slider=True)
-            col.prop(eevee_prop, "bloom_color")
+            col.prop(prop, "bloom_color", text="Color")
             col.prop(prop, "bloom_intensity", text="Intensity", slider=True)
             col.prop(prop, "bloom_clamp", text="Clamp", slider=True)
 


### PR DESCRIPTION
## 관련 링크
[링크](https://www.notion.so/acon3d/Sunlight-Bloom-29e3f2c4bfe14c09ba648d77243aaf96)

## 발제/내용

- Sunlight 토글 해제 시 토글 하위 항목이 그대로 노출됨
- Bloom 토글 해제 시에도 동일한 현상 발생
- (+) bloom 내 bloom_color 프로퍼티가 custom_properties가 아닌 문제도 발견

## 대응

### 어떤 조치를 취했나요?

- [x]  draw 내 `if context.scene.ACON_prop.use_bloom:` 문구 추가
- [x]  bloom 내 bloom_color 프로퍼티를 custom_properties로 변경해줌