### PR TITLE
Object Control 그리드가 노출되지 않는 문제

### DIFF
--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -127,6 +127,7 @@ def save_post_handler(dummy):
         scene.view_settings.view_transform = "Standard"
 
 
+@persistent
 def grid_on_when_selected(dummy):
     show_grid = len(bpy.context.selected_objects) > 0
     if find_screen_acon3d():


### PR DESCRIPTION
## 관련 링크
[이슈 링크](https://www.notion.so/acon3d/Issue-0070-Object-Control-fdfa8e39cefa45f4b5838af08172e063)

## 발제/내용

- 선택 오브젝트가 있어도 오브젝트 컨트롤 그리드가 노출되지 않음

## 대응

### 어떤 조치를 취했나요?

- `depsgraph_update_post` 핸들러에서 사용하는 `grid_on_when_selected` 함수에 `@persistent` 데코레이터가 왠지 모르게 빠져있었음.