### PR TITLE
두 번째 창부터 ACON_userInfo 메시가 없어서 에러가 발생하는 문제

### DIFF
--- a/release/scripts/startup/abler/general_tab/general.py
+++ b/release/scripts/startup/abler/general_tab/general.py
@@ -40,6 +40,7 @@ from ..lib.materials import materials_setup
 from ..lib.tracker import tracker
 from ..lib.read_cookies import read_remembered_show_guide
 from ..lib.import_file import AconImportHelper
+from ..lib.user_info import get_or_init_user_info
 
 
 def split_filepath(filepath):
@@ -78,7 +79,7 @@ class AconTutorialGuidePopUpOperator(bpy.types.Operator):
     def execute(self, context):
         tracker.tutorial_guide_on()
 
-        userInfo = bpy.data.meshes.get("ACON_userInfo")
+        userInfo = get_or_init_user_info()
         prop = userInfo.ACON_prop
         prop.show_guide = read_remembered_show_guide()
 

--- a/release/scripts/startup/abler/lib/read_cookies.py
+++ b/release/scripts/startup/abler/lib/read_cookies.py
@@ -31,8 +31,10 @@ def read_remembered_checkbox() -> bool:
 
 
 def remember_show_guide(self, context) -> None:
-    userInfo = bpy.data.meshes.get("ACON_userInfo")
-    prop = userInfo.ACON_prop
+    # 순환 import 회피
+    from ..lib.user_info import get_or_init_user_info
+    user_info = get_or_init_user_info()
+    prop = user_info.ACON_prop
     with open(path_cookies_tutorial_guide, "wb") as cookies_tutorial_guide:
         pickle.dump(prop.show_guide, cookies_tutorial_guide)
 

--- a/release/scripts/startup/abler/lib/user_info.py
+++ b/release/scripts/startup/abler/lib/user_info.py
@@ -1,0 +1,15 @@
+import bpy
+from ..lib.read_cookies import read_remembered_checkbox, read_remembered_username
+
+
+def get_or_init_user_info():
+    if userInfo := bpy.data.meshes.get("ACON_userInfo"):
+        return userInfo
+    userInfo = bpy.data.meshes.new("ACON_userInfo")
+    prop = userInfo.ACON_prop
+    prop.remember_username = read_remembered_checkbox()
+
+    if prop.remember_username:
+        prop.username = read_remembered_username()
+
+    return userInfo

--- a/release/scripts/startup/abler/operators.py
+++ b/release/scripts/startup/abler/operators.py
@@ -4,6 +4,7 @@ import bpy
 from .lib.tracker import tracker
 from .lib.materials import materials_setup
 from .lib.read_cookies import read_remembered_checkbox, read_remembered_username
+from .lib.user_info import get_or_init_user_info
 
 
 class Acon3dToonStyleOperator(bpy.types.Operator):
@@ -27,7 +28,7 @@ class Acon3dLogoutOperator(bpy.types.Operator):
 
     def execute(self, context):
         # prop를 업데이트 하면 ACON_userInfo도 업데이트
-        prop = bpy.data.meshes.get("ACON_userInfo").ACON_prop
+        prop = get_or_init_user_info().ACON_prop
         path = bpy.utils.resource_path("USER")
         path_cookiesFolder = os.path.join(path, "cookies")
         path_cookiesFile = os.path.join(path_cookiesFolder, "acon3d_session")


### PR DESCRIPTION
## 관련 링크

[태스크 카드 링크](https://www.notion.so/acon3d/General-New-Tutorial-guide-Python-error-091fa626469742b5a79e114b7235bd46)

## 발제/내용

- 튜토리얼 가이드 팝업과 로그아웃 기능 실행시에 ACON_userInfo 메시를 찾지 못해서 발생하는 문제를 해결했습니다.

## 대응

### 어떤 조치를 취했나요?

- ACON_userInfo 생성 및 초기화를 하는 함수를 따로 빼고, 필요한 곳에서 재사용하도록 했습니다.