### PR TITLE
다국어 번역 적용

### DIFF
--- a/release/scripts/startup/abler/export_tab/export_control.py
+++ b/release/scripts/startup/abler/export_tab/export_control.py
@@ -41,6 +41,7 @@ class Acon3dHighQualityRenderPanel(bpy.types.Panel):
     bl_category = "Export"
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
+    bl_translation_context = "abler"
     COMPAT_ENGINES = {"BLENDER_RENDER", "BLENDER_EEVEE", "BLENDER_WORKBENCH"}
 
     def draw_header(self, context):
@@ -63,13 +64,24 @@ class Acon3dHighQualityRenderPanel(bpy.types.Panel):
             row = layout.row()
             col = row.column()
             row = col.row()
-            row.prop(render_prop, "hq_render_full", text="Full Render")
+            row.prop(
+                render_prop, "hq_render_full", text="Full Render", text_ctxt="abler"
+            )
             row = col.row()
-            row.prop(render_prop, "hq_render_texture", text="Texture Render")
+            row.prop(
+                render_prop,
+                "hq_render_texture",
+                text="Texture Render",
+                text_ctxt="abler",
+            )
             row = col.row()
-            row.prop(render_prop, "hq_render_line", text="Line Render")
+            row.prop(
+                render_prop, "hq_render_line", text="Line Render", text_ctxt="abler"
+            )
             row = col.row()
-            row.prop(render_prop, "hq_render_shadow", text="Shadow Render")
+            row.prop(
+                render_prop, "hq_render_shadow", text="Shadow Render", text_ctxt="abler"
+            )
             col.template_list(
                 "RENDER_UL_List",
                 "",
@@ -194,6 +206,7 @@ class Acon3dQuickRenderPanel(bpy.types.Panel):
     bl_category = "Export"
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
+    bl_translation_context = "abler"
     COMPAT_ENGINES = {"BLENDER_RENDER", "BLENDER_EEVEE", "BLENDER_WORKBENCH"}
 
     def draw_header(self, context):
@@ -211,7 +224,7 @@ class Acon3dQuickRenderPanel(bpy.types.Panel):
         row.prop(scene.render, "resolution_x", text="")
         row.prop(scene.render, "resolution_y", text="")
         row = layout.row()
-        row.operator("acon3d.render_quick", text="Render Viewport", text_ctxt="*")
+        row.operator("acon3d.render_quick", text="Render Viewport")
 
 
 class Acon3dSnipRenderPanel(bpy.types.Panel):
@@ -222,6 +235,7 @@ class Acon3dSnipRenderPanel(bpy.types.Panel):
     bl_category = "Export"
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
+    bl_translation_context = "abler"
     COMPAT_ENGINES = {"BLENDER_RENDER", "BLENDER_EEVEE", "BLENDER_WORKBENCH"}
 
     def draw_header(self, context):
@@ -239,7 +253,7 @@ class Acon3dSnipRenderPanel(bpy.types.Panel):
         row.prop(scene.render, "resolution_x", text="")
         row.prop(scene.render, "resolution_y", text="")
         row = layout.row()
-        row.operator("acon3d.render_snip", text="Render Viewport", text_ctxt="*")
+        row.operator("acon3d.render_snip", text="Render Viewport")
 
 
 classes = (

--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -78,7 +78,7 @@ class Acon3dCameraViewOperator(bpy.types.Operator):
 
     bl_idname = "acon3d.camera_view"
     bl_label = "Camera View"
-    bl_translation_context = "*"
+    bl_translation_context = "abler"
     bl_options = {"REGISTER", "UNDO"}
 
     def execute(self, context):
@@ -91,7 +91,7 @@ class Acon3dRenderWarningOperator(BlockingModalOperator):
     bl_idname = "acon3d.render_warning"
     bl_label = "Render Selected Scenes"
     bl_description = "Render with high quality according to the set pixel"
-    bl_translation_context = "*"
+    bl_translation_context = "abler"
     scene_count: bpy.props.IntProperty(name="Scene count", default=0)
 
     def draw_modal(self, layout):
@@ -141,7 +141,7 @@ def render_save_handler(dummy):
 class Acon3dRenderSaveOpertor(bpy.types.Operator):
     bl_idname = "acon3d.render_save"
     bl_label = "Save and Render"
-    bl_translation_context = "*"
+    bl_translation_context = "abler"
 
     def execute(self, context):
         bpy.ops.acon3d.close_blocking_modal("INVOKE_DEFAULT")
@@ -223,7 +223,7 @@ class Acon3dRenderQuickOperator(Acon3dRenderOperator, ExportHelper):
     bl_idname = "acon3d.render_quick"
     bl_label = "Quick Render"
     bl_description = "Take a snapshot of the active viewport"
-    bl_translation_context = "*"
+    bl_translation_context = "abler"
 
     filename_ext = ".png"
     filter_glob: bpy.props.StringProperty(default="*.png", options={"HIDDEN"})
@@ -403,7 +403,7 @@ class Acon3dRenderSnipOperator(Acon3dRenderDirOperator):
 
     bl_idname = "acon3d.render_snip"
     bl_label = "Snip Render"
-    bl_translation_context = "*"
+    bl_translation_context = "abler"
 
     temp_scenes = []
     temp_layer = None
@@ -504,7 +504,7 @@ class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
 
     bl_idname = "acon3d.render_high_quality"
     bl_label = "Render Selected Scenes"
-    bl_translation_context = "*"
+    bl_translation_context = "abler"
 
     # 렌더를 위해 임시로 만들어진 scene list
     temp_scenes = []
@@ -676,7 +676,7 @@ class Acon3dCloseProgressOperator(bpy.types.Operator):
     bl_idname = "acon3d.close_progress"
     bl_label = "OK"
     bl_description = "Close Progress Panel"
-    bl_translation_context = "*"
+    bl_translation_context = "abler"
 
     @classmethod
     def poll(cls, context):

--- a/release/scripts/startup/abler/style_tab/styles_control.py
+++ b/release/scripts/startup/abler/style_tab/styles_control.py
@@ -35,7 +35,7 @@ import bpy
 
 class Acon3dStylesPanel(bpy.types.Panel):
     bl_idname = "ACON_PT_Styles"
-    bl_label = "Styles"
+    bl_label = "Style"
     bl_category = "Style"
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"

--- a/translate.py
+++ b/translate.py
@@ -9,17 +9,18 @@ def csv2po(filepath: str, outfile: str):
     # csv_dict용으로 따로 읽어야함
     with open(filepath, "r") as csv_file:
         csv_reader = csv.reader(csv_file, delimiter=",")
+        
         for row in csv_reader:
-            if csv_dict.get(row[0]):
+            if csv_dict.get(row[1]):
                 # 번역이 중복이고 값은 다른 경우
-                if row[1] != csv_dict.get(row[0]):
-                    print(f"csv file의 '{row[0]}'가 중복으로 들어가 있습니다.")
+                if row[2] != csv_dict.get(row[1])[1]:
+                    print(f"csv file의 '{row[1]}'가 중복으로 들어가 있습니다.")
                     count += 1
                 # 번역이 중복이고 값도 같은 경우
                 else:
                     pass
             else:
-                csv_dict[row[0]] = row[1]
+                csv_dict[row[1]] = (row[0],row[2])
 
     with open(outfile, "w") as po_file:
         for i, (key, value) in enumerate(csv_dict.items()):
@@ -27,12 +28,14 @@ def csv2po(filepath: str, outfile: str):
                 continue
 
             # msg도 영어로 들어가 번역이 필요 없는 경우
-            if key == value:
+            if key == value[1]:
                 continue
-
-            po_file.write(f'msgctxt "abler"\n')
+            
+            # "기능명"일 때만 msgctxt "abler" 넣기
+            if value[0] == "기능명":
+                po_file.write(f'msgctxt "abler"\n')
             po_file.write(f'msgid "{key}"\n')
-            po_file.write(f'msgstr "{value}"\n\n\n')
+            po_file.write(f'msgstr "{value[1]}"\n\n\n')
         
     print(f"total {count} mismatch")
 
@@ -62,17 +65,19 @@ def match_po_with_csv(csvfile: str, pofile: str):
                     trans_body = []
 
             for trans_item in trans_body_all:
+                if trans_item[0].startswith('msgctxt "abler"'):
+                    original_word = trans_item[1]
+                    translated_word = trans_item[2]
+                else:
+                    original_word = trans_item[0]
+                    translated_word = trans_item[1]
 
-                # 'msgctxt "abler"'가 아니면 pass
-                if not trans_item[0].startswith('msgctxt "abler"'):
-                    continue
-
-                if trans_item[1].startswith("msgid"):
-                    msgid = trans_item[1].split('"')[1]
+                if original_word.startswith("msgid"):
+                    msgid = original_word.split('"')[1]
                     if msgid in csv_dict:
                         msg_to_check = csv_dict[msgid]
-                if trans_item[2].startswith("msgstr") and msg_to_check:
-                    msgstr = trans_item[2].split('"')[1]
+                if translated_word.startswith("msgstr") and msg_to_check:
+                    msgstr = translated_word.split('"')[1]
                     if msgstr != msg_to_check:
                         print(f"PO file의 '{msgstr}'가 CSV파일의 '{msg_to_check}'와 일치하지 않습니다.")
                         err_count += 1

--- a/translate.py
+++ b/translate.py
@@ -10,27 +10,29 @@ def csv2po(filepath: str, outfile: str):
     with open(filepath, "r") as csv_file:
         csv_reader = csv.reader(csv_file, delimiter=",")
         for row in csv_reader:
-            # 이미 딕셔너리에 값이 있으면 번역이 중복으로 들어간 경우
             if csv_dict.get(row[0]):
-                print(f"csv file의 '{row[0]}'가 중복으로 들어가 있습니다.")
-                count += 1
+                # 번역이 중복이고 값은 다른 경우
+                if row[1] != csv_dict.get(row[0]):
+                    print(f"csv file의 '{row[0]}'가 중복으로 들어가 있습니다.")
+                    count += 1
+                # 번역이 중복이고 값도 같은 경우
+                else:
+                    pass
             else:
                 csv_dict[row[0]] = row[1]
 
-    with open(filepath, "r") as csv_file:
-        csv_reader = csv.reader(csv_file, delimiter=",")
-        with open(outfile, "w") as po_file:
-            for i, row in enumerate(csv_reader):
-                if i == 0:
-                    continue
+    with open(outfile, "w") as po_file:
+        for i, (key, value) in enumerate(csv_dict.items()):
+            if i == 0:
+                continue
 
-                # msg도 영어로 들어가 번역이 필요 없는 경우
-                if row[0] == row[1]:
-                    continue
+            # msg도 영어로 들어가 번역이 필요 없는 경우
+            if key == value:
+                continue
 
-                po_file.write(f'msgctxt "abler"\n')
-                po_file.write(f'msgid "{row[0]}"\n')
-                po_file.write(f'msgstr "{row[1]}"\n\n\n')
+            po_file.write(f'msgctxt "abler"\n')
+            po_file.write(f'msgid "{key}"\n')
+            po_file.write(f'msgstr "{value}"\n\n\n')
         
     print(f"total {count} mismatch")
 

--- a/translate.py
+++ b/translate.py
@@ -92,7 +92,7 @@ if __name__ == "__main__":
         if check_file_exist(input_csv):
             csv2po(input_csv, "output.po")
     
-    if sys.argv[1] == "--test" and len(sys.argv)>3:
+    elif sys.argv[1] == "--test" and len(sys.argv)>3:
         input_csv = sys.argv[2]
         output_po = sys.argv[3]
         if check_file_exist(input_csv) and check_file_exist(output_po):    

--- a/translate.py
+++ b/translate.py
@@ -31,8 +31,8 @@ def csv2po(filepath: str, outfile: str):
             if key == value[1]:
                 continue
             
-            # "기능명"일 때만 msgctxt "abler" 넣기
-            if value[0] == "기능명":
+            # "툴팁"일 때만 msgctxt "abler" pass
+            if value[0] != "툴팁":
                 po_file.write(f'msgctxt "abler"\n')
             po_file.write(f'msgid "{key}"\n')
             po_file.write(f'msgstr "{value[1]}"\n\n\n')


### PR DESCRIPTION
## 관련 링크
[링크](URL)

## 발제/내용

- csv파일 변경에 따른 translate.py 수정
- 다국어 번역 적용을 위한 에이블러 코드 수정

## 대응

### 어떤 조치를 취했나요?

- [x] translate.py 수정
- csv 파일에서 중복으로 들어가는 문구 중 번역이 다를 때만 안내문구 띄움
- 툴팁은 `msgctxt "abler"` 제외
- [x] 에이블러 코드 내 bl_translation_context = "abler" 빠져 있는 내용 추가