### PR TITLE
카메라 속성 UI 및 입력값 범위 조정

### DIFF
--- a/source/blender/makesrna/intern/rna_camera.c
+++ b/source/blender/makesrna/intern/rna_camera.c
@@ -578,7 +578,7 @@ void RNA_def_camera(BlenderRNA *brna)
   RNA_def_property_range(prop, 1.0f, 100.0f);
   RNA_def_property_ui_range(prop, 1.0f, 50.0f, 100, 4);
   RNA_def_property_ui_text(
-      prop, "Focal Length", "Adjust perspective camera lens value in millimeters (Range: 1~5000)");
+      prop, "Focal Length", "Adjust perspective camera lens value in millimeters (Range: 1~100)");
   RNA_def_property_update(prop, NC_OBJECT | ND_DRAW, "rna_Camera_update");
 
   prop = RNA_def_property(srna, "sensor_width", PROP_FLOAT, PROP_DISTANCE_CAMERA);

--- a/source/blender/makesrna/intern/rna_camera.c
+++ b/source/blender/makesrna/intern/rna_camera.c
@@ -458,8 +458,8 @@ static void rna_def_camera_dof_settings_data(BlenderRNA *brna)
                            "F-Stop",
                            "Adjust F-stop ratio (lower numbers give more defocus, higher numbers "
                            "give a sharper image)");
-  RNA_def_property_range(prop, 0.0f, FLT_MAX);
-  RNA_def_property_ui_range(prop, 0.1f, 128.0f, 10, 1);
+  RNA_def_property_range(prop, 0.0f, 128.0f);
+  RNA_def_property_ui_range(prop, 0.0f, 5.0f, 10, 1);
   RNA_def_property_update(prop, NC_OBJECT | ND_DRAW, "rna_Camera_dof_update");
 
   prop = RNA_def_property(srna, "aperture_blades", PROP_INT, PROP_NONE);

--- a/source/blender/makesrna/intern/rna_camera.c
+++ b/source/blender/makesrna/intern/rna_camera.c
@@ -575,8 +575,8 @@ void RNA_def_camera(BlenderRNA *brna)
 
   prop = RNA_def_property(srna, "lens", PROP_FLOAT, PROP_DISTANCE_CAMERA);
   RNA_def_property_float_sdna(prop, NULL, "lens");
-  RNA_def_property_range(prop, 1.0f, FLT_MAX);
-  RNA_def_property_ui_range(prop, 1.0f, 5000.0f, 100, 4);
+  RNA_def_property_range(prop, 1.0f, 100.0f);
+  RNA_def_property_ui_range(prop, 1.0f, 50.0f, 100, 4);
   RNA_def_property_ui_text(
       prop, "Focal Length", "Adjust perspective camera lens value in millimeters (Range: 1~5000)");
   RNA_def_property_update(prop, NC_OBJECT | ND_DRAW, "rna_Camera_update");


### PR DESCRIPTION
## 관련 링크

[카메라 속성 UI 및 입력값 범위 조정](https://www.notion.so/acon3d/UI-d4978c40495746858306bef81079b80d)


## 발제/내용

- DOF 속성 (Focus Distance, F-stop) 의 UI 및 입력 설정값 범위가 사양서와 다름
- 번역 작업 후 merge
  - [카메라 속성 UI 및 입력값 범위 조정 번역 #36](https://github.com/ACON3D/blender-translations/pull/36#pullrequestreview-1178826307)


## 대응

### 어떤 조치를 취했나요?

진행 상황 및 조치

- `rna_camera.c` 에 DOF 관련 UI 및 입력 범위가 정의되어 있음.
- F-stop
    
    ```c
    prop = RNA_def_property(srna, "aperture_fstop", PROP_FLOAT, PROP_NONE);
    RNA_def_property_range(prop, 0.0f, 128.0f);
    RNA_def_property_ui_range(prop, 0.0f, 5.0f, 10, 1);
    ```
    
- Focus Distance
    
    ```c
    prop = RNA_def_property(srna, "focus_distance", PROP_FLOAT, PROP_DISTANCE);
    RNA_def_property_range(prop, 1.0f, 50.0f);
    RNA_def_property_ui_range(prop, 1.0f, 100.0f, 1, 2);
    ```