### PR TITLE
스플래시 스크린이 2개 뜨는 문제

### DIFF
--- a/release/scripts/startup/abler/operators.py
+++ b/release/scripts/startup/abler/operators.py
@@ -46,8 +46,6 @@ class Acon3dLogoutOperator(bpy.types.Operator):
             # 아이디 기억하기 체크박스 상태와 아이디 불러오기
             prop.remember_username = read_remembered_checkbox()
             prop.username = read_remembered_username()
-
-            bpy.ops.wm.splash("INVOKE_DEFAULT")
         else:
             print("No login session file")
 


### PR DESCRIPTION
## 관련 링크
[이슈 카드](https://www.notion.so/acon3d/Issue-0078-2-c4450052af9a4eafbd889d148f324012)
[태스크 카드](https://www.notion.so/acon3d/2-d0deca81cba347ae8526c30981a2949d)

## 발제/내용

- 로그 아웃 후 로그인 스플래시 모달이 두 개 보이는 현상

## 대응

### 어떤 조치를 취했나요?

- `bpy.ops.wm.splash("INVOKE_DEFAULT")` 이 두 번 불러지고 있어서 `Acon3dLogoutOperator.execute`에서 삭제