### PR TITLE
파일 뷰어의 display mode 차이나는 에러

### DIFF
--- a/release/scripts/startup/abler/camera_tab/background_control.py
+++ b/release/scripts/startup/abler/camera_tab/background_control.py
@@ -128,14 +128,8 @@ class OpenCustomBackgroundOperator(bpy.types.Operator, AconImportHelper):
         return {"FINISHED"}
 
     def draw(self, context):
-        # FileBrowser UI 변경
+        super().draw(context)
         space = context.space_data
-        params = space.params
-
-        params.display_type = "THUMBNAIL"
-        params.display_size = "LARGE"
-        params.sort_method = "FILE_SORT_TIME"
-        params.use_sort_invert = True
         space.show_region_tool_props = False
 
 

--- a/release/scripts/startup/abler/camera_tab/background_control.py
+++ b/release/scripts/startup/abler/camera_tab/background_control.py
@@ -89,12 +89,8 @@ class OpenDefaultBackgroundOperator(bpy.types.Operator, AconImportHelper):
         return {"RUNNING_MODAL"}
 
     def draw(self, context):
-        # FileBrowser UI 변경
+        super().draw(context)
         space = context.space_data
-        params = space.params
-
-        params.display_type = "THUMBNAIL"
-        params.display_size = "LARGE"
         space.show_region_tool_props = False
         space.show_region_ui = False
         space.show_region_toolbar = False

--- a/release/scripts/startup/abler/camera_tab/background_control.py
+++ b/release/scripts/startup/abler/camera_tab/background_control.py
@@ -125,8 +125,7 @@ class OpenCustomBackgroundOperator(bpy.types.Operator, AconImportHelper):
 
     def draw(self, context):
         super().draw(context)
-        space = context.space_data
-        space.show_region_tool_props = False
+        context.space_data.show_region_tool_props = False
 
 
 class Acon3dBackgroundPanel(bpy.types.Panel):

--- a/release/scripts/startup/abler/general_tab/general.py
+++ b/release/scripts/startup/abler/general_tab/general.py
@@ -387,6 +387,8 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
     )
 
     def draw(self, context):
+        super().draw(context)
+
         layout = self.layout
         row = layout.row()
         row.label(text="Import files onto the viewport.")

--- a/release/scripts/startup/abler/lib/import_file.py
+++ b/release/scripts/startup/abler/lib/import_file.py
@@ -52,6 +52,6 @@ class AconImportHelper(ImportHelper):
 
         params.display_type = "THUMBNAIL"
         params.display_size = "LARGE"
-        params.recursion_level = None
+        params.recursion_level = "NONE"
         params.sort_method = "FILE_SORT_TIME"
-        params.use_sort_revert = True
+        params.use_sort_invert = True

--- a/release/scripts/startup/abler/lib/import_file.py
+++ b/release/scripts/startup/abler/lib/import_file.py
@@ -44,3 +44,14 @@ class AconImportHelper(ImportHelper):
         else:
             # 잘 되는 경우는 True 리턴
             return True
+
+    def draw(self, context):
+        # FileBrowser UI 변경
+        space = context.space_data
+        params = space.params
+
+        params.display_type = "THUMBNAIL"
+        params.display_size = "LARGE"
+        params.recursion_level = None
+        params.sort_method = "FILE_SORT_TIME"
+        params.use_sort_revert = True


### PR DESCRIPTION
## 관련 링크
[링크](https://www.notion.so/acon3d/display-mode-6063513ddd26417fa881fb5fd5e7a04b)

## 발제/내용

- 한번도 Background Default Image를 실행하지 않고 Blender File View Layer를 실행하면 Display Mode가 Vertical List 로 출력 됨.
- 한번이라도 Background default image 파일 레이어를 연 상태라면 이후에 어디에서  Blender File View Layer를 실행해도 Display Mode가  thumbnail view로 출력됨.

## 대응

### 어떤 조치를 취했나요?

- [x] 에이블러에서 파일 임포터로 쓰는 AconImportHelper 내에서 위의 요구사항을 무조건 적용하도록 변경
- [x] custom background image 에서는 추가로 왼쪽 설정창도 없어야 하기 때문에 오버라이딩 하는걸로 변경