### PR TITLE
Default Image > Display Mode의 드롭다운 Reverse Sorting이 비활성화 되어있는 문제

### DIFF
--- a/release/scripts/startup/abler/camera_tab/background_control.py
+++ b/release/scripts/startup/abler/camera_tab/background_control.py
@@ -95,6 +95,7 @@ class OpenDefaultBackgroundOperator(bpy.types.Operator, AconImportHelper):
 
         params.display_type = "THUMBNAIL"
         params.display_size = "LARGE"
+        params.use_sort_invert = True
         space.show_region_tool_props = False
         space.show_region_ui = False
         space.show_region_toolbar = False


### PR DESCRIPTION
## 관련 링크
[이슈 링크](https://www.notion.so/acon3d/Issue-0077-Camera-Background-Default-Image-Display-Mode-Reverse-Sorting-532ebad6aa3e416a987ce1abcd14892b)

## 발제/내용

- Camera>Background>Default Image 창의 상단 핸들에서 Display Mode의 우측 드롭다운 메뉴를 누를 경우
- Reverse Sorting이 비활성화 되어있음(체크 되어 있지 않음)

## 대응

### 어떤 조치를 취했나요?

- 해당 property를 True로 바꿔줌