### PR TITLE
Save Copy 초기 Filter, Toggle region 에러

### DIFF
--- a/release/scripts/startup/abler/lib/tracker/_tracker.py
+++ b/release/scripts/startup/abler/lib/tracker/_tracker.py
@@ -44,6 +44,8 @@ class EventKind(enum.Enum):
     save_fail = "Save Fail"
     save_as = "save_as"
     save_as_fail = "Save As Fail"
+    save_copy = "Save Copy"
+    save_copy_fail = "Save Copy Fail"
     group_navigate_bottom = "Group Navigate Bottom"
     group_navigate_top = "Group Navigate Top"
     group_navigate_down = "Group Navigate Down"
@@ -251,6 +253,12 @@ class Tracker(metaclass=ABCMeta):
 
     def save_as_fail(self):
         self._track(EventKind.save_as_fail.value)
+
+    def save_copy(self):
+        self._track(EventKind.save_copy.value)
+
+    def save_copy_fail(self):
+        self._track(EventKind.save_copy_fail.value)
 
     def group_navigate_bottom(self):
         self._track(EventKind.group_navigate_bottom.value)

--- a/release/scripts/startup/bl_ui/space_topbar.py
+++ b/release/scripts/startup/bl_ui/space_topbar.py
@@ -280,7 +280,7 @@ class TOPBAR_MT_file(Menu):
         layout.operator_context = 'INVOKE_AREA'
         layout.operator("acon3d.save_as", text="Save As...")
         layout.operator_context = 'INVOKE_AREA'
-        layout.operator("wm.save_as_mainfile", text="Save Copy...").copy = True
+        layout.operator("acon3d.save_copy", text="Save Copy...")
 
         layout.separator()
 


### PR DESCRIPTION
## 관련 링크
[링크](https://www.notion.so/acon3d/Save-Copy-Filter-Toggle-region-9f196818884b4245a6b36200399ebb8d)

## 발제/내용

- Save Copy가 에이블러 오퍼레이터가 아닌 블렌더 내장 오퍼레이터 `bpy.ops.wm.save_as_mainfile(copy=True)`기 때문에 발생
- 내장 오퍼레이터를 쓰기 때문에 Open Recent에도 등록이 안되고 있음

## 대응

### 어떤 조치를 취했나요?

 - [x]  `bpy.ops.wm.save_as_mainfile(copy=True)`를 감싸 `acon3d.save_copy` 오퍼레이터를 새로 만듦