### PR TITLE
Object Properties에서 Shadow 토글 설정이 파일에 저장되지 않는 문제

### DIFF
--- a/release/scripts/startup/abler/lib/materials/materials_handler.py
+++ b/release/scripts/startup/abler/lib/materials/materials_handler.py
@@ -236,7 +236,6 @@ def set_material_parameters_by_type(mat: Material) -> None:
         toonNode.inputs[3].default_value = 1
     elif type == "Diffuse":
         mat.blend_method = "CLIP"
-        mat.ACON_prop.toggle_shadow = True
         toonNode.inputs[1].default_value = 0
         toonNode.inputs[3].default_value = 1
     elif type == "Glow":


### PR DESCRIPTION
## 관련 링크

[Object Properties에서 Shadow 토글 설정이 파일에 저장되지 않음](https://www.notion.so/acon3d/Object-Properties-Shadow-3426c2b724e449abafaa6a5b2d8713cf)


## 발제/내용

- **오브젝트 선택 → Style → Object Properties → Shadow 토글 해제 → 저장 → 저장된 파일 열기**하면 Shadow 토글이 계속 켜져있음
- 파일에 Shadow 토글 상태가 저장되지 않고 있음


## 대응

### 현상의 원인

- Slack Help
    
    [https://acontainer.slack.com/archives/C02K1NPTV42/p1668424529542679](https://acontainer.slack.com/archives/C02K1NPTV42/p1668424529542679)
    
- 파일 오픈할 때, 재질을 다음 과정으로 설정함
    - 각 오브젝트에 `toggle_each_shadow()` 가 실행되면서 각 재질의 `mat.ACON_prop.toggle_shadow` 로 그림자 정보를 불러옴
    - 그런데 `pref.py` 에서 `apply_ACON_toon_style()` 을 실행하는데, 여기에서 `set_material_parameters_by_type()` 함수가 실행됨.

### 진행 상황 및 조치

- 위에서 언급한 함수 내부에서 **Diffuse** 재질의 그림자를 항상 `True` 로 설정하고 있어 해당 부분 삭제
