### PR TITLE
Full Render 시에 배경이미지 없이 렌더됨

### DIFF
--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -589,7 +589,10 @@ class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
         super().post_render(dummy, dum)
 
     def prepare_render(self):
-        render.clear_compositor()
+        _, _, render_type = self.render_queue[0]
+        compNodes = render.clear_compositor()
+        if render_type == "full":
+            render.setup_background_images_compositor(*compNodes)
         render.match_object_visibility()
 
     # render_type - line, shadow, texture


### PR DESCRIPTION
## 관련 링크
[이슈 카드](https://www.notion.so/acon3d/Issue-0085-Full-Render-16c5243ee4b24f5780cfbc8d885b5bf2)
[태스크 카드](https://www.notion.so/acon3d/Full-Render-a0087ba1ea5e494c9de1755dab20a4c4)

## 발제/내용

- 풀렌더 시 배경이미지가 보이지 않는 오류가 있음

## 대응

### 어떤 조치를 취했나요?

- Acon3dRenderDirOperator 의 prepare_render 에서 render_type full 인 경우setup_background_images_compositor 실행시키도록 함