### PR TITLE
씬 추가 생성 후 삭제 시 에러 변경사항

### DIFF
--- a/release/scripts/startup/abler/scene_tab/scene_control.py
+++ b/release/scripts/startup/abler/scene_tab/scene_control.py
@@ -82,8 +82,14 @@ class CreateSceneOperator(bpy.types.Operator):
 
         prop = context.window_manager.ACON_prop
         # self.name이 씬 이름 목록에 있을 땐 번호 추가
-        if self.name in prop.scene_col:
-            self.name += ".001"
+        while self.name in prop.scene_col:
+            scene_name = self.name.rsplit(".")[0]
+            post_fix = self.name.rsplit(".")[-1]
+            if post_fix.isnumeric():
+                post_fix = str(int(post_fix) + 1).zfill(3)
+            else:
+                post_fix = "001"
+            self.name = scene_name + "." + post_fix
 
         old_scene = context.scene
         new_scene = scenes.create_scene(old_scene, self.preset, self.name)

--- a/release/scripts/startup/abler/scene_tab/scene_control.py
+++ b/release/scripts/startup/abler/scene_tab/scene_control.py
@@ -83,8 +83,7 @@ class CreateSceneOperator(bpy.types.Operator):
         prop = context.window_manager.ACON_prop
         # self.name이 씬 이름 목록에 있을 땐 번호 추가
         while self.name in prop.scene_col:
-            scene_name = self.name.rsplit(".")[0]
-            post_fix = self.name.rsplit(".")[-1]
+            scene_name, post_fix = self.name.rsplit(".", 1)
             if post_fix.isnumeric():
                 post_fix = str(int(post_fix) + 1).zfill(3)
             else:


### PR DESCRIPTION
## 관련 링크
[링크](https://github.com/ACON3D/blender/compare/feature/skip-same-scene-name?expand=1)

## 발제/내용

- 이전 PR(https://github.com/ACON3D/blender/pull/225) 에서 post_fix `.001`을 붙여도 씬에 동일한 이름이 있을 때의 처리가 없었음

## 대응

### 어떤 조치를 취했나요?

- post_fix를 while 안에서 확인하도록 변경