### PR TITLE
Snap 기능 비활성화

### DIFF
--- a/release/scripts/startup/abler/lib/scenes.py
+++ b/release/scripts/startup/abler/lib/scenes.py
@@ -171,7 +171,7 @@ def add_scene_items(self, context: Context) -> List[Tuple[str, str, str]]:
 
 def snap_to_face():
     scene = bpy.context.scene
-    scene.tool_settings.use_snap = True
+    scene.tool_settings.use_snap = False
     scene.tool_settings.snap_elements = {"FACE"}
 
 


### PR DESCRIPTION
## 관련 링크

[Snap 기능을 비활성화 하기](https://www.notion.so/acon3d/Snap-8d631eebd5a8401b9b182a17420a72bd)


## 발제/내용

- `Snap to ...` 기능이 활성화가 되어 있는데, 사양서 기준으로 비활성화가 되어야함


## 대응

### 어떤 조치를 취했나요?

- 해당 기능을 비활성화함.