### PR TITLE
파일 뷰어에서 빈 곳에 더블클릭시 에러

### DIFF
--- a/release/scripts/presets/keyconfig/keymap_data/abler_default.py
+++ b/release/scripts/presets/keyconfig/keymap_data/abler_default.py
@@ -2034,7 +2034,7 @@ def km_file_browser_main(params):
     )
 
     items.extend([
-        ("file.execute", {"type": 'LEFTMOUSE', "value": 'DOUBLE_CLICK'}, None),
+        ("file.mouse_execute", {"type": 'LEFTMOUSE', "value": 'DOUBLE_CLICK'}, None),
         # Both .execute and .select are needed here. The former only works if
         # there's a file operator (i.e. not in regular editor mode) but is
         # needed to load files. The latter makes selection work if there's no


### PR DESCRIPTION
## 관련 링크
[링크](https://www.notion.so/acon3d/d6f8de22ac6c4aba8f5e88fa83aef26e)

## 발제/내용

- 렌더 파일 뷰어에서 더블클릭 시 렌더가 됨
- 파일 뷰어에서 빈 곳을 더블클릭할 때 동작이 발생하지 않아야함

## 대응

### 어떤 조치를 취했나요?

- 블렌더에선 파일 뷰어에서 빈 곳을 클릭했을 때 실행이 되지 않음 → 블렌더와 에이블러에 차이가 있다고 판단
- 확인 결과 keymap에서 블렌더는 File Browser 내 Execute File Window가 `file.mouse_execute`이고 에이블러는 `file.execute`였음.
- 에이블러 키맵에서 file.execute → file.mouse_execute 로 변경해주니 파일 뷰어에서 빈 곳을 더블클릭해도 아무 동작을 하지 않음!