### PR TITLE
상관없는 프로세스들의 오류에서도 로그인이 안되는 현상이 있어서 이를 고침

### DIFF
--- a/release/scripts/startup/abler/lib/login.py
+++ b/release/scripts/startup/abler/lib/login.py
@@ -8,8 +8,14 @@ def is_process_single() -> bool:
     Window: blender / macOS: abler
     """
     # TODO: Window 에서 프로세스 이름 abler 로 변경하기
-    process_count: int = sum(
-        i.startswith("ABLER") or i.startswith("blender") or i.startswith("abler")
-        for i in (p.name() for p in psutil.process_iter())
-    )
-    return process_count <= 1
+    # psutil에서 iteration하면서 process name을 가져올 수 없는 경우가 있어서 try-except로 처리해줌.
+    try:
+        process_count: int = sum(
+            i.startswith("ABLER") or i.startswith("blender") or i.startswith("abler")
+            for i in (p.name() for p in psutil.process_iter())
+        )
+    except Exception as e:
+        print(e)
+        return True
+    else:
+        return process_count <= 1


### PR DESCRIPTION
## 관련 링크
[링크](URL)

## 발제/내용

- 로그인 시에 계속 fail이 나서, 이유를 봤더니 psutil을 사용한 process 이름 받아오는 부분에서 해당 머신의 process들 중에서 상관 없는 에러가 나도 터지는 현상이 있어서 이를 고침

## 대응

### 어떤 조치를 취했나요?

- process count 받아오는 부분을 try-except처리하고 exception이 있을 경우 그냥 True를 반환하도록 처리함.