### PR TITLE
여러 에이블러 클라이언트 실행 중에 로그아웃을 해도 아무 반응이 없음

### DIFF
--- a/release/scripts/startup/abler/operators.py
+++ b/release/scripts/startup/abler/operators.py
@@ -38,13 +38,14 @@ class Acon3dLogoutOperator(bpy.types.Operator):
         #       render.py에 있는 event timer를 참고하면 좋을듯
         if os.path.exists(path_cookiesFile):
             os.remove(path_cookiesFile)
+
+        # login_status가 SUCCESS가 아닌 상태에서 modal_operator를 실행
         prop.login_status = "IDLE"
         bpy.ops.acon3d.modal_operator("INVOKE_DEFAULT")
 
         # 아이디 기억하기 체크박스 상태와 아이디 불러오기
         prop.remember_username = read_remembered_checkbox()
         prop.username = read_remembered_username()
-        # login_status가 SUCCESS가 아닌 상태에서 modal_operator를 실행
         tracker.logout()
 
         return {"FINISHED"}

--- a/release/scripts/startup/abler/operators.py
+++ b/release/scripts/startup/abler/operators.py
@@ -38,13 +38,13 @@ class Acon3dLogoutOperator(bpy.types.Operator):
         #       render.py에 있는 event timer를 참고하면 좋을듯
         if os.path.exists(path_cookiesFile):
             os.remove(path_cookiesFile)
+        prop.login_status = "IDLE"
         bpy.ops.acon3d.modal_operator("INVOKE_DEFAULT")
 
         # 아이디 기억하기 체크박스 상태와 아이디 불러오기
         prop.remember_username = read_remembered_checkbox()
         prop.username = read_remembered_username()
         # login_status가 SUCCESS가 아닌 상태에서 modal_operator를 실행
-        prop.login_status = "IDLE"
         tracker.logout()
 
         return {"FINISHED"}

--- a/release/scripts/startup/abler/operators.py
+++ b/release/scripts/startup/abler/operators.py
@@ -38,17 +38,13 @@ class Acon3dLogoutOperator(bpy.types.Operator):
         #       render.py에 있는 event timer를 참고하면 좋을듯
         if os.path.exists(path_cookiesFile):
             os.remove(path_cookiesFile)
+        bpy.ops.acon3d.modal_operator("INVOKE_DEFAULT")
 
-            # login_status가 SUCCESS가 아닌 상태에서 modal_operator를 실행
-            prop.login_status = "IDLE"
-            bpy.ops.acon3d.modal_operator("INVOKE_DEFAULT")
-
-            # 아이디 기억하기 체크박스 상태와 아이디 불러오기
-            prop.remember_username = read_remembered_checkbox()
-            prop.username = read_remembered_username()
-        else:
-            print("No login session file")
-
+        # 아이디 기억하기 체크박스 상태와 아이디 불러오기
+        prop.remember_username = read_remembered_checkbox()
+        prop.username = read_remembered_username()
+        # login_status가 SUCCESS가 아닌 상태에서 modal_operator를 실행
+        prop.login_status = "IDLE"
         tracker.logout()
 
         return {"FINISHED"}


### PR DESCRIPTION
## 관련 링크
[이슈 #0076](https://www.notion.so/acon3d/Issue-0079-d42c7df26a1040379790c41289d83c2c)

## 재현 경로

- 에이블러를 클라이언트를 두 개 실행 후, 둘다 로그인

## 현재 상태

- 한 클라이언트 (A) 에서 정상적으로 로그아웃
- 다른 클라이언트 (B) 에서 로그아웃하면 아무 반응이 없음
    - 혹은 파이썬 에러 메세지가 출력됨

       ![image](https://user-images.githubusercontent.com/43770096/202137188-4ee47ba7-8200-4e36-8a4a-02db38f2ab47.png)

## 적정 상태

- 클라이언트 A에서 로그아웃을 하더라도 켜져있는 클라이언트 B는 에이블러를 사용하는데 이슈가 없음
- 클라이언트 B에서 로그아웃을 시도했을 시에, 로그아웃이 가능하며, 에러메세지가 출력되지 않음

## 대응

### 어떤 조치를 취했나요?

- path_cookiesFile이 존재하지 않아도 로그아웃 오퍼레이터 실행 시에 제대로 기작이 작동되도록 수정