### PR TITLE
파일 브라우저의 옵션이 변경 안되는 문제

### DIFF
--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -18,7 +18,6 @@
 
 
 import bpy, platform, os, subprocess, datetime
-from bpy_extras.io_utils import ImportHelper
 from ..lib import render, cameras
 from ..lib.file_view import file_view_title
 from ..lib.materials import materials_handler
@@ -231,6 +230,7 @@ class Acon3dRenderQuickOperator(Acon3dRenderOperator, AconExportHelper):
     filter_glob: bpy.props.StringProperty(default="*.png", options={"HIDDEN"})
 
     def __init__(self):
+        AconExportHelper.__init__(self)
         scene = bpy.context.scene
         self.filepath = f"{scene.name}{self.filename_ext}"
 
@@ -302,6 +302,8 @@ class Acon3dRenderDirOperator(Acon3dRenderOperator, AconImportHelper):
     filter_glob: bpy.props.StringProperty(default="Folders", options={"HIDDEN"})
 
     def __init__(self):
+        AconImportHelper.__init__(self)
+
         # Get basename without file extension
         self.filepath = bpy.context.blend_data.filepath
 

--- a/release/scripts/startup/abler/lib/import_file.py
+++ b/release/scripts/startup/abler/lib/import_file.py
@@ -4,6 +4,10 @@ from bpy_extras.io_utils import ImportHelper, ExportHelper
 
 
 class AconImportHelper(ImportHelper):
+    def __init__(self) -> None:
+        super().__init__()
+        self.set_option = None
+
     def check_path(self, accepted: list[str]) -> bool:
         """
         :param accepted: 허용할 extension 리스트
@@ -46,27 +50,33 @@ class AconImportHelper(ImportHelper):
             return True
 
     def draw(self, context):
-        # FileBrowser UI 변경
-        space = context.space_data
-        params = space.params
+        # FileBrowser UI 설정이 맨처음에만 적용되게끔
+        if not self.set_option:
+            params = context.space_data.params
+            params.display_type = "THUMBNAIL"
+            params.display_size = "LARGE"
+            params.recursion_level = "NONE"
+            params.sort_method = "FILE_SORT_TIME"
+            params.use_sort_invert = True
+            params.use_filter = False
 
-        params.display_type = "THUMBNAIL"
-        params.display_size = "LARGE"
-        params.recursion_level = "NONE"
-        params.sort_method = "FILE_SORT_TIME"
-        params.use_sort_invert = True
-        params.use_filter = False
+            self.set_option = True
 
 
 class AconExportHelper(ExportHelper):
-    def draw(self, context):
-        # FileBrowser UI 변경
-        space = context.space_data
-        params = space.params
+    def __init__(self) -> None:
+        super().__init__()
+        self.set_option = None
 
-        params.display_type = "THUMBNAIL"
-        params.display_size = "LARGE"
-        params.recursion_level = "NONE"
-        params.sort_method = "FILE_SORT_TIME"
-        params.use_sort_invert = True
-        params.use_filter = False
+    def draw(self, context):
+        # FileBrowser UI 설정이 맨처음에만 적용되게끔
+        if not self.set_option:
+            params = context.space_data.params
+            params.display_type = "THUMBNAIL"
+            params.display_size = "LARGE"
+            params.recursion_level = "NONE"
+            params.sort_method = "FILE_SORT_TIME"
+            params.use_sort_invert = True
+            params.use_filter = False
+
+            self.set_option = True


### PR DESCRIPTION
## 관련 링크
[링크](https://www.notion.so/acon3d/7e2297af3d9d42f8b95fb880a2ecf743)

## 발제/내용

- 파일 브라우저의 옵션이 변경이 안됨

## 대응

### 어떤 조치를 취했나요?

- `FileSelectParams`를 관리하는 함수는 `draw()` 라 draw내에서 파일 뷰어 옵션을 지정해줘야함
- `draw()`는 매번 그리기 때문에, 파일 뷰어 옵션을 지정해주면 **변경이 불가능함**(변경해도 draw에서 다시 옵션의 원래 설정값으로 그리기 때문)
- init에서 self.set_option 변수를 만들어 self.set_option이 None일 때만 draw에서 그리고 난 뒤 self.set_option = True로 설정 → 맨 처음 파일 브라우저를 열 때만 설정값이 적용
- 동일한 처리를 AconExportHelper에도 적용
- AconImportHelper, AconExportHelper를 상속받는 클래스 내 init에서 self.set_option이 상속받게끔 `super().__init__()` , `AconExportHelper.__init__()`의 처리를 해줌