### PR TITLE
프로그레스 템플릿 UI 조정

### DIFF
--- a/release/scripts/startup/abler/export_tab/export_control.py
+++ b/release/scripts/startup/abler/export_tab/export_control.py
@@ -117,12 +117,19 @@ class Acon3dHighQualityRenderPanel(bpy.types.Panel):
             box.label(text=info.render_scene_name)
             box.template_progress_bar(progress=0.0)
 
-        sub = box.split(align=True, factor=0.25)
+        sub = box.split(align=True, factor=0.5)
 
-        col = sub.column(align=True)
-        col.label(text="Start", icon="DOT")
-        col.label(text="Finish", icon="DOT")
-        col.label(text="Time Span", icon="DOT")
+        sub2 = sub.split(align=True, factor=0.15)
+
+        col = sub2.column(align=True)
+        col.label(icon="DOT")
+        col.label(icon="DOT")
+        col.label(icon="DOT")
+
+        col = sub2.column(align=True)
+        col.label(text="Start")
+        col.label(text="Finish")
+        col.label(text="Time Span")
 
         col = sub.column(align=True)
         col.label(text=": - - -")
@@ -170,12 +177,19 @@ class Acon3dHighQualityRenderPanel(bpy.types.Panel):
             else:
                 col.template_progress_bar(progress=1.0)
 
-        sub = box.split(align=True, factor=0.25)
+        sub = box.split(align=True, factor=0.5)
 
-        col = sub.column(align=True)
-        col.label(text="Start", icon="DOT")
-        col.label(text="Finish", icon="DOT")
-        col.label(text="Time Span", icon="DOT")
+        sub2 = sub.split(align=True, factor=0.15)
+
+        col = sub2.column(align=True)
+        col.label(icon="DOT")
+        col.label(icon="DOT")
+        col.label(icon="DOT")
+
+        col = sub2.column(align=True)
+        col.label(text="Start")
+        col.label(text="Finish")
+        col.label(text="Time Span")
 
         start_string = timestamp_to_string(progress_prop.start_date)
         end_string = timestamp_to_string(progress_prop.end_date)

--- a/release/scripts/startup/abler/general_tab/general.py
+++ b/release/scripts/startup/abler/general_tab/general.py
@@ -710,12 +710,19 @@ class Acon3dImportProgressPanel(bpy.types.Panel):
         total_progress = skp_prop.total_progress
         box.template_progress_bar(progress=total_progress)
 
-        sub = box.split(align=True, factor=0.25)
+        sub = box.split(align=True, factor=0.45)
 
-        col = sub.column(align=True)
-        col.label(text="Start", icon="DOT")
-        col.label(text="Finish", icon="DOT")
-        col.label(text="Time Span", icon="DOT")
+        sub2 = sub.split(align=True, factor=0.15)
+
+        col = sub2.column(align=True)
+        col.label(icon="DOT")
+        col.label(icon="DOT")
+        col.label(icon="DOT")
+
+        col = sub2.column(align=True)
+        col.label(text="Start")
+        col.label(text="Finish")
+        col.label(text="Time Span")
 
         start_string = timestamp_to_string(skp_prop.start_date)
         end_string = timestamp_to_string(skp_prop.end_date)

--- a/release/scripts/startup/abler/lib/string_helper.py
+++ b/release/scripts/startup/abler/lib/string_helper.py
@@ -5,5 +5,5 @@ def timestamp_to_string(timestamp, is_date=True):
     if not timestamp:
         return "- - -"
     if is_date:
-        return strftime("%Y-%m-%d %H:%M:%S", localtime(timestamp))
+        return strftime("%H:%M:%S", localtime(timestamp))
     return strftime("%H:%M:%S", gmtime(timestamp))

--- a/source/blender/editors/interface/interface_templates.c
+++ b/source/blender/editors/interface/interface_templates.c
@@ -5852,7 +5852,6 @@ void uiTemplateProgressBar(uiLayout *layout, bContext *C, const float progress)
                                                                           NULL);
 
     but_progress->progress = progress;
-    UI_but_func_tooltip_set(&but_progress->but, progress_tooltip_func, tip_arg, MEM_freeN);
   }
 }
 


### PR DESCRIPTION
REMOVE year/month/day from timestamp_to_string function REMOVE tooltip from progress

## 관련 링크
[태스크 카드](https://www.notion.so/acon3d/328b595e2570421d8aabadead6e5496d)
[슬랙 쓰레드](https://acontainer.slack.com/archives/C01K142MCNS/p1668734383299789)

## 발제/내용

- 프로그레스 템플릿에서 글자가 잘리는 이슈가 있어서 UI 조정

## 대응

### 어떤 조치를 취했나요?

- 아이콘과 텍스트를 분리하고, 날짜를 없애기 시각/시간만 남겨서 유저가 보는데에 불편함이 없도록 변경
- 기존에 삭제되었던 프로그레스바의 tooltip 코드가 작업하면서 다시 생겨난 것 같아 다시 삭제