### PR TITLE
.tar 파일 취약점 보완 (@TrellixVulnTeam)

### DIFF
--- a/build_files/buildbot/codesign/base_code_signer.py
+++ b/build_files/buildbot/codesign/base_code_signer.py
@@ -87,7 +87,29 @@ def extract_files(archive_filepath: Path,
     # TODO(sergey): Verify files in the archive have relative path.
 
     with tarfile.TarFile.open(archive_filepath, mode='r') as tar_file_handle:
-        tar_file_handle.extractall(path=extraction_dir)
+
+        import os
+
+        def is_within_directory(directory, target):
+
+            abs_directory = os.path.abspath(directory)
+            abs_target = os.path.abspath(target)
+
+            prefix = os.path.commonprefix([abs_directory, abs_target])
+
+            return prefix == abs_directory
+
+        def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
+
+            for member in tar.getmembers():
+                member_path = os.path.join(path, member.name)
+                if not is_within_directory(path, member_path):
+                    raise Exception("Attempted Path Traversal in Tar File")
+
+            tar.extractall(path, members, numeric_owner=numeric_owner)
+
+
+        safe_extract(tar_file_handle, path=extraction_dir)
 
 
 class BaseCodeSigner(metaclass=abc.ABCMeta):


### PR DESCRIPTION
## 관련 링크

[CVE-2007-4559](https://github.com/advisories/GHSA-gw9q-c7gh-j9vm)
[참고](https://isarc.tachyonlab.com/5338)


## 발제/내용

### Patching [CVE-2007-4559](https://github.com/advisories/GHSA-gw9q-c7gh-j9vm)

Hi, we are security researchers from the Advanced Research Center at [Trellix](https://www.trellix.com/). We have began a campaign to patch a widespread bug named [CVE-2007-4559](https://github.com/advisories/GHSA-gw9q-c7gh-j9vm).

[CVE-2007-4559](https://github.com/advisories/GHSA-gw9q-c7gh-j9vm) is a 15 year old bug in the Python tarfile package. By using extract() or extractall() on a tarfile object without sanitizing input, a maliciously crafted .tar file could perform a directory path traversal attack. We found at least one unsantized extractall() in your codebase and are providing a patch for you via pull request.

The patch essentially checks to see if all tarfile members will be extracted safely and throws an exception otherwise. We encourage you to use this patch or your own solution to secure against [CVE-2007-4559](https://github.com/advisories/GHSA-gw9q-c7gh-j9vm). Further technical information about the vulnerability can be found in this [blog](https://www.trellix.com/en-us/about/newsroom/stories/research/tarfile-exploiting-the-world.html).

If you have further questions you may contact us through this projects lead researcher [Kasimir Schulz](mailto:kasimir.schulz@trellix.com).