### PR TITLE
에이블러 실행할 때의 애드온 관리

### DIFF
--- a/release/scripts/startup/abler/lib/addons.py
+++ b/release/scripts/startup/abler/lib/addons.py
@@ -1,7 +1,8 @@
 import bpy
 
 
-addons = [
+enable_addons = ["io_skp"]
+disable_addons = [
     "io_anim_bvh",
     "io_curve_svg",
     "io_mesh_ply",
@@ -12,10 +13,16 @@ addons = [
 ]
 
 
-def disable_preference_addons():
+def preferences_addons():
     prefs_context = bpy.context.preferences
     prefs_ops = bpy.ops.preferences
 
-    for addon in addons:
+    # 활성 addons
+    for addon in enable_addons:
+        if prefs_context.addons.find(addon) == -1:
+            prefs_ops.addon_enable(module=addon)
+
+    # 비활성 addons
+    for addon in disable_addons:
         if prefs_context.addons.find(addon) != -1:
             prefs_ops.addon_disable(module=addon)

--- a/release/scripts/startup/abler/lib/addons.py
+++ b/release/scripts/startup/abler/lib/addons.py
@@ -19,7 +19,7 @@ def manage_preferences_addons():
 
     # 활성 addons
     for addon in enable_addons:
-        if addon in prefs_context.addons:
+        if addon not in prefs_context.addons:
             prefs_ops.addon_enable(module=addon)
 
     # 비활성 addons

--- a/release/scripts/startup/abler/lib/addons.py
+++ b/release/scripts/startup/abler/lib/addons.py
@@ -13,16 +13,16 @@ disable_addons = [
 ]
 
 
-def preferences_addons():
+def manage_preferences_addons():
     prefs_context = bpy.context.preferences
     prefs_ops = bpy.ops.preferences
 
     # 활성 addons
     for addon in enable_addons:
-        if prefs_context.addons.find(addon) == -1:
+        if addon in prefs_context.addons:
             prefs_ops.addon_enable(module=addon)
 
     # 비활성 addons
     for addon in disable_addons:
-        if prefs_context.addons.find(addon) != -1:
+        if addon in prefs_context.addons:
             prefs_ops.addon_disable(module=addon)

--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -9,7 +9,7 @@ from .lib import cameras, shadow, render, scenes, post_open
 from .lib.materials import materials_setup, materials_handler
 from .lib.tracker import tracker
 from .lib.version import update_file_version
-from .lib.addons import disable_preference_addons
+from .lib.addons import preferences_addons
 
 
 def init_setting(dummy):
@@ -50,8 +50,8 @@ def init_setting(dummy):
     prefs_input.use_zoom_to_mouse = True
     prefs_input.use_mouse_depth_navigate = True
 
-    # Import에 적용되는 Addons 비활성화
-    disable_preference_addons()
+    # ABLER 실행 addons 관리
+    preferences_addons()
 
 
 def hide_header(dummy):

--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -9,7 +9,7 @@ from .lib import cameras, shadow, render, scenes, post_open
 from .lib.materials import materials_setup, materials_handler
 from .lib.tracker import tracker
 from .lib.version import update_file_version
-from .lib.addons import preferences_addons
+from .lib.addons import manage_preferences_addons
 
 
 def init_setting(dummy):
@@ -51,7 +51,7 @@ def init_setting(dummy):
     prefs_input.use_mouse_depth_navigate = True
 
     # ABLER 실행 addons 관리
-    preferences_addons()
+    manage_preferences_addons()
 
 
 def hide_header(dummy):


### PR DESCRIPTION
## 관련 링크

[SKP Import 애드온을 에이블러 시작할 때 실행](https://www.notion.so/acon3d/SKP-Import-8dc51f62ae6740e8a09756b37bb9d9bb)


## 발제/내용

- 에이블러 실행할 때 SKP Importer 애드온이 켜지지 않고 있어 사용할 수 없는 에러 및 UI 에러가 발생함.


## 대응

### 어떤 조치를 취했나요?

- 에이블러를 실행할 때 활성/비활성 애드온을 관리함
- 기존 `disable_preference_addons()` 함수에서는 사용하지 않을 애드온을 끄기만 했으므로, 켜주는 애드온도 같은 함수에서 다루기 위해 함수명을 `preferences_addons()` 로 수정함
- 애드온을 켜주는 과정도 추가
- 켜야할 애드온 `io_skp` 를 추가