### PR TITLE
씬 추가 생성 후 지우려고 할 시 뜨는 에러 재처리

### DIFF
--- a/release/scripts/startup/abler/scene_tab/scene_control.py
+++ b/release/scripts/startup/abler/scene_tab/scene_control.py
@@ -83,7 +83,8 @@ class CreateSceneOperator(bpy.types.Operator):
         prop = context.window_manager.ACON_prop
         # self.name이 씬 이름 목록에 있을 땐 번호 추가
         while self.name in prop.scene_col:
-            scene_name, post_fix = self.name.rsplit(".", 1)
+            scene_name = self.name.rsplit(".")[0]
+            post_fix = self.name.rsplit(".")[-1]
             if post_fix.isnumeric():
                 post_fix = str(int(post_fix) + 1).zfill(3)
             else:


### PR DESCRIPTION
## 관련 링크
[링크](https://www.notion.so/acon3d/0c7d5198c5dd4dbe8d17109c444f4a51)

## 발제/내용

- 씬 생성시 파일 넘버링 과정에서 에러가 재발생해 태스크 재오픈합니다.

## 대응

### 어떤 조치를 취했나요?

- 튜플로 변경했다가 에러 발생해 다시 리스트 인덱싱으로 변경했습니다. (네임에 "."이 없는 경우 rsplit 결과가 튜플이 아님)