### PR TITLE
Scene 탭과 Style탭의 순서가 바뀐 에러

### DIFF
--- a/release/scripts/startup/abler/camera_tab/background_control.py
+++ b/release/scripts/startup/abler/camera_tab/background_control.py
@@ -135,6 +135,7 @@ class Acon3dBackgroundPanel(bpy.types.Panel):
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
     bl_translation_context = "abler"
+    bl_order = 11
     bl_options = {"HIDE_HEADER"}
 
     def draw(self, context):

--- a/release/scripts/startup/abler/camera_tab/camera_control.py
+++ b/release/scripts/startup/abler/camera_tab/camera_control.py
@@ -108,6 +108,7 @@ class Acon3dCameraControlPanel(bpy.types.Panel):
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
     bl_translation_context = "abler"
+    bl_order = 10
     bl_options = {"HIDE_HEADER"}
 
     def draw(self, context):

--- a/release/scripts/startup/abler/export_tab/export_control.py
+++ b/release/scripts/startup/abler/export_tab/export_control.py
@@ -37,6 +37,7 @@ class Acon3dHighQualityRenderPanel(bpy.types.Panel):
     bl_category = "Export"
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
+    bl_order = 30
     bl_translation_context = "abler"
     COMPAT_ENGINES = {"BLENDER_RENDER", "BLENDER_EEVEE", "BLENDER_WORKBENCH"}
 
@@ -218,6 +219,7 @@ class Acon3dQuickRenderPanel(bpy.types.Panel):
     bl_category = "Export"
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
+    bl_order = 31
     bl_translation_context = "abler"
     COMPAT_ENGINES = {"BLENDER_RENDER", "BLENDER_EEVEE", "BLENDER_WORKBENCH"}
 
@@ -247,6 +249,7 @@ class Acon3dSnipRenderPanel(bpy.types.Panel):
     bl_category = "Export"
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
+    bl_order = 32
     bl_translation_context = "abler"
     COMPAT_ENGINES = {"BLENDER_RENDER", "BLENDER_EEVEE", "BLENDER_WORKBENCH"}
 

--- a/release/scripts/startup/abler/general_tab/general.py
+++ b/release/scripts/startup/abler/general_tab/general.py
@@ -669,6 +669,7 @@ class Acon3dGeneralPanel(bpy.types.Panel):
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
     bl_translation_context = "abler"
+    bl_order = 1
     bl_options = {"HIDE_HEADER"}
 
     def draw_header(self, context):

--- a/release/scripts/startup/abler/scene_tab/layer_control.py
+++ b/release/scripts/startup/abler/scene_tab/layer_control.py
@@ -120,6 +120,7 @@ class Acon3dLayersPanel(bpy.types.Panel):
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
     bl_translation_context = "abler"
+    bl_order = 12
 
     def draw_header(self, context):
         layout = self.layout

--- a/release/scripts/startup/abler/scene_tab/object_control.py
+++ b/release/scripts/startup/abler/scene_tab/object_control.py
@@ -188,6 +188,7 @@ class Acon3dObjectPanel(bpy.types.Panel):
     bl_category = "Scenes"
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
+    bl_order = 11
 
     def draw_header(self, context):
         layout = self.layout

--- a/release/scripts/startup/abler/scene_tab/scene_control.py
+++ b/release/scripts/startup/abler/scene_tab/scene_control.py
@@ -172,6 +172,9 @@ class Acon3dScenesPanel(bpy.types.Panel):
     bl_category = "Scenes"
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
+    # 블렌더에선 bl_order가 앞이어도 bl_options = {"HIDE_HEADER"}인 패널부터 먼저 배치돼 기획안과 다르게 나옴
+    # camera -> scene -> style 순으로 배치하도록
+    # Acon3dCameraControlPanel의 bl_order 값과 맞춰 하위 패널로 인식하게끔 만듦
     bl_order = 10
     bl_translation_context = "abler"
 

--- a/release/scripts/startup/abler/scene_tab/scene_control.py
+++ b/release/scripts/startup/abler/scene_tab/scene_control.py
@@ -172,6 +172,7 @@ class Acon3dScenesPanel(bpy.types.Panel):
     bl_category = "Scenes"
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
+    bl_order = 10
     bl_translation_context = "abler"
 
     def draw_header(self, context):

--- a/release/scripts/startup/abler/style_tab/styles_control.py
+++ b/release/scripts/startup/abler/style_tab/styles_control.py
@@ -40,6 +40,7 @@ class Acon3dStylesPanel(bpy.types.Panel):
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
     bl_translation_context = "abler"
+    bl_order = 20
     bl_options = {"HIDE_HEADER"}
 
     def draw(self, context):


### PR DESCRIPTION
## 관련 링크
[링크](https://www.notion.so/acon3d/Scene-Style-7c0642e74c264d1a9624fb30093360db)

## 발제/내용

- Scene 탭과 Style탭의 순서가 바껴서 나옴
- init에서 register 순서는 적정상태 대로 General > Camera > Scene > Style > Export
- `bl_options = {"HIDE_HEADER"}` 이 적용된 패널 순서대로 배치됨(블렌더 내장 순서로 보임)

## 대응

### 어떤 조치를 취했나요?

- [x]  패널 내 bl_order 속성을 써서 배치
- [x]  Camera와 Scene의 bl_order 값을 맞춰줘 하위 패널로 인식하게끔 만들어 Camera > Scene > Style 로 배치 (주석도 추가)
![image](https://user-images.githubusercontent.com/87409148/203002105-2315f83e-2bae-43a2-ad52-531768a7ca58.png)

