### PR TITLE
Scene 탭 이름이 Scenes로 되어 있는 문제

### DIFF
--- a/release/scripts/startup/abler/scene_tab/layer_control.py
+++ b/release/scripts/startup/abler/scene_tab/layer_control.py
@@ -116,7 +116,7 @@ class Acon3dLayersPanel(bpy.types.Panel):
 
     bl_idname = "ACON3D_PT_Layer"
     bl_label = "Layers"
-    bl_category = "Scenes"
+    bl_category = "Scene"
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
     bl_translation_context = "abler"

--- a/release/scripts/startup/abler/scene_tab/object_control.py
+++ b/release/scripts/startup/abler/scene_tab/object_control.py
@@ -185,7 +185,7 @@ class GroupNavigateBottomOperator(bpy.types.Operator):
 class Acon3dObjectPanel(bpy.types.Panel):
     bl_idname = "ACON_PT_Object_Main"
     bl_label = "Object Control"
-    bl_category = "Scenes"
+    bl_category = "Scene"
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
     bl_order = 11
@@ -222,7 +222,7 @@ class Acon3dGroupNavigationPanel(bpy.types.Panel):
     bl_parent_id = "ACON_PT_Object_Main"
     bl_idname = "ACON_PT_Group_Navigation"
     bl_label = "Group Navigation"
-    bl_category = "Style"
+    bl_category = "Scene"
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
 

--- a/release/scripts/startup/abler/scene_tab/scene_control.py
+++ b/release/scripts/startup/abler/scene_tab/scene_control.py
@@ -169,7 +169,7 @@ class DeleteSceneOperator(bpy.types.Operator):
 class Acon3dScenesPanel(bpy.types.Panel):
     bl_idname = "ACON3D_PT_scenes"
     bl_label = "Scenes"
-    bl_category = "Scenes"
+    bl_category = "Scene"
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
     # 블렌더에선 bl_order가 앞이어도 bl_options = {"HIDE_HEADER"}인 패널부터 먼저 배치돼 기획안과 다르게 나옴


### PR DESCRIPTION
## 관련 링크
[링크](https://www.notion.so/acon3d/Scene-Scenes-24ebc55302ee45df9779edcf7b0052ab)

## 발제/내용

- Scenes -> Scene 탭 이름 변경

## 대응

### 어떤 조치를 취했나요?

- bl_category = "Scenes" -> "Scene"