### PR TITLE
파일을 열 때 File View Layer에서 필터 옵션이 꺼져있는 문제

### DIFF
--- a/release/scripts/startup/abler/camera_tab/background_control.py
+++ b/release/scripts/startup/abler/camera_tab/background_control.py
@@ -70,6 +70,7 @@ class OpenDefaultBackgroundOperator(bpy.types.Operator, AconImportHelper):
     index: bpy.props.IntProperty(name="Index", default=0, options={"HIDDEN"})
     filter_glob: bpy.props.StringProperty(default="*.png", options={"HIDDEN"})
     filepath: bpy.props.StringProperty()
+    use_filter = True
 
     def execute(self, context):
         if not self.check_path(accepted=["png", "jpg"]):
@@ -107,6 +108,7 @@ class OpenCustomBackgroundOperator(bpy.types.Operator, AconImportHelper):
     image_extension = "*.png;*.jpg;"
     index: bpy.props.IntProperty(name="Index", default=0, options={"HIDDEN"})
     filter_glob: bpy.props.StringProperty(default=image_extension, options={"HIDDEN"})
+    use_filter = True
 
     def invoke(self, context, event):
         with file_view_title("BACKGROUND"):

--- a/release/scripts/startup/abler/general_tab/general.py
+++ b/release/scripts/startup/abler/general_tab/general.py
@@ -227,6 +227,7 @@ class FileOpenOperator(bpy.types.Operator, AconImportHelper, BaseFileOpenOperato
     bl_translation_context = "abler"
 
     filter_glob: bpy.props.StringProperty(default="*.blend", options={"HIDDEN"})
+    use_filter = True
 
     def invoke(self, context, event):
         with file_view_title("OPEN"):
@@ -423,6 +424,7 @@ class ImportOperator(bpy.types.Operator, AconImportHelper):
     import_lookatme: bpy.props.BoolProperty(
         default=False,
     )
+    use_filter = True
 
     def draw(self, context):
         super().draw(context)
@@ -472,6 +474,7 @@ class ImportBlenderOperator(bpy.types.Operator, AconImportHelper):
     bl_translation_context = "*"
 
     filter_glob: bpy.props.StringProperty(default="*.blend", options={"HIDDEN"})
+    use_filter = True
 
     class SameFileImportError(Exception):
         def __init__(self):
@@ -578,6 +581,7 @@ class ImportFBXOperator(bpy.types.Operator, AconImportHelper):
     bl_translation_context = "abler"
 
     filter_glob: bpy.props.StringProperty(default="*.fbx", options={"HIDDEN"})
+    use_filter = True
 
     def invoke(self, context, event):
         with file_view_title("IMPORT"):
@@ -641,6 +645,7 @@ class ImportSKPOperator(bpy.types.Operator, AconImportHelper):
 
     filter_glob: bpy.props.StringProperty(default="*.skp", options={"HIDDEN"})
     import_lookatme: bpy.props.BoolProperty(default=False)
+    use_filter = True
 
     def invoke(self, context, event):
         with file_view_title("IMPORT"):

--- a/release/scripts/startup/abler/lib/import_file.py
+++ b/release/scripts/startup/abler/lib/import_file.py
@@ -4,6 +4,8 @@ from bpy_extras.io_utils import ImportHelper, ExportHelper
 
 
 class AconImportHelper(ImportHelper):
+    use_filter: bool = False
+
     def __init__(self) -> None:
         super().__init__()
         self.set_option = None
@@ -58,7 +60,8 @@ class AconImportHelper(ImportHelper):
             params.recursion_level = "NONE"
             params.sort_method = "FILE_SORT_TIME"
             params.use_sort_invert = True
-            params.use_filter = False
+            if self.use_filter:
+                params.use_filter = True
 
             self.set_option = True
 


### PR DESCRIPTION
## 관련 링크
[태스크 카드](https://www.notion.so/acon3d/File-View-Layer-6a807d0a00194e58bf101b1b32cebd0f)

## 발제/내용

- Menu> Open
- Menu> Import> FBX
- Menu> Import> SKP
- Menu> Import> Blender
- General> Open
- General> Import
- Camera> Background Images> Default Image
- Camera> Background Images> Custom Image
위 부분에서 필터가 켜져있어야 함.

## 대응

### 어떤 조치를 취했나요?

- AconImportHelper 에 use_filter 변수를 추가하여 조건을 두었습니다.