### PR TITLE
Import SKP 를 연속으로 했을 때 패널이 갱신되지 않는 문제

### DIFF
--- a/release/scripts/startup/abler/general_tab/general.py
+++ b/release/scripts/startup/abler/general_tab/general.py
@@ -650,6 +650,7 @@ class ImportSKPOperator(bpy.types.Operator, AconImportHelper):
         if not self.check_path(accepted=["skp"]):
             return {"FINISHED"}
         try:
+            bpy.ops.acon3d.close_skp_progress()
             bpy.ops.acon3d.import_skp(
                 filepath=self.filepath, import_lookatme=self.import_lookatme
             )


### PR DESCRIPTION
## 관련 링크
[태스크 카드](https://www.notion.so/acon3d/Import-SKP-efcd478b18df4a469b7573e35824f230)

## 발제/내용

- 패널의 닫지 않고 Import SKP 를 연속으로 하는 경우 Import SKP 패널의 진척도가 100% 에서 변경되지 않음

## 대응

### 어떤 조치를 취했나요?

- acon3d.close_skp_progress 함수를 import 시작 전에도 실행하도록 했습니다.