### PR TITLE
북마크에 없는 디렉터리의 북마크 기능 사용을 제한

### DIFF
--- a/source/blender/editors/space_file/file_ops.c
+++ b/source/blender/editors/space_file/file_ops.c
@@ -1299,8 +1299,7 @@ static int bookmark_move_exec(bContext *C, wmOperator *op)
   /*
    * 파일 브라우저에서 북마크에 없는 디렉터리를 선택하고 북마크 Move to Top 관련 기능을 사용하면
    * 최상위 북마크가 삭제되는 문제가 발생함. 이 문제를 해결하기 위한 조건 추가.
-   * Issue: https://www.notion.so/acon3d/Issue-0114-d378035c4e4544dc9a0cc1137a4cdacf
-   * Task : https://www.notion.so/acon3d/Top-baa9d05d98fc4950a49c7e104186c4a0
+   * Task: https://www.notion.so/acon3d/Top-baa9d05d98fc4950a49c7e104186c4a0
    */
   if (act_index == -1) {
     return OPERATOR_CANCELLED;

--- a/source/blender/editors/space_file/file_ops.c
+++ b/source/blender/editors/space_file/file_ops.c
@@ -1296,6 +1296,16 @@ static int bookmark_move_exec(bContext *C, wmOperator *op)
     return OPERATOR_CANCELLED;
   }
 
+  /*
+   * 파일 브라우저에서 북마크에 없는 디렉터리를 선택하고 북마크 Move to Top 관련 기능을 사용하면
+   * 최상위 북마크가 삭제되는 문제가 발생함. 이 문제를 해결하기 위한 조건 추가.
+   * Issue: https://www.notion.so/acon3d/Issue-0114-d378035c4e4544dc9a0cc1137a4cdacf
+   * Task : https://www.notion.so/acon3d/Top-baa9d05d98fc4950a49c7e104186c4a0
+   */
+  if (act_index == -1) {
+    return OPERATOR_CANCELLED;
+  }
+
   switch (direction) {
     case FILE_BOOKMARK_MOVE_TOP:
       new_index = 0;


### PR DESCRIPTION
## 관련 링크

[파일 브라우저에서 북마크에 없는 디렉터리 선택 후, 북마크 Top 기능을 사용하면 최상위 북마크가 삭제되는 문제](https://www.notion.so/acon3d/Top-baa9d05d98fc4950a49c7e104186c4a0)


## 발제/내용

- 파일 브라우저에서 2개 이상의 북마크를 추가하고, 추가되지 않은 디렉터리를 선택하고 Move Bookmark (위로) / Move to Top 기능을 사용하면 가장 최상위 북마크가 삭제되고 있음


## 대응

### 어떤 조치를 취했나요?

- index를 하나하나 예외 처리하지 말고, 북마크에 없는 디렉터리를 선택했을 때는 북마크의 기능이 작동하지 않으면 될 것 같다고 생각함.
- 북마크에 없는 디렉터리의 `act_index` 의 값은 `-1` 이고, 이 값에 대해서 북마크 정렬 기능 동작 없이 오퍼레이터를 종료하면됨.