### PR TITLE
Import skp 실행 시 import 실행 여부를 묻는 팝업이 노출되지 않음

### DIFF
--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -114,7 +114,10 @@ class Acon3dRenderWarningOperator(BlockingModalOperator):
             col.operator("acon3d.render_save", text="Save and Render")
         else:
             col.operator("acon3d.render_high_quality", text="Render Selected Scenes")
-        col.operator("acon3d.close_blocking_modal", text="Cancel", text_ctxt="*")
+        cancel_props = col.operator(
+            "acon3d.close_blocking_modal", text="Cancel", text_ctxt="*"
+        )
+        cancel_props.description_text = "Cancel"
         row.label(text="")
 
         main.label(text="")

--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -114,10 +114,9 @@ class Acon3dRenderWarningOperator(BlockingModalOperator):
             col.operator("acon3d.render_save", text="Save and Render")
         else:
             col.operator("acon3d.render_high_quality", text="Render Selected Scenes")
-        cancel_props = col.operator(
-            "acon3d.close_blocking_modal", text="Cancel", text_ctxt="*"
-        )
-        cancel_props.description_text = "Cancel"
+        col.operator(
+            "acon3d.close_blocking_modal", text="Cancel", text_ctxt="abler"
+        ).description_text = "Cancel"
         row.label(text="")
 
         main.label(text="")

--- a/release/scripts/startup/abler/general_tab/general.py
+++ b/release/scripts/startup/abler/general_tab/general.py
@@ -696,14 +696,15 @@ class ImportSKPModalOperator(BlockingModalOperator):
         import_skp_props.filepath = self.filepath
         import_skp_props.import_lookatme = self.import_lookatme
 
-        col.operator("acon3d.close_blocking_modal", text="Cancel")
-        row.label(text="")
+        cancel_props = col.operator("acon3d.close_blocking_modal", text="Cancel")
+        cancel_props.description_text = "Cancel"
 
+        row.label(text="")
         main.label(text="")
 
 
 class ImportSKPAcceptOperator(bpy.types.Operator):
-    """Execute Selected File"""
+    """Import selected file"""
 
     bl_idname = "acon3d.import_skp_accept"
     bl_label = "Import"

--- a/release/scripts/startup/abler/general_tab/general.py
+++ b/release/scripts/startup/abler/general_tab/general.py
@@ -707,8 +707,9 @@ class ImportSKPModalOperator(BlockingModalOperator):
         import_skp_props.filepath = self.filepath
         import_skp_props.import_lookatme = self.import_lookatme
 
-        cancel_props = col.operator("acon3d.close_blocking_modal", text="Cancel")
-        cancel_props.description_text = "Cancel"
+        col.operator(
+            "acon3d.close_blocking_modal", text="Cancel", text_ctxt="abler"
+        ).description_text = "Cancel"
 
         row.label(text="")
         main.label(text="")

--- a/release/scripts/startup/abler/general_tab/general.py
+++ b/release/scripts/startup/abler/general_tab/general.py
@@ -656,7 +656,6 @@ class ImportSKPOperator(bpy.types.Operator, AconImportHelper):
         if not self.check_path(accepted=["skp"]):
             return {"FINISHED"}
         try:
-            bpy.ops.acon3d.close_skp_progress()
             bpy.ops.acon3d.import_skp_modal(
                 "INVOKE_DEFAULT",
                 filepath=self.filepath,
@@ -726,6 +725,7 @@ class ImportSKPAcceptOperator(bpy.types.Operator):
     import_lookatme: bpy.props.BoolProperty(default=False)
 
     def execute(self, context):
+        bpy.ops.acon3d.close_skp_progress()
         bpy.ops.acon3d.close_blocking_modal("INVOKE_DEFAULT")
         bpy.ops.acon3d.import_skp(
             "INVOKE_DEFAULT",

--- a/release/scripts/startup/abler/startup_flow.py
+++ b/release/scripts/startup/abler/startup_flow.py
@@ -455,7 +455,7 @@ class Acon3dAnchorOperator(bpy.types.Operator):
     @classmethod
     def description(cls, context, properties):
         if properties.description_text:
-            return bpy.app.translations.pgettext(properties.description_text)
+            return properties.description_text
         else:
             return None
 
@@ -527,8 +527,9 @@ class Acon3dUpdateAlertOperator(BlockingModalOperator):
             text="When using an older version of ABLER, some features may not work properly."
         )
         col.operator("acon3d.update_abler", text="Update ABLER")
-        close_props = col.operator("acon3d.close_blocking_modal", text="Close")
-        close_props.description_text = "Close"
+        col.operator(
+            "acon3d.close_blocking_modal", text="Close"
+        ).description_text = "Close"
         row.label(text="")
 
         main.label(text="")
@@ -613,8 +614,9 @@ class Acon3dLowFileVersionWarning(BlockingModalOperator):
         )
         row.label(text="Don’t show this message again.")
 
-        close_props = col.operator("acon3d.close_blocking_modal", text="Close")
-        close_props.description_text = "Close"
+        col.operator(
+            "acon3d.close_blocking_modal", text="Close"
+        ).description_text = "Close"
         row.label(text="")
 
         main.label(text="")

--- a/release/scripts/startup/abler/startup_flow.py
+++ b/release/scripts/startup/abler/startup_flow.py
@@ -527,7 +527,8 @@ class Acon3dUpdateAlertOperator(BlockingModalOperator):
             text="When using an older version of ABLER, some features may not work properly."
         )
         col.operator("acon3d.update_abler", text="Update ABLER")
-        col.operator("acon3d.close_blocking_modal", text="Close")
+        close_props = col.operator("acon3d.close_blocking_modal", text="Close")
+        close_props.description_text = "Close"
         row.label(text="")
 
         main.label(text="")
@@ -612,7 +613,8 @@ class Acon3dLowFileVersionWarning(BlockingModalOperator):
         )
         row.label(text="Don’t show this message again.")
 
-        col.operator("acon3d.close_blocking_modal", text="Close")
+        close_props = col.operator("acon3d.close_blocking_modal", text="Close")
+        close_props.description_text = "Close"
         row.label(text="")
 
         main.label(text="")

--- a/release/scripts/startup/abler/warning_modal.py
+++ b/release/scripts/startup/abler/warning_modal.py
@@ -162,10 +162,17 @@ class BlockingModalOperator(bpy.types.Operator):
 
 
 class CloseBlockingModalOperator(bpy.types.Operator):
-    """Close Tutorial Guide"""
-
     bl_idname = "acon3d.close_blocking_modal"
     bl_label = "OK"
+
+    description_text: bpy.props.StringProperty("")
+
+    @classmethod
+    def description(cls, context, properties):
+        if properties.description_text:
+            return bpy.app.translations.pgettext(properties.description_text)
+        else:
+            return None
 
     def execute(self, context):
         BlockingModalOperator.close_modal()


### PR DESCRIPTION
## 관련 링크
[태스크 링크](https://www.notion.so/acon3d/Import-skp-import-cf16e4715ac7409594c236d2f3f02cef)
[SKP Converter PR](https://github.com/ACON3D/SKP_Converter/pull/95)
[translations PR](https://github.com/ACON3D/blender-translations/pull/40)

## 발제/내용

- Import SKP 하기 전 팝업이 보여야 합니다.

## 대응

### 어떤 조치를 취했나요?

- ImportSKPModalOperator 추가하여 팝업 띄울 수 있도록 함.
- ImportAcceptOperator 추가하여 팝업에서 Import 할 수 있도록 함.
- CloseBlockingModalOperator 에 description_text 추가하여 상황에 따라 메시지 다르게 보여줄 수 있도록 수정함.