### PR TITLE
씬 삭제 후 포커스된 씬이 없어져서 씬 삭제 시 오류가 발생하는 문제

### DIFF
--- a/release/scripts/startup/abler/scene_tab/scene_control.py
+++ b/release/scripts/startup/abler/scene_tab/scene_control.py
@@ -159,10 +159,10 @@ class DeleteSceneOperator(bpy.types.Operator):
 
         # active_scene_index 처리
         if prop.active_scene_index == 0:
-            # 제일 아래의 씬을 삭제 후엔 제일 위의 씬으로 이동
+            # 맨 아래 씬 삭제 시 가장 위의 씬으로 이동
             next_scene_index = len(prop.scene_col) - 1
         else:
-            # 씬 삭제 후 내림차순으로 이동
+            # 씬을 삭제 시 바로 다음 순서의 씬(생성순 내림차순)으로 전환
             next_scene_index = prop.active_scene_index - 1
         prop.active_scene_index = next_scene_index
 

--- a/release/scripts/startup/abler/scene_tab/scene_control.py
+++ b/release/scripts/startup/abler/scene_tab/scene_control.py
@@ -157,11 +157,14 @@ class DeleteSceneOperator(bpy.types.Operator):
         bpy.data.scenes.remove(scene)
         prop.scene_col.remove(prop.active_scene_index)
 
-        # Why set `scene` value again? Because `remove(scene)` occurs funny bug
-        # that sets `scene` value to 1 when `nextScene` is the first element of
-        # `bpy.data.scenes` collection. This ends up having `scene` value invalid
-        # and displaying empty value in the ui panel.
-        prop.scene = nextScene.name
+        # active_scene_index 처리
+        if prop.active_scene_index == 0:
+            # 제일 아래의 씬을 삭제 후엔 제일 위의 씬으로 이동
+            next_scene_index = len(prop.scene_col) - 1
+        else:
+            # 씬 삭제 후 내림차순으로 이동
+            next_scene_index = prop.active_scene_index - 1
+        prop.active_scene_index = next_scene_index
 
         return {"FINISHED"}
 


### PR DESCRIPTION
## 관련 링크
[링크](https://www.notion.so/acon3d/0f06378a1fe0486e9a260ffae9b398a5)

## 발제/내용

- 씬을 삭제 시 바로 다음 순서의 씬(생성순 내림차순)으로 전환되어야 함 (맨 아래 씬 삭제 시 가장 위의 씬으로 이동함)
- 씬 삭제 시 다음 뷰포트에 출력된 씬이 씬 리스트에서 포커스되어야 함

## 대응

### 어떤 조치를 취했나요?

- [x] 맨 위의 씬을 삭제하면 active_scene_index가 len(scene)을 넘어가 선택된 씬이 사라지게됨 → delete 후 active_scene_index 처리를 넣어줌