### PR TITLE
login auto가 파일 열때마다 실행되는 문제

### DIFF
--- a/release/scripts/startup/abler/startup_flow.py
+++ b/release/scripts/startup/abler/startup_flow.py
@@ -491,10 +491,10 @@ def start_authentication():
         response = requests.get(
             "https://api-v2.acon3d.com/auth/acon3d/refresh", cookies=cookies
         )
-
+        is_file_open = bpy.data.filepath is not None and bpy.data.filepath != ""
         responseData = response.json()
         if token := responseData["accessToken"]:
-            if is_process_single():
+            if is_process_single() and not is_file_open:
                 tracker.login_auto()
             prop.login_status = "SUCCESS"
 

--- a/release/scripts/startup/abler/startup_flow.py
+++ b/release/scripts/startup/abler/startup_flow.py
@@ -491,10 +491,9 @@ def start_authentication():
         response = requests.get(
             "https://api-v2.acon3d.com/auth/acon3d/refresh", cookies=cookies
         )
-        is_file_open = bpy.data.filepath is not None and bpy.data.filepath != ""
         responseData = response.json()
         if token := responseData["accessToken"]:
-            if is_process_single() and not is_file_open:
+            if is_process_single() and not bpy.data.filepath:
                 tracker.login_auto()
             prop.login_status = "SUCCESS"
 

--- a/release/scripts/startup/abler/startup_flow.py
+++ b/release/scripts/startup/abler/startup_flow.py
@@ -491,6 +491,7 @@ def start_authentication():
         response = requests.get(
             "https://api-v2.acon3d.com/auth/acon3d/refresh", cookies=cookies
         )
+
         responseData = response.json()
         if token := responseData["accessToken"]:
             if is_process_single() and not bpy.data.filepath:


### PR DESCRIPTION
## 관련 링크
[태스크 카드](https://www.notion.so/acon3d/login-auto-324c054e76b9487cab56e8dc4d3f1436)

## 발제/내용

- 파일 오픈할 때마다 믹스패널의 login auto 도 같이 실행됨

## 대응

### 어떤 조치를 취했나요?

- `bpy.data.filepath`가 있을때만 login auto가 실행되도록 함.