### PR TITLE
퀵 렌더, 스닙 렌더의 트래킹 시점이 완료 시점이 아님

### DIFF
--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -241,8 +241,6 @@ class Acon3dRenderQuickOperator(Acon3dRenderOperator, AconExportHelper):
             return super().invoke(context, event)
 
     def execute(self, context):
-        tracker.render_quick()
-
         # Get basename without file extension
         self.dirname, self.basename = os.path.split(os.path.normpath(self.filepath))
 
@@ -300,6 +298,10 @@ class Acon3dRenderQuickOperator(Acon3dRenderOperator, AconExportHelper):
                 bpy.ops.render.render("INVOKE_DEFAULT", write_still=self.write_still)
 
         return {"PASS_THROUGH"}
+
+    def on_render_finish(self, context):
+        tracker.render_quick()
+        return super().on_render_finish(context)
 
 
 class Acon3dRenderDirOperator(Acon3dRenderOperator, AconImportHelper):
@@ -456,8 +458,6 @@ class Acon3dRenderSnipOperator(Acon3dRenderDirOperator):
         render.match_object_visibility()
 
     def prepare_queue(self, context):
-        tracker.render_snip()
-
         scene = context.scene.copy()
         self.render_queue.append((None, scene))
         self.temp_scenes.append(scene)
@@ -496,6 +496,7 @@ class Acon3dRenderSnipOperator(Acon3dRenderDirOperator):
         return {"RUNNING_MODAL"}
 
     def on_render_finish(self, context):
+        tracker.render_snip()
 
         for mat in bpy.data.materials:
             materials_handler.set_material_parameters_by_type(mat)
@@ -505,8 +506,7 @@ class Acon3dRenderSnipOperator(Acon3dRenderDirOperator):
 
         self.temp_scenes.clear()
 
-        super().on_render_finish(context)
-        return {"FINISHED"}
+        return super().on_render_finish(context)
 
 
 class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
@@ -686,8 +686,7 @@ class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
 
         self.temp_scenes.clear()
 
-        super().on_render_finish(context)
-        return {"FINISHED"}
+        return super().on_render_finish(context)
 
     @classmethod
     def poll(self, context):


### PR DESCRIPTION
## 관련 링크
[태스크 카드](https://www.notion.so/acon3d/a1974bb80b4e4c4d82764994f2678f6b)

## 발제/내용

- 전체 렌더는 각 렌더 완료 시 트래킹
- 퀵, 스닙 렌더는 렌더 시작 시 트래킹되고 있음

## 대응

### 어떤 조치를 취했나요?

- 퀵, 스닙 렌더 렌더 완료 후 트래킹하도록 변경