### PR TITLE
SKP Import 성공 / 실패 개선

### DIFF
--- a/release/scripts/startup/abler/general_tab/general.py
+++ b/release/scripts/startup/abler/general_tab/general.py
@@ -655,17 +655,12 @@ class ImportSKPOperator(bpy.types.Operator, AconImportHelper):
     def execute(self, context):
         if not self.check_path(accepted=["skp"]):
             return {"FINISHED"}
-        try:
-            bpy.ops.acon3d.import_skp_modal(
-                "INVOKE_DEFAULT",
-                filepath=self.filepath,
-                import_lookatme=self.import_lookatme,
-            )
-        except Exception as e:
-            tracker.import_skp_fail()
-            raise e
-        else:
-            tracker.import_skp()
+
+        bpy.ops.acon3d.import_skp_modal(
+            "INVOKE_DEFAULT",
+            filepath=self.filepath,
+            import_lookatme=self.import_lookatme,
+        )
 
         return {"FINISHED"}
 
@@ -726,6 +721,7 @@ class ImportSKPAcceptOperator(bpy.types.Operator):
     import_lookatme: bpy.props.BoolProperty(default=False)
 
     def execute(self, context):
+        tracker.import_skp()
         bpy.ops.acon3d.close_skp_progress()
         bpy.ops.acon3d.close_blocking_modal("INVOKE_DEFAULT")
         bpy.ops.acon3d.import_skp(

--- a/release/scripts/startup/abler/lib/tracker/_tracker.py
+++ b/release/scripts/startup/abler/lib/tracker/_tracker.py
@@ -30,6 +30,7 @@ class EventKind(enum.Enum):
     import_fbx = "Import FBX"
     import_fbx_fail = "Import FBX Fail"
     import_skp = "Import SKP"
+    import_skp_success = "Import SKP Success"
     import_skp_fail = "Import SKP Fail"
     toggle_toolbar = "Toggle Toolbar"
     fly_mode = "Fly Mode"
@@ -217,8 +218,11 @@ class Tracker(metaclass=ABCMeta):
     def import_skp(self):
         self._track(EventKind.import_skp.value)
 
-    def import_skp_fail(self):
-        self._track(EventKind.import_skp_fail.value)
+    def import_skp_success(self, data):
+        self._track(EventKind.import_skp_success.value, data)
+
+    def import_skp_fail(self, data):
+        self._track(EventKind.import_skp_fail.value, data)
 
     def scene_add(self):
         self._track(EventKind.scene_add.value)


### PR DESCRIPTION
## 관련 링크
[태스크 카드](https://www.notion.so/acon3d/Import-SKP-415aeef0ef8e40dea1db8962e0a9f0d3)
[이슈 카드](https://www.notion.so/acon3d/Issue-0121-skp-Import-c1ab58bc6ff54d0f83c41598e4a842c4)
[SKP_Converter PR]()
[blender-translations PR]()

## 발제/내용

- Import SKP 의 트래킹이 시작 시에만 되고 성공 / 실패 시에는 되고 있지 않음

## 대응

### 어떤 조치를 취했나요?

- Import SKP / Import SKP Success / Import SKP Fail 세가지로 Import SKP 의 트래킹 동작 구분
- 실제 Import 시작 시 Import SKP 트래킹할 수 있도록 위치 변경