### PR TITLE
로그인 연속 실패 팝업의 영문 문구가 잘림

### DIFF
--- a/release/scripts/startup/abler/startup_flow.py
+++ b/release/scripts/startup/abler/startup_flow.py
@@ -417,7 +417,7 @@ class LoginTask(AsyncTask):
             bpy.ops.acon3d.alert(
                 "INVOKE_DEFAULT",
                 title="Login failed",
-                message_1="The number of consecutive password error count exceeded.",
+                message_1="Login error count exceeded.",
                 message_2="Please try again in few minutes.",
             )
         else:


### PR DESCRIPTION
## 관련 링크

[태스크](https://www.notion.so/acon3d/69d7e4f44a1742a4a4918b3a534c00dd)
[이슈](https://www.notion.so/acon3d/Issue-0116-79ed8183a58a4d999852f2235b11af30)
[blender-translations PR](https://github.com/ACON3D/blender-translations/pull/46)


## 발제/내용

- 로그인 연속 실패 팝업의 영문 문구가 잘려서 보인다.

## 대응

### 어떤 조치를 취했나요?

- 로그인 연속 실패 팝업의 영문 문구를 짧게 변경하였습니다.