### PR TITLE
고품질 전체 렌더 시 블룸이 적용 안되는 문제

### DIFF
--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -628,7 +628,8 @@ class Acon3dRenderHighQualityOperator(Acon3dRenderDirOperator):
         bpy.context.window_manager.progress_prop.total_render_num += 1
 
         scene.name = f"{base_scene.name}_{render_type}"
-        scene.eevee.use_bloom = False
+        if render_type != "full":
+            scene.eevee.use_bloom = False
         scene.render.use_lock_interface = True
 
         # scene_info - UI 에 이름과 진행 상황을 보여주기 위한 데이터


### PR DESCRIPTION
## 관련 링크
[링크](https://www.notion.so/acon3d/15930245b0004ed2ae72aa142dc8149e)

## 발제/내용

- 전체 렌더 시 블룸이 적용이 안됨

## 대응

### 어떤 조치를 취했나요?

- render_type으로 use_bloom 조건 맞춰주기