### PR TITLE
Save, Quick Render 브라우저의 파일명 구좌가 비어 있는 상태에서 Save As를 실행했을 때 오류

### DIFF
--- a/release/scripts/startup/abler/export_tab/render_control.py
+++ b/release/scripts/startup/abler/export_tab/render_control.py
@@ -245,6 +245,11 @@ class Acon3dRenderQuickOperator(Acon3dRenderOperator, AconExportHelper):
             return super().invoke(context, event)
 
     def execute(self, context):
+        self.check_path(
+            save_check=False,
+            default_name=f"{context.scene.name}{self.filename_ext}",
+        )
+
         # Get basename without file extension
         self.dirname, self.basename = os.path.split(os.path.normpath(self.filepath))
 

--- a/release/scripts/startup/abler/general_tab/general.py
+++ b/release/scripts/startup/abler/general_tab/general.py
@@ -327,6 +327,8 @@ class SaveOperator(bpy.types.Operator, AconExportHelper):
 
     def execute(self, context):
         try:
+            self.check_path(save_check=True)
+
             if bpy.data.is_saved:
                 self.filepath = context.blend_data.filepath
                 dirname, basename = split_filepath(self.filepath)
@@ -370,6 +372,8 @@ class SaveAsOperator(bpy.types.Operator, AconExportHelper):
 
     def execute(self, context):
         try:
+            self.check_path(save_check=False)
+
             numbered_filepath, numbered_filename = numbering_filepath(
                 self.filepath, self.filename_ext
             )
@@ -404,6 +408,8 @@ class SaveCopyOperator(bpy.types.Operator, AconExportHelper):
 
     def execute(self, context):
         try:
+            self.check_path(save_check=False)
+
             numbered_filepath, numbered_filename = numbering_filepath(
                 self.filepath, self.filename_ext
             )

--- a/release/scripts/startup/abler/lib/import_file.py
+++ b/release/scripts/startup/abler/lib/import_file.py
@@ -71,6 +71,17 @@ class AconExportHelper(ExportHelper):
         super().__init__()
         self.set_option = None
 
+    def check_path(self, save_check: bool, default_name: str = "untitled.blend"):
+        """
+        :param save_check: 저장 유무를 판단할 것인지
+        :param default_name: 기본 이름
+
+        :return:
+            filepath 가 디렉토리인 경우 filepath 에 default_name 추가
+        """
+        if not (save_check and bpy.data.is_saved) and os.path.isdir(self.filepath):
+            self.filepath = os.path.join(self.filepath, default_name)
+
     def draw(self, context):
         # FileBrowser UI 설정이 맨처음에만 적용되게끔
         if not self.set_option:


### PR DESCRIPTION
## 관련 링크
[태스크](https://www.notion.so/acon3d/Save-Quick-Render-Save-As-ccbc00eb651c44acba202ffcd8df8a3f)
[이슈](https://www.notion.so/acon3d/Issue-0119-Save-Quick-Render-Save-As-18cb4369bcc541c5864a492810e8500f)

## 발제/내용

Save / Save as / Save Copy / Render Quick 시
- 파일명 구좌에 빈 값이 들어가면, 현 디렉토리의 주소를 가져오고, 그 디렉토리의 주소 뒤에 .blend, .png 등을 붙여서 저장
- 위 과정에서 상위 폴더로 올라가면 쓰기 권한이 없어서 파일 저장을 실패하고 오류가 발생

## 대응

### 어떤 조치를 취했나요?

- check_path 함수를 추가하여 파일명을 빈 채로 저장하면 해당 디렉토리에 디폴트 값으로 저장되도록 함.
  - 디렉토리인지 체크 후 해당 주소에 디폴트 값 추가