### PR TITLE
[온보딩 프로젝트] Cube 패널 추가 후 Cube를 Control하는 버튼 추가

### DIFF
--- a/release/scripts/startup/abler/__init__.py
+++ b/release/scripts/startup/abler/__init__.py
@@ -43,6 +43,7 @@ from .scene_tab import scene_control, object_control, layer_control
 from .style_tab import styles_control
 from .export_tab import render_control
 from .export_tab import export_control
+from .cube_tab import create_cube
 from . import pref
 from . import operators
 from . import warning_modal
@@ -66,6 +67,7 @@ importedLibrary = [
     pref,
     operators,
     warning_modal,
+    create_cube,
 ]
 if "--background" not in sys.argv and "-b" not in sys.argv:
     from . import startup_flow

--- a/release/scripts/startup/abler/cube_tab/create_cube.py
+++ b/release/scripts/startup/abler/cube_tab/create_cube.py
@@ -1,0 +1,92 @@
+import random
+
+import bpy
+
+
+class AconAddCubeOperator(bpy.types.Operator):
+    bl_idname = "acon3d.add_cube"
+    bl_label = "Add Cube"
+    bl_translation_context = "abler"
+
+    def execute(self, context):
+        x = random.randint(0, 12)
+        y = random.randint(0, 12)
+        z = random.randint(0, 12)
+
+        bpy.ops.mesh.primitive_cube_add(location=(x, y, z), size=2.0)
+        return {"FINISHED"}
+
+
+class AconDeleteAllCubesOperator(bpy.types.Operator):
+    bl_idname = "acon3d.delete_all_cubes"
+    bl_label = "Delete All Cubes"
+    bl_translation_context = "abler"
+
+    def execute(self, context):
+        bpy.ops.object.select_all(action="SELECT")
+        bpy.ops.object.delete()
+
+        return {"FINISHED"}
+
+
+class AconNameCubeOperator(bpy.types.Operator):
+    bl_idname = "acon3d.name_cube"
+    bl_label = "Name New Cube"
+    bl_translation_context = "abler"
+    bl_options = {"REGISTER", "UNDO"}
+
+    name: bpy.props.StringProperty(
+        name="Name", description="Write cube name", maxlen=10
+    )
+
+    def execute(self, context):
+        pass
+
+        return {"FINISHED"}
+
+
+class Acon3dCubePanel(bpy.types.Panel):
+    bl_idname = "ACON3D_PT_cube"
+    bl_label = "Cube"
+    bl_category = "Cube"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_translation_context = "abler"
+    bl_order = 1
+
+    def draw_header(self, context):
+        layout = self.layout
+        layout.label(icon="EVENT_A")
+
+    def draw(self, context):
+        layout = self.layout
+
+        row = layout.row()
+        row.scale_y = 1.0
+        row.operator("acon3d.add_cube", text="add cube")
+
+        row = layout.row()
+        row.scale_y = 1.0
+        row.operator("acon3d.delete_all_cubes", text="delete all")
+
+
+classes = (
+    Acon3dCubePanel,
+    AconAddCubeOperator,
+    AconDeleteAllCubesOperator,
+    AconNameCubeOperator,
+)
+
+
+def register():
+    from bpy.utils import register_class
+
+    for cls in classes:
+        register_class(cls)
+
+
+def unregister():
+    from bpy.utils import unregister_class
+
+    for cls in reversed(classes):
+        unregister_class(cls)

--- a/release/scripts/startup/abler/cube_tab/create_cube.py
+++ b/release/scripts/startup/abler/cube_tab/create_cube.py
@@ -29,22 +29,6 @@ class AconDeleteAllCubesOperator(bpy.types.Operator):
         return {"FINISHED"}
 
 
-class AconNameCubeOperator(bpy.types.Operator):
-    bl_idname = "acon3d.name_cube"
-    bl_label = "Name New Cube"
-    bl_translation_context = "abler"
-    bl_options = {"REGISTER", "UNDO"}
-
-    name: bpy.props.StringProperty(
-        name="Name", description="Write cube name", maxlen=10
-    )
-
-    def execute(self, context):
-        pass
-
-        return {"FINISHED"}
-
-
 class Acon3dCubePanel(bpy.types.Panel):
     bl_idname = "ACON3D_PT_cube"
     bl_label = "Cube"
@@ -70,11 +54,31 @@ class Acon3dCubePanel(bpy.types.Panel):
         row.operator("acon3d.delete_all_cubes", text="delete all")
 
 
+class ACON3dNameCubePanel(bpy.types.Panel):
+
+    bl_idname = "ACON3D_PT_NameCube"
+    bl_label = "Cube Name"
+    bl_category = "Cube"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_translation_context = "abler"
+    bl_order = 1
+
+    def draw_header(self, context):
+        layout = self.layout
+        layout.label(icon="EVENT_B")
+
+    def draw(self, context):
+        layout = self.layout
+        prop = context.scene.ACON_prop
+        layout.prop(prop, "cube_name", text="name")
+
+
 classes = (
     Acon3dCubePanel,
     AconAddCubeOperator,
     AconDeleteAllCubesOperator,
-    AconNameCubeOperator,
+    ACON3dNameCubePanel,
 )
 
 

--- a/release/scripts/startup/abler/cube_tab/create_cube.py
+++ b/release/scripts/startup/abler/cube_tab/create_cube.py
@@ -101,11 +101,57 @@ class ACON3dMoveCubePanel(bpy.types.Panel):
         layout.prop(prop, "location_z", text="z")
 
 
+class ACON3dScaleCubePanel(bpy.types.Panel):
+    bl_idname = "ACON3D_PT_ScaleCube"
+    bl_label = "Scale Cube"
+    bl_category = "Cube"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_translation_context = "abler"
+    bl_order = 1
+
+    def draw_header(self, context):
+        layout = self.layout
+        layout.label(icon="EVENT_B")
+
+    def draw(self, context):
+        layout = self.layout
+        obj = context.object
+        prop = obj.ACON_prop
+        layout.prop(prop, "scale_x", text="x")
+        layout.prop(prop, "scale_y", text="y")
+        layout.prop(prop, "scale_z", text="z")
+
+
+class ACON3dRotateCubePanel(bpy.types.Panel):
+    bl_idname = "ACON3D_PT_RotateCube"
+    bl_label = "Rotate Cube"
+    bl_category = "Cube"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_translation_context = "abler"
+    bl_order = 1
+
+    def draw_header(self, context):
+        layout = self.layout
+        layout.label(icon="EVENT_B")
+
+    def draw(self, context):
+        layout = self.layout
+        obj = context.object
+        prop = obj.ACON_prop
+        layout.prop(prop, "rotate_x", text="x")
+        layout.prop(prop, "rotate_y", text="y")
+        layout.prop(prop, "rotate_z", text="z")
+
+
 classes = (
     Acon3dCubePanel,
     AconAddCubeOperator,
     AconDeleteAllCubesOperator,
     ACON3dMoveCubePanel,
+    ACON3dScaleCubePanel,
+    ACON3dRotateCubePanel,
 )
 
 

--- a/release/scripts/startup/abler/cube_tab/create_cube.py
+++ b/release/scripts/startup/abler/cube_tab/create_cube.py
@@ -28,7 +28,7 @@ class AconAddCubeOperator(bpy.types.Operator):
         mesh = bpy.ops.mesh.primitive_cube_add(location=(x, y, z), size=2.0)
         ob = bpy.context.object
         me = ob.data
-        ob.name = "CUBEOBJ"
+        ob.name = self.name
         me.name = "CUBEMESH"
 
         return {"FINISHED"}

--- a/release/scripts/startup/abler/cube_tab/create_cube.py
+++ b/release/scripts/startup/abler/cube_tab/create_cube.py
@@ -9,9 +9,9 @@ class AconAddCubeOperator(bpy.types.Operator):
     bl_translation_context = "abler"
 
     name: bpy.props.StringProperty(name="Name", description="Write scene name")
-    x: bpy.props.IntProperty(name="x")
-    y: bpy.props.IntProperty(name="y")
-    z: bpy.props.IntProperty(name="z")
+    location_x: bpy.props.IntProperty(name="x")
+    location_y: bpy.props.IntProperty(name="y")
+    location_z: bpy.props.IntProperty(name="z")
 
     def invoke(self, context, event):
         wm = context.window_manager
@@ -22,24 +22,26 @@ class AconAddCubeOperator(bpy.types.Operator):
         layout.separator()
         layout.prop(self, "name")
         layout.separator()
-        layout.prop(self, "x")
+        layout.prop(self, "location_x")
         layout.separator()
-        layout.prop(self, "y")
+        layout.prop(self, "location_y")
         layout.separator()
-        layout.prop(self, "z")
+        layout.prop(self, "location_z")
         layout.separator()
 
     def execute(self, context):
-        bpy.ops.mesh.primitive_cube_add(location=(self.x, self.y, self.z), size=2.0)
+        bpy.ops.mesh.primitive_cube_add(
+            location=(self.location_x, self.location_y, self.location_z), size=2.0
+        )
 
-        c1 = random.uniform(0.0, 1.0)
-        c2 = random.uniform(0.0, 1.0)
-        c3 = random.uniform(0.0, 1.0)
-        c4 = 1
+        hue = random.uniform(0.0, 1.0)
+        saturation = random.uniform(0.0, 1.0)
+        value = random.uniform(0.0, 1.0)
+        alpha = 1
 
         color_mat = bpy.data.materials.new("Color Mat")
         id = color_mat.name
-        bpy.data.materials[id].diffuse_color = (c1, c2, c3, c4)
+        bpy.data.materials[id].diffuse_color = (hue, saturation, value, alpha)
 
         ob = bpy.context.active_object
         ob.name = self.name
@@ -49,9 +51,9 @@ class AconAddCubeOperator(bpy.types.Operator):
         return {"FINISHED"}
 
 
-class AconDeleteAllCubesOperator(bpy.types.Operator):
-    bl_idname = "acon3d.delete_all_cubes"
-    bl_label = "Delete All Cubes"
+class AconDeleteAllOperator(bpy.types.Operator):
+    bl_idname = "acon3d.delete_all"
+    bl_label = "Delete All"
     bl_translation_context = "abler"
 
     def execute(self, context):
@@ -83,7 +85,7 @@ class Acon3dCubePanel(bpy.types.Panel):
 
         row = layout.row()
         row.scale_y = 1.0
-        row.operator("acon3d.delete_all_cubes", text="delete all")
+        row.operator("acon3d.delete_all", text="delete all")
 
 
 class ACON3dMoveCubePanel(bpy.types.Panel):
@@ -93,7 +95,7 @@ class ACON3dMoveCubePanel(bpy.types.Panel):
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
     bl_translation_context = "abler"
-    bl_order = 1
+    bl_order = 2
 
     def draw_header(self, context):
         layout = self.layout
@@ -115,7 +117,7 @@ class ACON3dScaleCubePanel(bpy.types.Panel):
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
     bl_translation_context = "abler"
-    bl_order = 1
+    bl_order = 3
 
     def draw_header(self, context):
         layout = self.layout
@@ -137,7 +139,7 @@ class ACON3dRotateCubePanel(bpy.types.Panel):
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
     bl_translation_context = "abler"
-    bl_order = 1
+    bl_order = 4
 
     def draw_header(self, context):
         layout = self.layout
@@ -155,7 +157,7 @@ class ACON3dRotateCubePanel(bpy.types.Panel):
 classes = (
     Acon3dCubePanel,
     AconAddCubeOperator,
-    AconDeleteAllCubesOperator,
+    AconDeleteAllOperator,
     ACON3dMoveCubePanel,
     ACON3dScaleCubePanel,
     ACON3dRotateCubePanel,

--- a/release/scripts/startup/abler/cube_tab/create_cube.py
+++ b/release/scripts/startup/abler/cube_tab/create_cube.py
@@ -9,6 +9,9 @@ class AconAddCubeOperator(bpy.types.Operator):
     bl_translation_context = "abler"
 
     name: bpy.props.StringProperty(name="Name", description="Write scene name")
+    x: bpy.props.IntProperty(name="x")
+    y: bpy.props.IntProperty(name="y")
+    z: bpy.props.IntProperty(name="z")
 
     def invoke(self, context, event):
         wm = context.window_manager
@@ -19,13 +22,18 @@ class AconAddCubeOperator(bpy.types.Operator):
         layout.separator()
         layout.prop(self, "name")
         layout.separator()
+        layout.prop(self, "x")
+        layout.separator()
+        layout.prop(self, "y")
+        layout.separator()
+        layout.prop(self, "z")
+        layout.separator()
 
     def execute(self, context):
-        x = random.randint(0, 12)
-        y = random.randint(0, 12)
-        z = random.randint(0, 12)
 
-        mesh = bpy.ops.mesh.primitive_cube_add(location=(x, y, z), size=2.0)
+        mesh = bpy.ops.mesh.primitive_cube_add(
+            location=(self.x, self.y, self.z), size=2.0
+        )
         ob = bpy.context.object
         me = ob.data
         ob.name = self.name

--- a/release/scripts/startup/abler/cube_tab/create_cube.py
+++ b/release/scripts/startup/abler/cube_tab/create_cube.py
@@ -35,10 +35,7 @@ class AconAddCubeOperator(bpy.types.Operator):
             location=(self.x, self.y, self.z), size=2.0
         )
         ob = bpy.context.object
-        me = ob.data
         ob.name = self.name
-        me.name = "CUBEMESH"
-
         return {"FINISHED"}
 
 
@@ -94,7 +91,7 @@ class ACON3dMoveCubePanel(bpy.types.Panel):
 
     def draw(self, context):
         layout = self.layout
-        obj = bpy.context.object
+        obj = bpy.context.active_object
         prop = obj.ACON_prop
         layout.prop(prop, "location_x", text="x")
         layout.prop(prop, "location_y", text="y")

--- a/release/scripts/startup/abler/cube_tab/create_cube.py
+++ b/release/scripts/startup/abler/cube_tab/create_cube.py
@@ -13,7 +13,12 @@ class AconAddCubeOperator(bpy.types.Operator):
         y = random.randint(0, 12)
         z = random.randint(0, 12)
 
-        bpy.ops.mesh.primitive_cube_add(location=(x, y, z), size=2.0)
+        mesh = bpy.ops.mesh.primitive_cube_add(location=(x, y, z), size=2.0)
+        ob = bpy.context.object
+        me = ob.data
+        ob.name = "CUBEOBJ"
+        me.name = "CUBEMESH"
+
         return {"FINISHED"}
 
 
@@ -55,7 +60,6 @@ class Acon3dCubePanel(bpy.types.Panel):
 
 
 class ACON3dNameCubePanel(bpy.types.Panel):
-
     bl_idname = "ACON3D_PT_NameCube"
     bl_label = "Cube Name"
     bl_category = "Cube"

--- a/release/scripts/startup/abler/cube_tab/create_cube.py
+++ b/release/scripts/startup/abler/cube_tab/create_cube.py
@@ -88,9 +88,9 @@ class Acon3dCubePanel(bpy.types.Panel):
         row.operator("acon3d.delete_all", text="delete all")
 
 
-class ACON3dMoveCubePanel(bpy.types.Panel):
+class ACON3dMovePanel(bpy.types.Panel):
     bl_idname = "ACON3D_PT_MoveCube"
-    bl_label = "Move Cube"
+    bl_label = "Move"
     bl_category = "Cube"
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
@@ -110,9 +110,9 @@ class ACON3dMoveCubePanel(bpy.types.Panel):
         layout.prop(prop, "location_z", text="z")
 
 
-class ACON3dScaleCubePanel(bpy.types.Panel):
+class ACON3dScalePanel(bpy.types.Panel):
     bl_idname = "ACON3D_PT_ScaleCube"
-    bl_label = "Scale Cube"
+    bl_label = "Scale"
     bl_category = "Cube"
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
@@ -132,9 +132,9 @@ class ACON3dScaleCubePanel(bpy.types.Panel):
         layout.prop(prop, "scale_z", text="z")
 
 
-class ACON3dRotateCubePanel(bpy.types.Panel):
+class ACON3dRotatePanel(bpy.types.Panel):
     bl_idname = "ACON3D_PT_RotateCube"
-    bl_label = "Rotate Cube"
+    bl_label = "Rotate"
     bl_category = "Cube"
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
@@ -158,9 +158,9 @@ classes = (
     Acon3dCubePanel,
     AconAddCubeOperator,
     AconDeleteAllOperator,
-    ACON3dMoveCubePanel,
-    ACON3dScaleCubePanel,
-    ACON3dRotateCubePanel,
+    ACON3dMovePanel,
+    ACON3dScalePanel,
+    ACON3dRotatePanel,
 )
 
 

--- a/release/scripts/startup/abler/cube_tab/create_cube.py
+++ b/release/scripts/startup/abler/cube_tab/create_cube.py
@@ -8,6 +8,18 @@ class AconAddCubeOperator(bpy.types.Operator):
     bl_label = "Add Cube"
     bl_translation_context = "abler"
 
+    name: bpy.props.StringProperty(name="Name", description="Write scene name")
+
+    def invoke(self, context, event):
+        wm = context.window_manager
+        return wm.invoke_props_dialog(self)
+
+    def draw(self, context):
+        layout = self.layout
+        layout.separator()
+        layout.prop(self, "name")
+        layout.separator()
+
     def execute(self, context):
         x = random.randint(0, 12)
         y = random.randint(0, 12)

--- a/release/scripts/startup/abler/cube_tab/create_cube.py
+++ b/release/scripts/startup/abler/cube_tab/create_cube.py
@@ -112,7 +112,7 @@ class ACON3dScaleCubePanel(bpy.types.Panel):
 
     def draw_header(self, context):
         layout = self.layout
-        layout.label(icon="EVENT_B")
+        layout.label(icon="EVENT_C")
 
     def draw(self, context):
         layout = self.layout
@@ -134,7 +134,7 @@ class ACON3dRotateCubePanel(bpy.types.Panel):
 
     def draw_header(self, context):
         layout = self.layout
-        layout.label(icon="EVENT_B")
+        layout.label(icon="EVENT_D")
 
     def draw(self, context):
         layout = self.layout

--- a/release/scripts/startup/abler/cube_tab/create_cube.py
+++ b/release/scripts/startup/abler/cube_tab/create_cube.py
@@ -94,7 +94,7 @@ class ACON3dMoveCubePanel(bpy.types.Panel):
 
     def draw(self, context):
         layout = self.layout
-        obj = context.object
+        obj = bpy.context.object
         prop = obj.ACON_prop
         layout.prop(prop, "location_x", text="x")
         layout.prop(prop, "location_y", text="y")

--- a/release/scripts/startup/abler/cube_tab/create_cube.py
+++ b/release/scripts/startup/abler/cube_tab/create_cube.py
@@ -79,9 +79,9 @@ class Acon3dCubePanel(bpy.types.Panel):
         row.operator("acon3d.delete_all_cubes", text="delete all")
 
 
-class ACON3dNameCubePanel(bpy.types.Panel):
-    bl_idname = "ACON3D_PT_NameCube"
-    bl_label = "Cube Name"
+class ACON3dMoveCubePanel(bpy.types.Panel):
+    bl_idname = "ACON3D_PT_MoveCube"
+    bl_label = "Move Cube"
     bl_category = "Cube"
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
@@ -94,15 +94,18 @@ class ACON3dNameCubePanel(bpy.types.Panel):
 
     def draw(self, context):
         layout = self.layout
-        prop = context.scene.ACON_prop
-        layout.prop(prop, "cube_name", text="name")
+        obj = context.object
+        prop = obj.ACON_prop
+        layout.prop(prop, "location_x", text="x")
+        layout.prop(prop, "location_y", text="y")
+        layout.prop(prop, "location_z", text="z")
 
 
 classes = (
     Acon3dCubePanel,
     AconAddCubeOperator,
     AconDeleteAllCubesOperator,
-    ACON3dNameCubePanel,
+    ACON3dMoveCubePanel,
 )
 
 

--- a/release/scripts/startup/abler/cube_tab/create_cube.py
+++ b/release/scripts/startup/abler/cube_tab/create_cube.py
@@ -30,12 +30,22 @@ class AconAddCubeOperator(bpy.types.Operator):
         layout.separator()
 
     def execute(self, context):
+        bpy.ops.mesh.primitive_cube_add(location=(self.x, self.y, self.z), size=2.0)
 
-        mesh = bpy.ops.mesh.primitive_cube_add(
-            location=(self.x, self.y, self.z), size=2.0
-        )
-        ob = bpy.context.object
+        c1 = random.uniform(0.0, 1.0)
+        c2 = random.uniform(0.0, 1.0)
+        c3 = random.uniform(0.0, 1.0)
+        c4 = 1
+
+        color_mat = bpy.data.materials.new("Color Mat")
+        id = color_mat.name
+        bpy.data.materials[id].diffuse_color = (c1, c2, c3, c4)
+
+        ob = bpy.context.active_object
         ob.name = self.name
+        mesh = bpy.context.active_object.data
+        mesh.materials.append(color_mat)
+
         return {"FINISHED"}
 
 

--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -593,12 +593,6 @@ class AconSceneProperty(bpy.types.PropertyGroup):
         update=scenes.change_background_color,
     )
 
-    cube_name: bpy.props.StringProperty(
-        name="Cube Name",
-        description="custom cube name",
-        maxlen=10,
-    )
-
 
 class AconMaterialProperty(bpy.types.PropertyGroup):
     @classmethod
@@ -776,6 +770,15 @@ class AconObjectProperty(bpy.types.PropertyGroup):
     state_begin: bpy.props.PointerProperty(type=AconObjectStateProperty)
 
     state_end: bpy.props.PointerProperty(type=AconObjectStateProperty)
+
+    location_x: bpy.props.FloatProperty(name="x", update=objects.edit_state)
+
+    location_y: bpy.props.FloatProperty(
+        name="y",
+        update=objects.edit_state,
+    )
+
+    location_z: bpy.props.FloatProperty(name="z", update=objects.edit_state)
 
 
 classes = (

--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -730,6 +730,9 @@ class AconObjectProperty(bpy.types.PropertyGroup):
     def unregister(cls):
         del bpy.types.Object.ACON_prop
 
+    def get_location_x(self, context):
+        return context.selected_object.location[0]
+
     group: bpy.props.CollectionProperty(type=AconObjectGroupProperty)
 
     group_list: bpy.props.EnumProperty(
@@ -771,14 +774,20 @@ class AconObjectProperty(bpy.types.PropertyGroup):
 
     state_end: bpy.props.PointerProperty(type=AconObjectStateProperty)
 
-    location_x: bpy.props.FloatProperty(name="x", update=objects.edit_state)
+    location_x: bpy.props.FloatProperty(
+        name="x",
+        update=objects.edit_state,
+    )
 
     location_y: bpy.props.FloatProperty(
         name="y",
         update=objects.edit_state,
     )
 
-    location_z: bpy.props.FloatProperty(name="z", update=objects.edit_state)
+    location_z: bpy.props.FloatProperty(
+        name="z",
+        update=objects.edit_state,
+    )
 
     scale_x: bpy.props.FloatProperty(
         name="x",
@@ -790,7 +799,10 @@ class AconObjectProperty(bpy.types.PropertyGroup):
         update=objects.edit_state,
     )
 
-    scale_z: bpy.props.FloatProperty(name="z", update=objects.edit_state)
+    scale_z: bpy.props.FloatProperty(
+        name="z",
+        update=objects.edit_state,
+    )
 
     rotate_x: bpy.props.FloatProperty(
         name="x",
@@ -802,7 +814,10 @@ class AconObjectProperty(bpy.types.PropertyGroup):
         update=objects.edit_state,
     )
 
-    rotate_z: bpy.props.FloatProperty(name="z", update=objects.edit_state)
+    rotate_z: bpy.props.FloatProperty(
+        name="z",
+        update=objects.edit_state,
+    )
 
 
 classes = (

--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -731,7 +731,7 @@ class AconObjectProperty(bpy.types.PropertyGroup):
         del bpy.types.Object.ACON_prop
 
     def get_location_x(self, context):
-        return context.selected_object.location[0]
+        return context.selected_objects[0].location[0]
 
     group: bpy.props.CollectionProperty(type=AconObjectGroupProperty)
 
@@ -777,6 +777,7 @@ class AconObjectProperty(bpy.types.PropertyGroup):
     location_x: bpy.props.FloatProperty(
         name="x",
         update=objects.edit_state,
+        get=get_location_x,
     )
 
     location_y: bpy.props.FloatProperty(

--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -593,6 +593,12 @@ class AconSceneProperty(bpy.types.PropertyGroup):
         update=scenes.change_background_color,
     )
 
+    cube_name: bpy.props.StringProperty(
+        name="Cube Name",
+        description="custom cube name",
+        maxlen=10,
+    )
+
 
 class AconMaterialProperty(bpy.types.PropertyGroup):
     @classmethod

--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -730,9 +730,6 @@ class AconObjectProperty(bpy.types.PropertyGroup):
     def unregister(cls):
         del bpy.types.Object.ACON_prop
 
-    def get_location_x(self, context):
-        return context.selected_objects[0].location[0]
-
     group: bpy.props.CollectionProperty(type=AconObjectGroupProperty)
 
     group_list: bpy.props.EnumProperty(
@@ -776,50 +773,50 @@ class AconObjectProperty(bpy.types.PropertyGroup):
 
     location_x: bpy.props.FloatProperty(
         name="x",
-        update=objects.edit_state,
+        update=objects.edit_state_location,
     )
 
     location_y: bpy.props.FloatProperty(
         name="y",
-        update=objects.edit_state,
+        update=objects.edit_state_location,
     )
 
     location_z: bpy.props.FloatProperty(
         name="z",
-        update=objects.edit_state,
+        update=objects.edit_state_location,
     )
 
     scale_x: bpy.props.FloatProperty(
         name="x",
-        update=objects.edit_state,
+        update=objects.edit_state_scale,
         default=1,
     )
 
     scale_y: bpy.props.FloatProperty(
         name="y",
-        update=objects.edit_state,
+        update=objects.edit_state_scale,
         default=1,
     )
 
     scale_z: bpy.props.FloatProperty(
         name="z",
-        update=objects.edit_state,
+        update=objects.edit_state_scale,
         default=1,
     )
 
     rotate_x: bpy.props.FloatProperty(
         name="x",
-        update=objects.edit_state,
+        update=objects.edit_state_rotate,
     )
 
     rotate_y: bpy.props.FloatProperty(
         name="y",
-        update=objects.edit_state,
+        update=objects.edit_state_rotate,
     )
 
     rotate_z: bpy.props.FloatProperty(
         name="z",
-        update=objects.edit_state,
+        update=objects.edit_state_rotate,
     )
 
 

--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -780,6 +780,30 @@ class AconObjectProperty(bpy.types.PropertyGroup):
 
     location_z: bpy.props.FloatProperty(name="z", update=objects.edit_state)
 
+    scale_x: bpy.props.FloatProperty(
+        name="x",
+        update=objects.edit_state,
+    )
+
+    scale_y: bpy.props.FloatProperty(
+        name="y",
+        update=objects.edit_state,
+    )
+
+    scale_z: bpy.props.FloatProperty(name="z", update=objects.edit_state)
+
+    rotate_x: bpy.props.FloatProperty(
+        name="x",
+        update=objects.edit_state,
+    )
+
+    rotate_y: bpy.props.FloatProperty(
+        name="y",
+        update=objects.edit_state,
+    )
+
+    rotate_z: bpy.props.FloatProperty(name="z", update=objects.edit_state)
+
 
 classes = (
     AconSceneColGroupProperty,

--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -777,7 +777,6 @@ class AconObjectProperty(bpy.types.PropertyGroup):
     location_x: bpy.props.FloatProperty(
         name="x",
         update=objects.edit_state,
-        get=get_location_x,
     )
 
     location_y: bpy.props.FloatProperty(
@@ -793,16 +792,19 @@ class AconObjectProperty(bpy.types.PropertyGroup):
     scale_x: bpy.props.FloatProperty(
         name="x",
         update=objects.edit_state,
+        default=1,
     )
 
     scale_y: bpy.props.FloatProperty(
         name="y",
         update=objects.edit_state,
+        default=1,
     )
 
     scale_z: bpy.props.FloatProperty(
         name="z",
         update=objects.edit_state,
+        default=1,
     )
 
     rotate_x: bpy.props.FloatProperty(

--- a/release/scripts/startup/abler/lib/objects.py
+++ b/release/scripts/startup/abler/lib/objects.py
@@ -137,36 +137,37 @@ def move_state(self, context):
             prop.state_slider = state_slider
 
 
-def change_location_x(self, context):
-    obj = context.object
-    location = obj.location
-    prop = obj.ACON_prop
-    prop.location_x = location[0]
-
-
-def edit_state(self, context):
+def edit_state_location(self, context):
     for obj in context.selected_objects:
         if obj is not None:
             location_x = self.location_x
             location_y = self.location_y
             location_z = self.location_z
 
+            obj.location[0] = location_x
+            obj.location[1] = location_y
+            obj.location[2] = location_z
+
+
+def edit_state_scale(self, context):
+    for obj in context.selected_objects:
+        if obj is not None:
             scale_x = self.scale_x
             scale_y = self.scale_y
             scale_z = self.scale_z
 
+            obj.scale[0] = scale_x
+            obj.scale[1] = scale_y
+            obj.scale[2] = scale_z
+
+
+def edit_state_rotate(self, context):
+    for obj in context.selected_objects:
+        if obj is not None:
             rotate_x = self.rotate_x
             rotate_y = self.rotate_y
             rotate_z = self.rotate_z
 
-            obj = context.active_object
-
-            obj.location[0] = location_x
-            obj.location[1] = location_y
-            obj.location[2] = location_z
-            obj.scale[0] = scale_x
-            obj.scale[1] = scale_y
-            obj.scale[2] = scale_z
             obj.rotation_euler[0] = rotate_x
             obj.rotation_euler[1] = rotate_y
             obj.rotation_euler[2] = rotate_z

--- a/release/scripts/startup/abler/lib/objects.py
+++ b/release/scripts/startup/abler/lib/objects.py
@@ -143,6 +143,14 @@ def edit_state(self, context):
     location_y = self.location_y
     location_z = self.location_z
 
+    scale_x = self.scale_x
+    scale_y = self.scale_y
+    scale_z = self.scale_z
+
+    rotate_x = self.rotate_x
+    rotate_y = self.rotate_y
+    rotate_z = self.rotate_z
+
     for obj in context.selected_objects:
 
         prop = obj.ACON_prop
@@ -153,3 +161,9 @@ def edit_state(self, context):
         obj.location[0] = location_x
         obj.location[1] = location_y
         obj.location[2] = location_z
+        obj.scale[0] = scale_x
+        obj.scale[1] = scale_y
+        obj.scale[2] = scale_z
+        obj.rotation_euler[0] = rotate_x
+        obj.rotation_euler[1] = rotate_y
+        obj.rotation_euler[2] = rotate_z

--- a/release/scripts/startup/abler/lib/objects.py
+++ b/release/scripts/startup/abler/lib/objects.py
@@ -137,6 +137,13 @@ def move_state(self, context):
             prop.state_slider = state_slider
 
 
+def change_location_x(self, context):
+    obj = context.object
+    location = obj.location
+    prop = obj.ACON_prop
+    prop.location_x = location[0]
+
+
 def edit_state(self, context):
 
     location_x = self.location_x
@@ -151,19 +158,14 @@ def edit_state(self, context):
     rotate_y = self.rotate_y
     rotate_z = self.rotate_z
 
-    for obj in context.selected_objects:
+    obj = context.active_object
 
-        prop = obj.ACON_prop
-
-        if obj != context.object and not prop.use_state:
-            continue
-
-        obj.location[0] = location_x
-        obj.location[1] = location_y
-        obj.location[2] = location_z
-        obj.scale[0] = scale_x
-        obj.scale[1] = scale_y
-        obj.scale[2] = scale_z
-        obj.rotation_euler[0] = rotate_x
-        obj.rotation_euler[1] = rotate_y
-        obj.rotation_euler[2] = rotate_z
+    obj.location[0] = location_x
+    obj.location[1] = location_y
+    obj.location[2] = location_z
+    obj.scale[0] = scale_x
+    obj.scale[1] = scale_y
+    obj.scale[2] = scale_z
+    obj.rotation_euler[0] = rotate_x
+    obj.rotation_euler[1] = rotate_y
+    obj.rotation_euler[2] = rotate_z

--- a/release/scripts/startup/abler/lib/objects.py
+++ b/release/scripts/startup/abler/lib/objects.py
@@ -135,3 +135,21 @@ def move_state(self, context):
 
         if prop.state_slider != state_slider:
             prop.state_slider = state_slider
+
+
+def edit_state(self, context):
+
+    location_x = self.location_x
+    location_y = self.location_y
+    location_z = self.location_z
+
+    for obj in context.selected_objects:
+
+        prop = obj.ACON_prop
+
+        if obj != context.object and not prop.use_state:
+            continue
+
+        obj.location[0] = location_x
+        obj.location[1] = location_y
+        obj.location[2] = location_z

--- a/release/scripts/startup/abler/lib/objects.py
+++ b/release/scripts/startup/abler/lib/objects.py
@@ -145,27 +145,28 @@ def change_location_x(self, context):
 
 
 def edit_state(self, context):
+    for obj in context.selected_objects:
+        if obj is not None:
+            location_x = self.location_x
+            location_y = self.location_y
+            location_z = self.location_z
 
-    location_x = self.location_x
-    location_y = self.location_y
-    location_z = self.location_z
+            scale_x = self.scale_x
+            scale_y = self.scale_y
+            scale_z = self.scale_z
 
-    scale_x = self.scale_x
-    scale_y = self.scale_y
-    scale_z = self.scale_z
+            rotate_x = self.rotate_x
+            rotate_y = self.rotate_y
+            rotate_z = self.rotate_z
 
-    rotate_x = self.rotate_x
-    rotate_y = self.rotate_y
-    rotate_z = self.rotate_z
+            obj = context.active_object
 
-    obj = context.active_object
-
-    obj.location[0] = location_x
-    obj.location[1] = location_y
-    obj.location[2] = location_z
-    obj.scale[0] = scale_x
-    obj.scale[1] = scale_y
-    obj.scale[2] = scale_z
-    obj.rotation_euler[0] = rotate_x
-    obj.rotation_euler[1] = rotate_y
-    obj.rotation_euler[2] = rotate_z
+            obj.location[0] = location_x
+            obj.location[1] = location_y
+            obj.location[2] = location_z
+            obj.scale[0] = scale_x
+            obj.scale[1] = scale_y
+            obj.scale[2] = scale_z
+            obj.rotation_euler[0] = rotate_x
+            obj.rotation_euler[1] = rotate_y
+            obj.rotation_euler[2] = rotate_z

--- a/release/scripts/startup/abler/style_tab/styles_control.py
+++ b/release/scripts/startup/abler/style_tab/styles_control.py
@@ -73,7 +73,7 @@ class LinePanel(bpy.types.Panel):
         layout = self.layout
         layout.prop(context.scene.ACON_prop, "toggle_toon_edge", text="")
 
-    def draw(selfo, context):
+    def draw(self, context):
         layout = self.layout
         layout.use_property_split = True
         layout.use_property_decorate = False  # No animation.

--- a/release/scripts/startup/abler/style_tab/styles_control.py
+++ b/release/scripts/startup/abler/style_tab/styles_control.py
@@ -73,7 +73,7 @@ class LinePanel(bpy.types.Panel):
         layout = self.layout
         layout.prop(context.scene.ACON_prop, "toggle_toon_edge", text="")
 
-    def draw(self, context):
+    def draw(selfo, context):
         layout = self.layout
         layout.use_property_split = True
         layout.use_property_decorate = False  # No animation.


### PR DESCRIPTION
## 발제/내용

- 온보딩 프로젝트로 Cube라는 패널을 생성한 후, 그 안에 cube를 control하는 버튼들을 추가함. 

## 패널에 추가한 기능

### 1. Add Cube/ Delete All
- ``add cube``클릭 시, 생성되는 큐브의 위치와 이름을 지정할 수 있음. 
- 생성되는 큐브에 랜덤으로 색상이 지정됨. 
- ``delete all``클릭 시, 화면의 모든 개체가 삭제 됨. 
### 2. Move Cube/ Scale Cube/ Rotate Cube
- 슬라이더를 이용해 개체의 위치와 크기를 조정하고 회전할 수 있음. 

## 보완해야 할 부분

### 선택한 cube의 현재 위치를 불러와서 슬라이더에 적용할 수 있음.
- 현재 상태에서는 슬라이더로 변화시킨 값만 저장되어 기즈모를 이용해 cube를 직접 움직인 경우 그 값이 슬라이더에 반영되지 않음.