### PR TITLE
view_3d가 아닌 다른 화면에서 화면 그리드가 작동하는 문제

### DIFF
--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -141,6 +141,7 @@ def find_screen_acon3d() -> bool:
         "ACON3D" in bpy.data.screens.keys()
         and len(bpy.data.screens["ACON3D"].areas) > 0
         and len(bpy.data.screens["ACON3D"].areas[0].spaces) > 0
+        and bpy.data.screens["ACON3D"].areas[0].spaces[0].type == "VIEW_3D"
     )
 
 


### PR DESCRIPTION
## 관련 링크
[그리드 오류 발생의 방어 코드 작성-테스크 카드](https://www.notion.so/acon3d/20ffe5f8c101489c85d4f48da6f68cf0)

## 발제/내용
[센트리 에러](https://sentry.io/organizations/carpenstreet/issues/3748549901/?referrer=slack)

## 대응
- VIEW 3D가 아닌 다른 화면에서 그리드를 제어하려는 것으로 보임
- 해당 부분 방어 코드로 처리하기

### 어떤 조치를 취했나요?
- `find_screen_acon3d()`에서 `bpy.data.screens["ACON3D"].areas[0].spaces[0].type`이 `"VIEW_3D"`인지 확인함