### PR TITLE
node가 존재하지 않을 경우에 대한 방지 코드

### DIFF
--- a/release/scripts/startup/abler/lib/materials/materials_handler.py
+++ b/release/scripts/startup/abler/lib/materials/materials_handler.py
@@ -465,7 +465,9 @@ def change_toon_shading_brightness(self, context: Context) -> None:
     if not node_group:
         return
     node_outline = node_group.nodes.get("ACON_nodeGroup_toonFace")
-    inputs = node_outline.inputs
+    if not node_outline:
+        return
+    inputs: List[NodeSocket] = node_outline.inputs
 
     prop: PropertyGroup = context.scene.ACON_prop
     value_1: FloatProperty = prop.toon_shading_brightness_1

--- a/release/scripts/startup/abler/lib/materials/materials_handler.py
+++ b/release/scripts/startup/abler/lib/materials/materials_handler.py
@@ -219,6 +219,10 @@ def set_material_parameters_by_type(mat: Material) -> None:
 
     type: EnumProperty = mat.ACON_prop.type
 
+    toonNodeTree: Optional[Node] = mat.node_tree
+    if not toonNodeTree:
+        return
+
     toonNode: Optional[Node] = mat.node_tree.nodes.get("ACON_nodeGroup_combinedToon")
     if not toonNode:
         return


### PR DESCRIPTION
## 관련 링크
[change_toon_shading_brightness 에서 nodes.get 의 결과가 비어있을 때 오류 발생 - 에러 카드](https://www.notion.so/acon3d/change_toon_shading_brightness-nodes-get-c95ce3fc68ee4e4b8b64e56a8bdf8609)
[material 의 node_tree 내에 nodes 가 없는 경우에 에러 발생 - 에러 카드](https://www.notion.so/acon3d/material-node_tree-nodes-8dfb5b3c6356461b9127c18c3b936743)

## 발제/내용
- 유저가 노드를 삭제해서 노드가 존재하게 되지 않았을 때 생기는 문제로 추정됨
- 유저가 노드를 새로 생성해서 노드트리가 존재하게 되지 않았을 때 생기는 문제로 추정됨


## 대응

### 어떤 조치를 취했나요?
- node가 존재하지 않을 경우를 If문으로 확인하는 방지코드를 작성함
- nodetree가 존재하지 않을 경우를 If문으로 확인하는 방지코드를 작성함