### PR TITLE
Operator description 추가(English only)

### DIFF
--- a/release/scripts/startup/abler/custom_properties.py
+++ b/release/scripts/startup/abler/custom_properties.py
@@ -97,7 +97,7 @@ class AconWindowManagerProperty(bpy.types.PropertyGroup):
 
     keyword_input: bpy.props.StringProperty(
         name="",
-        description="Enter search keywords",
+        description="Enter search keywords (English only)",
     )
 
 


### PR DESCRIPTION
## 관련 링크
[영문으로만 검색가능한거에 대한 명시](https://acontainer.slack.com/archives/C04H7MJP10B/p1675404249708239)

## 발제/내용
- 유저들에게 영문으로만 검색이 된다는 사실을 알려야 함.

## 대응

### 어떤 조치를 취했나요?
- English only라고 명시함