### PR TITLE
abler.warning_modal에서 self.layout이 없을 때 에러 발생

### DIFF
--- a/release/scripts/startup/abler/warning_modal.py
+++ b/release/scripts/startup/abler/warning_modal.py
@@ -191,7 +191,6 @@ class WM_MT_splash_modal(bpy.types.Menu):
     draw_func = None
 
     def draw(self, context):
-        print(self.layout)
         if self.layout:
             self.draw_func(self.layout)
 

--- a/release/scripts/startup/abler/warning_modal.py
+++ b/release/scripts/startup/abler/warning_modal.py
@@ -191,7 +191,9 @@ class WM_MT_splash_modal(bpy.types.Menu):
     draw_func = None
 
     def draw(self, context):
-        self.draw_func(self.layout)
+        print(self.layout)
+        if self.layout:
+            self.draw_func(self.layout)
 
 
 classes = (


### PR DESCRIPTION
## 관련 링크
[abler.warning_modal에서 self.layout이 없을 때 에러 발생  - 에러 카드](https://www.notion.so/acon3d/abler-warning_modal-self-layout-d360a1e086f1473880df8b98ba176cc5)

## 발제/내용
- WM_MT_splash_modal의 draw() 함수에서 `self.draw_func(self.layout)`을 실행할 때 self.layout이 None이라 에러 발생

## 대응

### 어떤 조치를 취했나요?
- self-layout이 None인지 확인하는 if문 추가