### PR TITLE
OS에서 직접 삭제한 파일 경로에 파일을 저장하려고 할때 발생하는 문제

### DIFF
--- a/release/scripts/startup/abler/general_tab/general.py
+++ b/release/scripts/startup/abler/general_tab/general.py
@@ -364,6 +364,7 @@ class SaveOperator(bpy.types.Operator, AconExportHelper):
     def execute(self, context):
         try:
             self.check_path(save_check=True)
+            self.check_filepath(save_check=True)
 
             if bpy.data.is_saved:
                 self.filepath = context.blend_data.filepath
@@ -432,6 +433,7 @@ class SaveAsOperator(bpy.types.Operator, AconExportHelper):
     def execute(self, context):
         try:
             self.check_path(save_check=False)
+            self.check_filepath(save_check=True)
 
             numbered_filepath, numbered_filename = numbering_filepath(
                 self.filepath, self.filename_ext

--- a/release/scripts/startup/abler/general_tab/general.py
+++ b/release/scripts/startup/abler/general_tab/general.py
@@ -364,7 +364,7 @@ class SaveOperator(bpy.types.Operator, AconExportHelper):
     def execute(self, context):
         try:
             self.check_path(save_check=True)
-            self.check_filepath(save_check=True)
+            self.check_filepath()
 
             if bpy.data.is_saved:
                 self.filepath = context.blend_data.filepath
@@ -433,7 +433,7 @@ class SaveAsOperator(bpy.types.Operator, AconExportHelper):
     def execute(self, context):
         try:
             self.check_path(save_check=False)
-            self.check_filepath(save_check=True)
+            self.check_filepath()
 
             numbered_filepath, numbered_filename = numbering_filepath(
                 self.filepath, self.filename_ext

--- a/release/scripts/startup/abler/lib/import_file.py
+++ b/release/scripts/startup/abler/lib/import_file.py
@@ -82,12 +82,12 @@ class AconExportHelper(ExportHelper):
         if not (save_check and bpy.data.is_saved) and os.path.isdir(self.filepath):
             self.filepath = os.path.join(self.filepath, default_name)
 
-    def check_filepath(self, save_check: bool):
+    def check_filepath(self):
         # 가장 최근에 저장한 디렉토리 안에 untitled라는 새로운 파일을 만들고 저장합니다
         # 파일명을 입력하지 않으면 dirname.blend으로 저장됩니다
         # 발생할 수 있는 문제: untitled라는 파일안에 계속 파일이 생성 될 수 있다
         dirname, basename = os.path.split(os.path.normpath(self.filepath))
-        if not os.path.isdir(dirname) and not (save_check and bpy.data.is_saved):
+        if not os.path.isdir(dirname) and not bpy.data.is_saved:
             self.filepath = bpy.context.blend_data.filepath
             history_path = bpy.utils.user_resource("CONFIG") + "/recent-files.txt"
             with open(history_path, 'r') as f:

--- a/release/scripts/startup/abler/lib/import_file.py
+++ b/release/scripts/startup/abler/lib/import_file.py
@@ -82,6 +82,23 @@ class AconExportHelper(ExportHelper):
         if not (save_check and bpy.data.is_saved) and os.path.isdir(self.filepath):
             self.filepath = os.path.join(self.filepath, default_name)
 
+    def check_filepath(self, save_check: bool):
+        # 가장 최근에 저장한 디렉토리 안에 untitled라는 새로운 파일을 만들고 저장합니다
+        # 파일명을 입력하지 않으면 dirname.blend으로 저장됩니다
+        # 발생할 수 있는 문제: untitled라는 파일안에 계속 파일이 생성 될 수 있다
+        dirname, basename = os.path.split(os.path.normpath(self.filepath))
+        if not os.path.isdir(dirname) and not (save_check and bpy.data.is_saved):
+            self.filepath = bpy.context.blend_data.filepath
+            history_path = bpy.utils.user_resource("CONFIG") + "/recent-files.txt"
+            with open(history_path, 'r') as f:
+                last_line = f.readline()
+                recent_path = last_line.split('/')
+                recent_path.pop()
+                recent_dir = '/'.join(recent_path)
+                os.makedirs(recent_dir + "/untitled/", exist_ok=True)
+            f.close()
+            self.filepath = os.path.join(recent_dir + "/untitled/" + basename)
+
     def draw(self, context):
         # FileBrowser UI 설정이 맨처음에만 적용되게끔
         if not self.set_option:

--- a/release/scripts/startup/abler/lib/import_file.py
+++ b/release/scripts/startup/abler/lib/import_file.py
@@ -96,7 +96,6 @@ class AconExportHelper(ExportHelper):
                 recent_path.pop()
                 recent_dir = '/'.join(recent_path)
                 os.makedirs(recent_dir + "/untitled/", exist_ok=True)
-            f.close()
             self.filepath = os.path.join(recent_dir + "/untitled/" + basename)
 
     def draw(self, context):


### PR DESCRIPTION
## 관련 링크
[저장을 할 때 폴더에 접근하고, OS에서 삭제한 후에 저장을 실행하면 발생하는 문제 - 에러 카드](https://www.notion.so/acon3d/OS-ad6bad4ef5a44d839aa78bd9606534dd)

## 발제/내용
- 유저가 파일경로가 사라진 상태에서 파일을 저장하려고 할 때 에러가 발생함

## 대응

### 어떤 조치를 취했나요?
- 가장 최근에 저장한 디렉토리안에 untitled라는 새로운 파일을 생성 후, 그곳에 파일 저장