### PR TITLE
SWTASK-31 grid_on_when_selected에서 selected_objects가 없어서 발생하는 문제

### DIFF
--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -129,8 +129,8 @@ def save_post_handler(dummy):
 
 @persistent
 def grid_on_when_selected(dummy):
-    if selected := bpy.context.selected_objects:
-        show_grid = len(selected) > 0
+    if selected_objects := bpy.context.selected_objects:
+        show_grid = len(selected_objects) > 0
     if find_screen_acon3d():
         viewport_overlay = bpy.data.screens["ACON3D"].areas[0].spaces[0].overlay
         viewport_overlay.show_ortho_grid = show_grid

--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -129,8 +129,8 @@ def save_post_handler(dummy):
 
 @persistent
 def grid_on_when_selected(dummy):
-    if bpy.context.selected_objects is not None:
-        show_grid = len(bpy.context.selected_objects) > 0
+    if selected := bpy.context.selected_objects:
+        show_grid = len(selected) > 0
     if find_screen_acon3d():
         viewport_overlay = bpy.data.screens["ACON3D"].areas[0].spaces[0].overlay
         viewport_overlay.show_ortho_grid = show_grid

--- a/release/scripts/startup/abler/pref.py
+++ b/release/scripts/startup/abler/pref.py
@@ -129,7 +129,8 @@ def save_post_handler(dummy):
 
 @persistent
 def grid_on_when_selected(dummy):
-    show_grid = len(bpy.context.selected_objects) > 0
+    if bpy.context.selected_objects is not None:
+        show_grid = len(bpy.context.selected_objects) > 0
     if find_screen_acon3d():
         viewport_overlay = bpy.data.screens["ACON3D"].areas[0].spaces[0].overlay
         viewport_overlay.show_ortho_grid = show_grid


### PR DESCRIPTION
## 관련 링크
[grid_on_when_selected 에서 selected_objects 가 없을 때 에러 발생 - 에러 카드](https://www.notion.so/acon3d/grid_on_when_selected-selected_objects-425a307e30874400bf02ff14b3966a66?pvs=4)

## 발제/내용
- `selected_objects`가 없어서 에러가 발생함.
- 재현하지 못함.

## 대응

### 어떤 조치를 취했나요?
- `selected_objects`를 확인하는 `if문` 추가